### PR TITLE
Feature/article edition bug

### DIFF
--- a/src/main/web/florence/js/functions/_checkRenameUri.js
+++ b/src/main/web/florence/js/functions/_checkRenameUri.js
@@ -72,7 +72,6 @@ function checkRenameUri(collectionId, data, renameUri, onSave) {
                         data = pageData;
 
                         Florence.globalVars.pagePath = newUri;
-                        ;
                         //is it a compendium? Rename children array
                         //take this out if moveContent in Zebedee works
                         if (data.type === 'compendium_landing_page') {
@@ -97,7 +96,8 @@ function checkRenameUri(collectionId, data, renameUri, onSave) {
         var tmpNewUri = data.uri.split("/");
         //Articles with no edition. Add date as edition
         if (data.type === 'article' || data.type === 'article_download') {
-            var editionDate = $.datepicker.formatDate('yy-mm-dd', new Date());
+            console.log(data.description.releaseDate);
+            var editionDate = $.datepicker.formatDate('yy-mm-dd', new Date(data.description.releaseDate));
             tmpNewUri.splice([tmpNewUri.length - 2], 2, titleNoSpace, editionDate);
         } else {
             tmpNewUri.splice([tmpNewUri.length - 1], 1, titleNoSpace);

--- a/src/main/web/florence/js/functions/_loadT4Creator.js
+++ b/src/main/web/florence/js/functions/_loadT4Creator.js
@@ -88,6 +88,10 @@ function loadT4Creator(collectionId, releaseDate, pageType, parentUrl) {
                 return false;
             }
 
+            if (pageType === 'bulletin' && !validatePageName($('#edition'))) {
+                return false;
+            }
+
             pageData = pageTypeDataT4(pageType);
             pageData.description.edition = $('#edition').val();
             if (title) {

--- a/src/main/web/florence/js/functions/_loadT4Creator.js
+++ b/src/main/web/florence/js/functions/_loadT4Creator.js
@@ -81,6 +81,7 @@ function loadT4Creator(collectionId, releaseDate, pageType, parentUrl) {
         $('form').off().submit(function (e) {
             e.preventDefault();
             releaseDateManual = $('#releaseDate').val();
+            var pageEdition = $('#edition').val();
 
             // Do input validation
             var nameValid = validatePageName();
@@ -88,12 +89,18 @@ function loadT4Creator(collectionId, releaseDate, pageType, parentUrl) {
                 return false;
             }
 
-            if (pageType === 'bulletin' && !validatePageName($('#edition'))) {
+            // Bulletin page title validation
+            if (pageType === 'bulletin' && !validatePageName(pageEdition)) {
                 return false;
             }
 
+            // Article page validation - remove empty space
+            if ((pageType === 'article' || pageType === 'article_download') && pageEdition === " ") {
+                pageEdition = "";
+            }
+
             pageData = pageTypeDataT4(pageType);
-            pageData.description.edition = $('#edition').val();
+            pageData.description.edition = pageEdition;
             if (title) {
                 //do nothing;
             } else {

--- a/src/main/web/florence/js/functions/_loadT4Creator.js
+++ b/src/main/web/florence/js/functions/_loadT4Creator.js
@@ -84,8 +84,7 @@ function loadT4Creator(collectionId, releaseDate, pageType, parentUrl) {
 
             // Do input validation
             var nameValid = validatePageName();
-            var editionValid = validatePageName('#edition');
-            if (!nameValid || !editionValid) {
+            if (!nameValid) {
                 return false;
             }
 


### PR DESCRIPTION
### What

Two bugs existed existed:
1. Articles were being forced to have an edition in the create screen
2. If a space was added in the creator and then removed in the editor the 'articles' path would be removed, saving the page in an invalid location.

### How to review

Attempt to create a bulletin, article and article download with and without titles to test they give the expected result. Delete the editions in those and check the page type isn't removed from the path.

### Who can review

@robchamberspfc if you could check this one please in terms of functionality? I'll do the merge once you've given it the thumbs up
