### PR TITLE
Routing to workspace edit screen

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,6 +134,7 @@ func main() {
 	router.HandleFunc("/florence/publishing-queue", legacyIndexFile)
 	router.HandleFunc("/florence/reports", legacyIndexFile)
 	router.HandleFunc("/florence/users-and-access", legacyIndexFile)
+	router.HandleFunc("/florence/workspace", legacyIndexFile)
 	router.HandleFunc("/florence/websocket", websocketHandler)
 	router.HandleFunc("/florence{uri:/.*}", newAppHandler)
 	router.Handle("/{uri:.*}", babbageProxy)

--- a/src/legacy/js/classes/pathUtils.js
+++ b/src/legacy/js/classes/pathUtils.js
@@ -9,6 +9,15 @@ if (typeof module !== 'undefined') {
   module.exports = PathUtils;
 }
 
-
+function getQueryVariable(variable)
+{
+       var query = window.location.search.substring(1);
+       var vars = query.split("&");
+       for (var i=0;i<vars.length;i++) {
+               var pair = vars[i].split("=");
+               if(pair[0] == variable){return pair[1];}
+       }
+       return(false);
+}
 
 

--- a/src/legacy/js/functions/_setupFlorence.js
+++ b/src/legacy/js/functions/_setupFlorence.js
@@ -159,7 +159,8 @@ function setupFlorence() {
             "collections": "collections",
             "publishing-queue": "publish",
             "reports": "reports",
-            "users-and-access": "users"
+            "users-and-access": "users",
+            "workspace": "workspace"
         }[path];
     };
     $('.js-nav-item--' + mapPathToViewID(path)).addClass('selected');

--- a/src/legacy/js/functions/_viewController.js
+++ b/src/legacy/js/functions/_viewController.js
@@ -5,6 +5,34 @@ function viewController(view) {
         if (view === 'collections') {
             viewCollections();
         }
+        else if (view === 'workspace') {
+            /*
+                Example of a correct URL:
+                '/florence/workspace?collection=:collectionID&uri=:pageURI'
+            */
+
+            const collectionID = getQueryVariable("collection");
+            const pageURI = getQueryVariable("uri");
+            window.history.replaceState({}, "Florence", "/florence/collections");
+            
+            if (!pageURI || !collectionID) {
+                console.error("Unable to get either page URI or collection ID from the path", {pageURI, collectionID});
+                viewCollections();
+                return;
+            }
+
+            getCollectionDetails(collectionID, response => {
+                Florence.collection = Object.assign({}, Florence.collection, {
+                    id: collectionID,
+                    name: response.name,
+                    date: response.publishDate,
+                    type: response.type
+                });
+                createWorkspace(pageURI, collectionID, "edit", response);
+            }, error => {
+                console.error("Error getting collection date, redirected to collections screen", error);
+            });
+        }
         else if (view === 'users') {
             viewUsers();
         }

--- a/src/legacy/js/functions/_viewController.js
+++ b/src/legacy/js/functions/_viewController.js
@@ -30,7 +30,7 @@ function viewController(view) {
                 });
                 createWorkspace(pageURI, collectionID, "edit", response);
             }, error => {
-                console.error("Error getting collection date, redirected to collections screen", error);
+                console.error("Error getting collection data, redirected to collections screen", error);
             });
         }
         else if (view === 'users') {


### PR DESCRIPTION
### What

Add the ability to go to a editor screen for a page via the URL alone. This will allow us to refactor the collections screen, because we needed the functionality to be able to keep the 'edit' click on a page item in a collection.

### How to review

Check the code isn't too crazy (although a bit of leeway is needed because it's old Florence code) and check the functionality works. An example of what a working URL should look like:
```
/florence/workspace?collection=myCollectionID&uri=/economy
```

### Who can review

@jondewijones 
