### PR TITLE
Change default bind address to 8080 so it matches all other DP apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+BIND_ADDR ?= :8081
 BINPATH ?= build
 ENABLE_NEW_APP ?= 1
 
@@ -6,7 +7,7 @@ build: generate
 
 debug: generate
 	go build -tags 'debug' -o $(BINPATH)/florence
-	HUMAN_LOG=1 ENABLE_NEW_APP=${ENABLE_NEW_APP} $(BINPATH)/florence
+	HUMAN_LOG=1 BIND_ADDR=${BIND_ADDR} ENABLE_NEW_APP=${ENABLE_NEW_APP} $(BINPATH)/florence
 
 generate: ${GOPATH}/bin/go-bindata
 	# build the production version

--- a/assets/prod.go
+++ b/assets/prod.go
@@ -116,7 +116,7 @@ func DistCssMainCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/css/main.css", size: 218577, mode: os.FileMode(420), modTime: time.Unix(1494256536, 0)}
+	info := bindataFileInfo{name: "../dist/css/main.css", size: 218577, mode: os.FileMode(420), modTime: time.Unix(1494424852, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -136,7 +136,7 @@ func DistImgSpritePng() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/img/sprite.png", size: 9553, mode: os.FileMode(420), modTime: time.Unix(1494256536, 0)}
+	info := bindataFileInfo{name: "../dist/img/sprite.png", size: 9553, mode: os.FileMode(420), modTime: time.Unix(1494424852, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -156,7 +156,7 @@ func DistJsFlorenceBundleJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/js/florence.bundle.js", size: 3017796, mode: os.FileMode(420), modTime: time.Unix(1494256536, 0)}
+	info := bindataFileInfo{name: "../dist/js/florence.bundle.js", size: 3017796, mode: os.FileMode(420), modTime: time.Unix(1494424852, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -176,7 +176,7 @@ func DistLegacyAssetsCssMainMinCss() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/legacy-assets/css/main.min.css", size: 215631, mode: os.FileMode(420), modTime: time.Unix(1494256532, 0)}
+	info := bindataFileInfo{name: "../dist/legacy-assets/css/main.min.css", size: 215631, mode: os.FileMode(420), modTime: time.Unix(1494424848, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -196,7 +196,7 @@ func DistLegacyAssetsIndexHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/legacy-assets/index.html", size: 3801, mode: os.FileMode(420), modTime: time.Unix(1494256532, 0)}
+	info := bindataFileInfo{name: "../dist/legacy-assets/index.html", size: 3801, mode: os.FileMode(420), modTime: time.Unix(1494424848, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -236,7 +236,7 @@ func DistLegacyAssetsJsMainJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/legacy-assets/js/main.js", size: 619338, mode: os.FileMode(420), modTime: time.Unix(1494257137, 0)}
+	info := bindataFileInfo{name: "../dist/legacy-assets/js/main.js", size: 619338, mode: os.FileMode(420), modTime: time.Unix(1494577748, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -256,7 +256,7 @@ func DistLegacyAssetsJsTemplatesJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/legacy-assets/js/templates.js", size: 366718, mode: os.FileMode(420), modTime: time.Unix(1494256532, 0)}
+	info := bindataFileInfo{name: "../dist/legacy-assets/js/templates.js", size: 366718, mode: os.FileMode(420), modTime: time.Unix(1494512832, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -276,7 +276,7 @@ func DistLegacyAssetsVersionJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/legacy-assets/version.json", size: 50, mode: os.FileMode(420), modTime: time.Unix(1494256532, 0)}
+	info := bindataFileInfo{name: "../dist/legacy-assets/version.json", size: 50, mode: os.FileMode(420), modTime: time.Unix(1494424848, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -296,7 +296,7 @@ func DistManifestJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/manifest.json", size: 259, mode: os.FileMode(420), modTime: time.Unix(1494256536, 0)}
+	info := bindataFileInfo{name: "../dist/manifest.json", size: 259, mode: os.FileMode(420), modTime: time.Unix(1494424852, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -316,7 +316,7 @@ func DistRefactoredHtml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/refactored.html", size: 295, mode: os.FileMode(420), modTime: time.Unix(1494256536, 0)}
+	info := bindataFileInfo{name: "../dist/refactored.html", size: 295, mode: os.FileMode(420), modTime: time.Unix(1494424852, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -336,7 +336,7 @@ func DistServiceWorkerJs() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "../dist/service-worker.js", size: 139, mode: os.FileMode(420), modTime: time.Unix(1494256536, 0)}
+	info := bindataFileInfo{name: "../dist/service-worker.js", size: 139, mode: os.FileMode(420), modTime: time.Unix(1494424852, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gorilla/pat"
 )
 
-var bindAddr = ":8081"
+var bindAddr = ":8080"
 var babbageURL = "http://localhost:8080"
 var zebedeeURL = "http://localhost:8082"
 var enableNewApp = false


### PR DESCRIPTION
### What

Use `:8080` as default bind address but update to `:8081` in the `make debug` command, so that there's not a conflict during local development.

### How to review

A simple code review of the file changes will be fine.

### Who can review

Anyone but me.
