### PR TITLE
Set publish flag to true in release if added to collection with match…

### DIFF
--- a/src/main/web/florence/js/functions/_t16ReleaseEditor.js
+++ b/src/main/web/florence/js/functions/_t16ReleaseEditor.js
@@ -269,6 +269,24 @@ function releaseEditor(collectionId, data) {
         });
     }
 
+    // Check whether release is being added back into collection and the published flag should be toggled to truthy
+    function checkPublishedFlag(data) {
+        return new Promise (function(resolve, reject) {
+            if (!data.description.published) {
+                getCollection(collectionId, success = function (collectionData) {
+                    if (collectionData.releaseUri == data.uri) {
+                        data.description.published = true;
+                    }
+                    resolve()
+                }, error = function (error) {
+                    reject(error);
+                });
+            } else {
+                resolve();
+            }
+        });
+    }
+
     //Save and update preview page
     //Get collection content
 
@@ -291,7 +309,14 @@ function releaseEditor(collectionId, data) {
     });
 
     function save(onSave) {
-        checkRenameUri(collectionId, data, renameUri, onSave);
+        // Check whether the publish flag needs to be toggle - this is async so needs to be a promise
+        checkPublishedFlag(data).then(function() {
+            // Once publish flag is checked then continue with rest of save
+            checkRenameUri(collectionId, data, renameUri, onSave);
+        }).catch(function(error) {
+            console.log("Error getting collection data: ", error);
+        });
+
     }
 }
 


### PR DESCRIPTION
### What

Set publish flag to true if releaseUri in collection matches release's uri and it's published flag isn't already true.

### How to review

Able to take a release out of a collection scheduled by the release, edit it in another collection (if necessary) and then add it back in. It will no longer lose the published flag when put back into the original collection

### Who can review

@jondewijones 