### PR TITLE
Fix bulletin passing value rather than selector to input validation

### DIFF
--- a/src/main/web/florence/js/functions/_loadT4Creator.js
+++ b/src/main/web/florence/js/functions/_loadT4Creator.js
@@ -90,7 +90,7 @@ function loadT4Creator(collectionId, releaseDate, pageType, parentUrl) {
             }
 
             // Bulletin page title validation
-            if (pageType === 'bulletin' && !validatePageName(pageEdition)) {
+            if (pageType === 'bulletin' && !validatePageName('#edition')) {
                 return false;
             }
 


### PR DESCRIPTION
### What

Bulletin creation failing because edition value being passed as argument to input validation, rather than jQuery selector.

### How to review

Bulletins can be created easily.

### Who can review

Anyone but @Crispioso

