### PR TITLE
Stop logging full websocket buffer to fix infinite loop

### DIFF
--- a/src/legacy/js/classes/_websocket.js
+++ b/src/legacy/js/classes/_websocket.js
@@ -64,7 +64,7 @@ var websocket = {
 
         if (websocket.buffer.size >= 50) {
             console.warn(`Websocket buffer has reached it's limit, so message will not be sent to server. Message: \n`, message);
-            log.add(log.eventTypes.socketBufferFull); // This has to be excluded from being sent to the server or else we'll have an infinite loop
+            //log.add(log.eventTypes.socketBufferFull); // This has to be excluded from being sent to the server or else we'll have an infinite loop
             return;
         }
 


### PR DESCRIPTION
### What

Remove logging of full websocket buffer because it causes an infinite loop - which we know will happen everytime at the moment because websockets aren't working on develop or production.

### How to review

Code check.

### Who can review

Anyone but me.
