### PR TITLE
don't display a version alert if there's a connection error

### DIFF
--- a/src/main/web/florence/js/functions/_setupFlorence.js
+++ b/src/main/web/florence/js/functions/_setupFlorence.js
@@ -371,6 +371,10 @@ function setupFlorence() {
         // Get the latest version and alert user if it differs from version stored on load (but only if the user hasn't been warned already, so they don't get spammed after being warned already)
         if (!userWarned) {
             checkVersion().then(function (response) {
+                if (response instanceof TypeError) {
+                    // FIXME do something more useful with this
+                    return
+                }
                 if (response.major !== runningVersion.major || response.minor !== runningVersion.minor || response.build !== runningVersion.build) {
                     console.log("New version of Florence available: ", response.major + "." + response.minor + "." + response.build);
                     swal({


### PR DESCRIPTION
### What

Prevent 'new version' alert displaying when there's a Florence connection error

Probably needs to let the user know, e.g. using the network ping indicator or by greying out the screen

### How to review

Start florence, open in browser, stop florence, make sure alert isn't displayed after around 10s

### Who can review

Anyone except @ian-kent
