### PR TITLE
Update datasets screen to handle completed and confirmed instances

### DIFF
--- a/src/app/utilities/api-clients/datasets.js
+++ b/src/app/utilities/api-clients/datasets.js
@@ -54,4 +54,11 @@ export default class datasets {
                  return response;
              });
     }
+
+    static getNewVersionsAndCompletedInstances() {
+        return http.get(`/dataset/instances?state=completed,edition-confirmed`)
+            .then(response => {
+                return response;
+            });
+    }
 }

--- a/src/app/views/datasets/DatasetsController.jsx
+++ b/src/app/views/datasets/DatasetsController.jsx
@@ -115,18 +115,18 @@ class DatasetsController extends Component {
         try {
             const values = datasets.map(dataset => {
                 dataset = dataset.current || dataset.next || dataset;
-                const datasetInstances = instances.filter(instance => {
+                const datasetInstances = [];
+                instances.forEach(instance => {
                     const datasetID = instance.links.dataset.id;
                     if (datasetID === dataset.id) {
-                        return {
+                        datasetInstances.push({
                             date: instance.last_updated,
                             isInstance: !(instance.edition && instance.version),
                             edition: instance.edition || "-",
                             version: instance.version || "-",
-                            url: instance.state !== "edition-confirmed" ? url.resolve(`datasets/${datasetID}/instances/${instance.id}/metadata`) : url.resolve(`datasets/${datasetID}/editions/${instance.edition}/version/${instance.version}`)
-                        }
+                            url: instance.state !== "edition-confirmed" ? url.resolve(`datasets/${datasetID}/instances/${instance.id}/metadata`) : url.resolve(`datasets/${datasetID}/editions/${instance.edition}/versions/${instance.version}/metadata`)
+                        });
                     }
-                    return false;
                 });
                 return {
                     title: dataset.title,

--- a/src/app/views/datasets/DatasetsController.jsx
+++ b/src/app/views/datasets/DatasetsController.jsx
@@ -114,8 +114,8 @@ class DatasetsController extends Component {
     mapResponseToTableData(datasets, instances) {
         try {
             const values = datasets.map(dataset => {
-                dataset = dataset.current;
-                const datasetInstances = instances.map(instance => {
+                dataset = dataset.current || dataset.next || dataset;
+                const datasetInstances = instances.filter(instance => {
                     const datasetID = instance.links.dataset.id;
                     if (datasetID === dataset.id) {
                         return {
@@ -126,6 +126,7 @@ class DatasetsController extends Component {
                             url: instance.state !== "edition-confirmed" ? url.resolve(`datasets/${datasetID}/instances/${instance.id}/metadata`) : url.resolve(`datasets/${datasetID}/editions/${instance.edition}/version/${instance.version}`)
                         }
                     }
+                    return false;
                 });
                 return {
                     title: dataset.title,

--- a/src/app/views/datasets/DatasetsController.jsx
+++ b/src/app/views/datasets/DatasetsController.jsx
@@ -29,7 +29,7 @@ class DatasetsController extends Component {
     componentWillMount() {
         this.setState({isFetchingDatasets: true});
         const fetches = [
-            datasets.getCompletedInstances(),
+            datasets.getNewVersionsAndCompletedInstances(),
             datasets.getAll()
         ]
         Promise.all(fetches).then(responses => {
@@ -112,29 +112,37 @@ class DatasetsController extends Component {
     }
     
     mapResponseToTableData(datasets, instances) {
-
-        const values = datasets.map(dataset => {
-            const datasetInstances = instances.map(instance => {
-                const datasetID = instance.links.dataset.id;
-                console.log(instance);
-                if (datasetID === dataset.id) {
-                    return {
-                        date: instance.last_updated,
-                        isInstance: !(instance.edition && instance.version),
-                        edition: instance.edition || "-",
-                        version: instance.version || "-",
-                        url: instance.state !== "edition-confirmed" ? url.resolve(`datasets/${datasetID}/instances/${instance.id}/metadata`) : url.resolve(`datasets/${datasetID}/editions/${instance.edition}/version/${instance.version}`)
+        try {
+            const values = datasets.map(dataset => {
+                dataset = dataset.current;
+                const datasetInstances = instances.map(instance => {
+                    const datasetID = instance.links.dataset.id;
+                    if (datasetID === dataset.id) {
+                        return {
+                            date: instance.last_updated,
+                            isInstance: !(instance.edition && instance.version),
+                            edition: instance.edition || "-",
+                            version: instance.version || "-",
+                            url: instance.state !== "edition-confirmed" ? url.resolve(`datasets/${datasetID}/instances/${instance.id}/metadata`) : url.resolve(`datasets/${datasetID}/editions/${instance.edition}/version/${instance.version}`)
+                        }
                     }
+                });
+                return {
+                    title: dataset.title,
+                    id: dataset.id,
+                    instances: datasetInstances
                 }
-            });
-            return {
-                title: dataset.title,
-                id: dataset.id,
-                instances: datasetInstances
-            }
-        });
-
-        return values;
+            });  
+            return values; 
+        } catch (error) {
+            const notification = {
+                type: "warning",
+                message: "Error trying to map the datasets data to the table structure. Please refresh the page."
+            };
+            notifications.add(notification);
+            console.error("Error mapping dataset API responses to view", error);
+            return [];
+        }
     }
 
     render() {

--- a/src/app/views/datasets/metadata/DatasetMetadata.test.js
+++ b/src/app/views/datasets/metadata/DatasetMetadata.test.js
@@ -1,0 +1,136 @@
+import React from 'react';
+import {DatasetMetadata} from './DatasetMetadata.jsx';
+import notifications from '../../../utilities/notifications';
+import renderer from 'react-test-renderer';
+import { shallow, mount } from 'enzyme';
+
+console.error = jest.fn();
+
+jest.mock('../../../utilities/notifications', () => {
+    return {
+        add: jest.fn(() => {
+            //
+        })
+    }
+});
+
+jest.mock('../../../utilities/http', () => {
+    return {
+        resolve: function() {
+            //
+        }
+    }
+});
+
+jest.mock('../../../utilities/api-clients/datasets', () => (
+    {
+        get: jest.fn(() => {
+            return Promise.resolve({
+                "current": {
+                    "collection_id": "fddffdfdaadf-e8ad17766a81bf589e76ef57d854945fdf0bfe546000228837aa70701506869c",
+                    "id": "931a8a2a-0dc8-42b6-a884-7b6054ed3b68",
+                    "links": {
+                        "editions": {
+                            "href": "http://localhost:22000/datasets/931a8a2a-0dc8-42b6-a884-7b6054ed3b68/editions"
+                        },
+                        "latest_version": {
+                            "id": "efcc4581-30b1-463b-b85b-2e2d85c4918b",
+                            "href": "http://localhost:22000/datasets/931a8a2a-0dc8-42b6-a884-7b6054ed3b68/editions/2016/versions/1"
+                        },
+                        "self": {
+                            "href": "http://localhost:22000/datasets/931a8a2a-0dc8-42b6-a884-7b6054ed3b68"
+                        }
+                    },
+                    "qmi": {
+                        "href": "http://localhost:8080/datasets/12345",
+                        "title": "An example QMI",
+                        "descrption": "this is an example QMI for you to look at"
+                    },
+                    "related_datasets": [
+                      {
+                          "href": "http://localhost:8080/datasets/6789910",
+                          "title": "Crime in the UK"
+                      },
+                      {
+                          "href": "http://localhost:8080/datasets/6789910",
+                          "title": "More Crime in the UK"
+                      }
+                    ],
+                    "publications": [
+                        {
+                            "href": "http://www.localhost:8080/datasets/173849jf8j238d",
+                            "title": "An example publication"
+                        }
+                    ],
+                    "next_release": "pudding",
+                    "keywords": ["keyword1", "keyword2"],
+                    "publisher": {},
+                    "qmi": {},
+                    "state": "published",
+                    "title": "CPI",
+                    "uri": "/economy/inflationandpricesindices/datasets/consumerpriceindices"
+                }
+            })
+        }),
+        getAll: jest.fn().mockImplementation(() => {
+            return Promise.resolve()
+        })
+    }
+));
+
+const mockEvent = {
+    preventDefault: function() {}
+}
+
+const defaultProps = {
+    dispatch: function(){},
+    datasets: [],
+    params: {
+      dataset: "1234"
+    }
+}
+
+test("Dataset details page matches stored snapshot", () => {
+    const component = renderer.create(
+      <DatasetMetadata {...defaultProps} />
+    );
+    expect(component.toJSON()).toMatchSnapshot();
+});
+
+test("Dataset ID displayed matches ID from dataset API", async () => {
+  const component = mount(
+      <DatasetMetadata {...defaultProps} />
+  );
+  await component.instance().componentWillMount();
+  expect(component.update().state("isFetchingDataset")).toBe(false);
+  expect(component.update().find('.datasetId').text()).toEqual(datasetID);
+});
+
+test("Dataset title updates after successful fetch from dataset API on mount", async () => {
+    const component = shallow(
+        <DatasetMetadata {...defaultProps} />
+    );
+
+    expect(component.state("title")).toBe(null);
+    await component.instance().componentWillMount();
+    expect(component.update().state("title")).toBe("CPI");
+});
+
+test("Correct modal type shows when user wants to add a related bulletin", async () => {
+    const component = shallow(
+        <DatasetMetadata {...defaultProps} />
+    );
+    expect(component.state("modalType")).toBe("");
+    await component.instance().handleAddRelatedClick("bulletin");
+    expect(component.state("modalType")).toBe("bulletin");
+});
+
+test("Removing a related QMI updates state to be empty", async () => {
+    const component = mount(
+        <DatasetMetadata {...defaultProps} />
+    );
+    await component.instance().componentWillMount();
+    expect(component.update().state("relatedQMI")).to.have.length.of(1);
+    await component.instance().removeRelated("qmi", "123");
+    expect(component.update().state("relatedQMI")).to.have.length.of(0);
+});

--- a/src/app/views/datasets/metadata/__snapshots__/DatasetDetails.test.js.snap
+++ b/src/app/views/datasets/metadata/__snapshots__/DatasetDetails.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `
+<div
+  className="grid grid--justify-center"
+>
+  <div
+    className="grid__col-4"
+  >
+    <h1>
+      Dataset details
+    </h1>
+    <div
+      className="margin-bottom--1"
+    >
+      ◀ 
+      <a
+        href="#"
+        onClick={[Function]}
+      >
+        Back
+      </a>
+    </div>
+    <p
+      className="margin-bottom--1"
+    >
+      This information is common across all editions of the dataset.
+      <br />
+      Changing it will affect all previous edition
+    </p>
+    <div
+      className="loader loader--dark"
+    />
+  </div>
+  
+</div>
+`;
+
+exports[`Dataset details page matches stored snapshot 1`] = `
+<div
+  className="grid grid--justify-center"
+>
+  <div
+    className="grid__col-4"
+  >
+    <h1>
+      Dataset details
+    </h1>
+    <div
+      className="margin-bottom--1"
+    >
+      ◀ 
+      <a
+        href="#"
+        onClick={[Function]}
+      >
+        Back
+      </a>
+    </div>
+    <p
+      className="margin-bottom--1"
+    >
+      This information is common across all editions of the dataset.
+      <br />
+      Changing it will affect all previous edition
+    </p>
+    <div
+      className="loader loader--dark"
+    />
+  </div>
+  
+</div>
+`;
+
+exports[`Version preview matches stored snapshot 1`] = `
+<div
+  className="grid grid--justify-center"
+>
+  <div
+    className="grid__col-4"
+  >
+    <h1>
+      Dataset details
+    </h1>
+    <div
+      className="margin-bottom--1"
+    >
+      ◀ 
+      <a
+        href="#"
+        onClick={[Function]}
+      >
+        Back
+      </a>
+    </div>
+    <p
+      className="margin-bottom--1"
+    >
+      This information is common across all editions of the dataset.
+      <br />
+      Changing it will affect all previous edition
+    </p>
+    <div
+      className="loader loader--dark"
+    />
+  </div>
+  
+</div>
+`;

--- a/src/app/views/datasets/metadata/__snapshots__/DatasetMetadata.test.js.snap
+++ b/src/app/views/datasets/metadata/__snapshots__/DatasetMetadata.test.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Dataset details page matches stored snapshot 1`] = `
+<div
+  className="grid grid--justify-center"
+>
+  <div
+    className="grid__col-4"
+  >
+    <h1>
+      Dataset details
+    </h1>
+    <div
+      className="margin-bottom--1"
+    >
+      ◀ 
+      <a
+        href="#"
+        onClick={[Function]}
+      >
+        Back
+      </a>
+    </div>
+    <p
+      className="margin-bottom--1"
+    >
+      This information is common across all editions of the dataset.
+      <br />
+      Changing it will affect all previous edition
+    </p>
+    <div
+      className="loader loader--dark"
+    />
+  </div>
+  
+</div>
+`;

--- a/src/app/views/datasets/preview/DatasetPreview.jsx
+++ b/src/app/views/datasets/preview/DatasetPreview.jsx
@@ -125,7 +125,7 @@ class DatasetPreview extends Component {
                 <div className="preview__header grid grid--justify-center">
                     <div className="grid__col-6 margin-top--1 margin-bottom--1">
                         <form onSubmit={this.handleApproveSubmit}>
-                            &#9664; <Link to={`${url.parent()}`}>Back</Link>
+                            &#9664; <Link to={`${url.resolve("../")}`}>Back</Link>
                             <h2 className="inline-block margin-left--1">{this.state.datasetTitle || ""}</h2>
                             <button disabled={this.state.isApprovingVersion} className="btn btn--primary btn--block margin-left--1">Approve</button>
                             {this.state.isApprovingVersion &&

--- a/src/app/views/datasets/preview/VersionPreview.jsx
+++ b/src/app/views/datasets/preview/VersionPreview.jsx
@@ -127,7 +127,7 @@ export class VersionPreview extends Component {
                 <div className="preview__header grid grid--justify-center">
                     <div className="grid__col-6 margin-top--1 margin-bottom--1">
                         <form onSubmit={this.handleApproveSubmit}>
-                            &#9664; <Link to={`${url.parent()}`}>Back</Link>
+                            &#9664; <Link to={`${url.resolve("../")}`}>Back</Link>
                             <h2 className="inline-block margin-left--1">{this.state.datasetTitle || ""}</h2>
                             <button disabled={this.state.isApprovingVersion} className="btn btn--primary btn--block margin-left--1">Approve</button>
                             {this.state.isApprovingVersion &&

--- a/src/app/views/datasets/selectable-table/SelectableTableController.jsx
+++ b/src/app/views/datasets/selectable-table/SelectableTableController.jsx
@@ -12,8 +12,11 @@ const propTypes = {
         id: PropTypes.string.isRequired,
         instances: PropTypes.arrayOf(PropTypes.shape({
             date: PropTypes.string,
-            edition: PropTypes.string,
-            version: PropTypes.string
+            edition: PropTypes.string.isRequired,
+            version: PropTypes.oneOfType([
+                PropTypes.string.isRequired,
+                PropTypes.number.isRequired
+            ])
         }))
     }))
 }

--- a/src/app/views/uploads/dataset/upload-details/DatasetUploadMetadata.jsx
+++ b/src/app/views/uploads/dataset/upload-details/DatasetUploadMetadata.jsx
@@ -158,7 +158,7 @@ class DatasetUploadMetadata extends Component {
             })
         }).then(() => {
             this.setState({isSubmittingData: false});
-            this.props.dispatch(push(url.parent()));
+            this.props.dispatch(push(url.resolve("../")));
         }).catch(error => {
             switch (error.status) {
                 case(400):{
@@ -236,7 +236,7 @@ class DatasetUploadMetadata extends Component {
             <div className="grid grid--justify-center">
                 <div className="grid__col-6">
                     <div className="margin-top--2">
-                        &#9664; <Link to={url.parent()}>Return</Link>
+                        &#9664; <Link to={url.resolve("../")}>Return</Link>
                     </div>
                     <h1 className="margin-top--1">Dataset upload details</h1>
                     {this.state.isFetchingData ? 


### PR DESCRIPTION
### What

**Don't merge until https://github.com/ONSdigital/dp-dataset-api/pull/43 is merged.**

Update Florence to take advantage of the update to the Dataset API, which means we can make one request to get 'completed' and 'edition-confirmed' instances.

Current issue is that as soon as an edition is confirmed it disappears from the dataset screen.

### How to review

1) Switch to the branch ~~`feature/state-filter-csv`~~ `cmd-develop` on the dataset API.
2) Make you have some instances that are a mix of the state 'completed' and 'edition-confirmed'.
3) Go to `/florence/datasets`.
4) Edition and version should for edition confirmed instances, but only edition for completed instances.
5) Clicking 'view' should take you to the correct respective url (e.g. a version goes to '/florence/datasets/:datasetID/editions/:edition/versions/:version/metadata')

### Who can review

Anyone but me.
