### PR TITLE
Stop page rename on the edit of a Welsh page's title

### DIFF
--- a/src/main/web/florence/js/functions/_checkRenameUri.js
+++ b/src/main/web/florence/js/functions/_checkRenameUri.js
@@ -7,6 +7,12 @@
  */
 function checkRenameUri(collectionId, data, renameUri, onSave) {
 
+    // If Welsh page then don't rename - any edits to the Welsh title with override the main English path
+    if (Florence.globalVars.welsh) {
+        onSave(collectionId, data.uri, JSON.stringify(data));
+        return;
+    }
+
     if (renameUri && !data.description.language && !data.description.edition) {   // It will not change welsh url + do not rename content with edition.
         doRename();
     } else {

--- a/src/main/web/florence/js/functions/_createWorkspace.js
+++ b/src/main/web/florence/js/functions/_createWorkspace.js
@@ -1,4 +1,4 @@
-/**
+    /**
  * Handles the initial creation of the workspace screen.
  * @param path - path to iframe
  * @param collectionId


### PR DESCRIPTION
### What

Editing the title for a Welsh page would rename the path for both the English and Welsh version to the Welsh page's title. 

### How to review

Welsh pages can be created at the same time as the English version being created and updating it's title doesn't update the path of the pages. It works correctly if you publish the English version first, so you can use that behaviour as an example of it working as expected.

### Who can review

@jondewijones
