### PR TITLE
Hotfix/lowercase email on login

### DIFF
--- a/src/legacy/js/functions/_postLogin.js
+++ b/src/legacy/js/functions/_postLogin.js
@@ -5,6 +5,9 @@
  * @returns {boolean}
  */
 function postLogin(email, password) {
+    // lowercase email address, before we login/store in local storage, so it matches zebedee
+    // allows string comparisons between zebedee responses and local storage data to work
+    email = email.toLowerCase();
     $.ajax({
         url: "/zebedee/login",
         dataType: 'json',


### PR DESCRIPTION
### What

Lowercase email address on login before storing in localStorage so string comparisons between login email and zebedee data works.

### How to review

Without the fix: 

* Login to Florence with uppercase letters in the email address
* Create a page, edit the page, save and submit for review
* Edit the page again
* Should incorrectly display 'Save and submit for approval'

With the fix:

* Same steps as above, but should now display 'Save and submit for review'

### Who can review

@jondewijones @Crispioso 