### PR TITLE
Feature/disable preview

### DIFF
--- a/src/app/views/datasets/collection/CollectionView.jsx
+++ b/src/app/views/datasets/collection/CollectionView.jsx
@@ -8,6 +8,7 @@ import Select from '../../../components/Select';
 const propTypes = {
     hasChosen: PropTypes.bool.isRequired,
     isGettingCollections: PropTypes.bool.isRequired,
+    isGettingDataset: PropTypes.bool.isRequired,
     isSubmitting: PropTypes.bool.isRequired,
     errorMsg: PropTypes.string,
     collectionsSelectItems: PropTypes.array,
@@ -16,7 +17,8 @@ const propTypes = {
     handleSubmit: PropTypes.func.isRequired,
     handleCollectionChange: PropTypes.func.isRequired,
     handleOnBackFromSuccess: PropTypes.func.isRequired,
-    backLink: PropTypes.string.isRequired
+    backLink: PropTypes.string.isRequired,
+    hasVersion: PropTypes.string
 };
 
 class CollectionView extends Component {
@@ -26,7 +28,7 @@ class CollectionView extends Component {
 
     renderSuccess() {
         const selectedCollection = this.props.selectedCollection;
-        const link = `${location.pathname}/preview`;
+        const isGettingDataset = this.props.isGettingDataset;
         return (
             <div>
                 <div className="margin-top--2">
@@ -34,11 +36,42 @@ class CollectionView extends Component {
                 </div>
                 <h1 className="margin-top--1">Success</h1>
                 <p>This dataset has been checked and added to {selectedCollection.name}.</p>
-                <Link to={link} className="btn btn--positive margin-top--1">
-                    Preview dataset
-                </Link>
+                {isGettingDataset ?
+                    <div className="form__loader loader loader--dark margin-left--1"></div> 
+                    : 
+                    this.renderNextStep()
+                }
             </div>
         )
+    }
+
+    renderNextStep() {
+        const hasVersion = this.props.hasVersion;
+
+        if (hasVersion === "true"){
+            const previewLink = `${location.pathname}/preview`;
+            return (
+                <Link to={previewLink} className="btn btn--positive margin-top--1">
+                    Preview dataset
+                </Link>
+            )
+        }
+
+        if (hasVersion === "false"){
+            return (
+                <Link className="btn btn--primary margin-top--1" to={url.resolve("/uploads/data")}>
+                    Upload a dataset
+                </Link>
+            )
+        }
+
+        if (hasVersion === ""){
+            return (
+                <Link className="btn btn--primary margin-top--1" to={url.resolve("/datasets")}>
+                    Return to datasets
+                </Link>
+            )
+        }
     }
 
     renderChoices() {
@@ -59,6 +92,7 @@ class CollectionView extends Component {
                                 onChange={this.props.handleCollectionChange}
                                 error={this.props.errorMsg}
                                 selectedOption={this.props.selectedCollection.id}
+                                version={this.props.hasVersion}
                         />
 
                         {selectedCollection.id ? this.renderSelectedCollectionDetails() : ""}

--- a/src/app/views/datasets/collection/DatasetCollectionController.jsx
+++ b/src/app/views/datasets/collection/DatasetCollectionController.jsx
@@ -5,9 +5,9 @@ import { connect } from 'react-redux';
 import dateFormat from 'dateformat';
 import notifications from '../../../utilities/notifications';
 import collections from '../../../utilities/api-clients/collections';
+import datasets from '../../../utilities/api-clients/datasets';
 import CollectionView from './CollectionView';
 import url from '../../../utilities/url';
-
 
 const propTypes = {
     params: PropTypes.shape({
@@ -23,12 +23,14 @@ export class DatasetCollectionController extends Component {
         this.state = {
             hasChosen: false,
             isGettingCollections: false,
+            isGettingDataset: false,
             isSubmitting: false,
             errorMsg: "",
             collectionsSelectItems: [],
             allCollections: [],
             selectedCollection: {},
             nextRelease: "",
+            hasVersion: ""
         };
 
         this.handleCollectionChange = this.handleCollectionChange.bind(this);
@@ -38,8 +40,16 @@ export class DatasetCollectionController extends Component {
 
     componentWillMount() {
         this.getCollections();
+        this.getDatasets();
     }
-
+    getDatasets() {
+        this.setState({isGettingDataset: true});
+        datasets.get(this.props.params.datasetID)
+            .then(dataset => {
+                this.setState(dataset.next.links.latest_version ? {hasVersion: "true"} : {hasVersion:"false"});
+        });
+        this.setState({isGettingDataset: false});
+    }
     getCollections() {
         this.setState({isGettingCollections: true});
         collections.getAll()

--- a/src/app/views/datasets/preview/DatasetPreview.jsx
+++ b/src/app/views/datasets/preview/DatasetPreview.jsx
@@ -21,7 +21,8 @@ class DatasetPreview extends Component {
 
         this.state = {
             datasetTitle: null,
-            isApprovingVersion: false
+            isApprovingVersion: false,
+            latestVersion: null
         }
 
         this.handleApproveSubmit = this.handleApproveSubmit.bind(this);
@@ -29,10 +30,15 @@ class DatasetPreview extends Component {
     
     componentWillMount() {
         datasets.get(this.props.params.datasetID).then(dataset => {
-            this.setState({datasetTitle: dataset.next.title});
+            const latestVersionPath = url.resolve(dataset.current.links.latest_version.href);
+            this.setState({
+                datasetTitle: dataset.next.title,
+                latestVersion: latestVersionPath
+            });
+
         }).catch(error => {
             switch(error.status) {
-                case(403): {
+                case(403): {   
                     const notification = {
                         type: "neutral",
                         message: `You do not have permission to view dataset '${this.props.params.datasetID}'`
@@ -120,6 +126,7 @@ class DatasetPreview extends Component {
 
     render() {
         const params = this.props.params;
+        const path = this.state.latestVersion
         return (
             <div className="preview">
                 <div className="preview__header grid grid--justify-center">
@@ -135,7 +142,7 @@ class DatasetPreview extends Component {
                     </div>
                 </div>
                 <Preview 
-                    path={`//${location.host}/datasets/${params.datasetID}`}
+                    path={`//${location.host}${path}`}
                 />
             </div>
         )

--- a/src/app/views/datasets/preview/DatasetPreview.jsx
+++ b/src/app/views/datasets/preview/DatasetPreview.jsx
@@ -126,7 +126,7 @@ class DatasetPreview extends Component {
 
     render() {
         const params = this.props.params;
-        const path = this.state.latestVersion
+        const path = this.state.latestVersion;
         return (
             <div className="preview">
                 <div className="preview__header grid grid--justify-center">

--- a/src/app/views/datasets/preview/VersionPreview.jsx
+++ b/src/app/views/datasets/preview/VersionPreview.jsx
@@ -137,7 +137,7 @@ export class VersionPreview extends Component {
                     </div>
                 </div>
                 <Preview
-                    path={`//${location.host}/datasets/${params.datasetID}`}
+                    path={`//${location.host}/datasets/${params.datasetID}/editions/${params.edition}/versions/${params.version}`}
                 />
             </div>
         )


### PR DESCRIPTION
### What

On the add to collection screen in a dataset there are now three scenarios:
1) If the dataset has a version - the preview button is displayed.
2) If the dataset does not have a version - button to upload dataset is shown.
3) If there is a problem fetching the dataset information - button back to all datasets is shown.

### How to review

Ensure you can create the first two scenarios and check the elements render and work correctly.

Click on the "edit dataset details" link and go through the metadata journey.

### Who can review

Anyone.