### PR TITLE
Show Dataset ID if title doesn't exist yet

### DIFF
--- a/src/app/views/datasets/DatasetsController.jsx
+++ b/src/app/views/datasets/DatasetsController.jsx
@@ -129,7 +129,7 @@ class DatasetsController extends Component {
                     }
                 });
                 return {
-                    title: dataset.title,
+                    title: dataset.title || dataset.id,
                     id: dataset.id,
                     instances: datasetInstances
                 }


### PR DESCRIPTION
### What

Allow the datasets screen to show the dataset ID if a title isn't in the object - prevents us from getting ugly runtime errors if they data isn't in the structure we expect.

### How to review

Super quick code check should be fine.

### Who can review

Anyone but me.
