### PR TITLE
Bind compendium data save to correct button class

### DIFF
--- a/src/main/web/florence/js/functions/_t6CompendiumDataEditor.js
+++ b/src/main/web/florence/js/functions/_t6CompendiumDataEditor.js
@@ -96,7 +96,7 @@ function compendiumDataEditor(collectionId, data) {
     var editNav = $('.edit-nav');
     editNav.off(); // remove any existing event handlers.
 
-    editNav.on('click', '#save', function () {
+    editNav.on('click', '.btn-edit-save', function () {
         save();
         updateContent(collectionId, data.uri, JSON.stringify(data));
     });


### PR DESCRIPTION
### What

Compendium data editor 'save' button didn't work - there was no response from clicking it. The save function was bound to the wrong ID.

### How to review

Compendium data saves when the 'save' button is clicked.

### Who can review

Jon Jones
