### PR TITLE
Add configurable environment variable for port to Java app

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 # Remote debug:
 export JAVA_OPTS="-Xdebug -Xmx256m -Xrunjdwp:transport=dt_socket,address=8001,server=y,suspend=n"
-export PORT="8081"
+export PORT="${PORT:-8081}"
 
 # File reloading:
 export RESTOLINO_STATIC="src/main/web"


### PR DESCRIPTION
### What

Allow Florence's the port for the server-side application to be configurable by the environment.

### How to review

Try and `./run.sh PORT=10000` and check whether Florence now starts up on port 10000.

### Who can review

Anyone but me.
