### PR TITLE
Fix some routes going to old Collections screen

### DIFF
--- a/src/legacy/js/functions/_viewCollections.js
+++ b/src/legacy/js/functions/_viewCollections.js
@@ -1,144 +1,151 @@
 function viewCollections(collectionId) {
 
-    var result = {};
-    var pageDataRequests = []; // list of promises - one for each ajax request.
-    pageDataRequests.push(
-        $.ajax({
-            url: "/zebedee/collections",
-            type: "get",
-            success: function (data) {
-                result.data = data;
-            },
-            error: function (jqxhr) {
-                handleApiError(jqxhr);
-            }
-        })
-    );
-    pageDataRequests.push(
-        getTeams(
-            success = function (team) {
-                result.team = team;
-            },
-            error = function (response) {
-                handleApiError(response);
-            }
-        )
-    );
-
-    $.when.apply($, pageDataRequests).then(function () {
-
-        var response = [], teams = [], date = "";
-
-        $.each(result.data, function (i, collection) {
-            var approvalStates = {inProgress: false, thrownError: false, completed: false, notStarted: false};
-
-            if (collection.approvalStatus != "COMPLETE") {
-
-                // Set publish date
-                if (!collection.publishDate) {
-                    date = '[manual collection]';
-                } else if (collection.publishDate && collection.type === 'manual') {
-                    date = StringUtils.formatIsoDateString(collection.publishDate) + ' [rolled back]';
-                } else {
-                    date = StringUtils.formatIsoDateString(collection.publishDate);
-                }
-
-                // Set approval state
-                switch (collection.approvalStatus) {
-                    case (undefined): {
-                        break;
-                    }
-                    case ('NOT_STARTED'): {
-                        approvalStates.notStarted = true;
-                        break;
-                    }
-                    case ('IN_PROGRESS'): {
-                        approvalStates.inProgress = true;
-                        break;
-                    }
-                    case ('COMPLETE'): {
-                        approvalStates.completed = true;
-                        break;
-                    }
-                    case ('ERROR'): {
-                        approvalStates.thrownError = true;
-                        break;
-                    }
-                }
-
-                response.push({id: collection.id, name: collection.name, date: date, approvalState: approvalStates});
-            }
-        });
-
-        var isDataVis = false;
-        if (Florence.Authentication.userType() === "DATA_VISUALISATION") {
-            isDataVis = true;
-        }
-        var collectionsHtml = templates.collectionList({response: response, teams: result.team.teams, isDataVis: isDataVis});
-        $('.section').html(collectionsHtml);
-
-        if (collectionId) {
-            viewCollectionDetails(collectionId, $('.js-selectable-table tr[data-id="' + collectionId + '"]'));
-        }
-
-        $('.js-selectable-table tbody tr').click(function () {
-            var collectionId = $(this).attr('data-id');
-            viewCollectionDetails(collectionId, $(this));
-        });
-
-        $("#team-tag").tagit({
-            singleField: true,
-            singleFieldNode: $('#team-input')
-        });
-
-        $('.ui-autocomplete-input').hide();
-
-        $('select#team').change(function () {
-            $('#team-tag').tagit('createTag', $("#team option:selected").text());
-        });
-
-        $('#team-input').change(function () {
-            teams = $('#team-input').val().split(',');
-            //After creating the array tagit leaves an empty string if all elements are removed
-            if (teams.length === 1 && teams[0] === "") {
-                teams = [];
-            }
-        });
-
-        $('form input[type=radio]').click(function () {
-
-            if ($(this).val() === 'manual') {
-                $('#scheduledPublishOptions').hide();
-            } else if ($(this).val() === 'scheduled') {
-                $('#scheduledPublishOptions').show();
-            } else if ($(this).val() === 'custom') {
-                $('#customScheduleOptions').show();
-                $('#releaseScheduleOptions').hide();
-            } else if ($(this).val() === 'release') {
-                $('#customScheduleOptions').hide();
-                $('#releaseScheduleOptions').show();
-            }
-        });
+    if (collectionId) {
+        location.href = location.origin + "/florence/collections/" + collectionId;
+    } else {
+        location.pathname = "/florence/collections";
+    }
 
 
-        $(function () {
-            var today = new Date();
-            $('#date').datepicker({
-                minDate: today,
-                dateFormat: 'dd/mm/yy',
-                constrainInput: true
-            });
-        });
+    // var result = {};
+    // var pageDataRequests = []; // list of promises - one for each ajax request.
+    // pageDataRequests.push(
+    //     $.ajax({
+    //         url: "/zebedee/collections",
+    //         type: "get",
+    //         success: function (data) {
+    //             result.data = data;
+    //         },
+    //         error: function (jqxhr) {
+    //             handleApiError(jqxhr);
+    //         }
+    //     })
+    // );
+    // pageDataRequests.push(
+    //     getTeams(
+    //         success = function (team) {
+    //             result.team = team;
+    //         },
+    //         error = function (response) {
+    //             handleApiError(response);
+    //         }
+    //     )
+    // );
+
+    // $.when.apply($, pageDataRequests).then(function () {
+
+    //     var response = [], teams = [], date = "";
+
+    //     $.each(result.data, function (i, collection) {
+    //         var approvalStates = {inProgress: false, thrownError: false, completed: false, notStarted: false};
+
+    //         if (collection.approvalStatus != "COMPLETE") {
+
+    //             // Set publish date
+    //             if (!collection.publishDate) {
+    //                 date = '[manual collection]';
+    //             } else if (collection.publishDate && collection.type === 'manual') {
+    //                 date = StringUtils.formatIsoDateString(collection.publishDate) + ' [rolled back]';
+    //             } else {
+    //                 date = StringUtils.formatIsoDateString(collection.publishDate);
+    //             }
+
+    //             // Set approval state
+    //             switch (collection.approvalStatus) {
+    //                 case (undefined): {
+    //                     break;
+    //                 }
+    //                 case ('NOT_STARTED'): {
+    //                     approvalStates.notStarted = true;
+    //                     break;
+    //                 }
+    //                 case ('IN_PROGRESS'): {
+    //                     approvalStates.inProgress = true;
+    //                     break;
+    //                 }
+    //                 case ('COMPLETE'): {
+    //                     approvalStates.completed = true;
+    //                     break;
+    //                 }
+    //                 case ('ERROR'): {
+    //                     approvalStates.thrownError = true;
+    //                     break;
+    //                 }
+    //             }
+
+    //             response.push({id: collection.id, name: collection.name, date: date, approvalState: approvalStates});
+    //         }
+    //     });
+
+    //     var isDataVis = false;
+    //     if (Florence.Authentication.userType() === "DATA_VISUALISATION") {
+    //         isDataVis = true;
+    //     }
+    //     var collectionsHtml = templates.collectionList({response: response, teams: result.team.teams, isDataVis: isDataVis});
+    //     $('.section').html(collectionsHtml);
+
+    //     if (collectionId) {
+    //         viewCollectionDetails(collectionId, $('.js-selectable-table tr[data-id="' + collectionId + '"]'));
+    //     }
+
+    //     $('.js-selectable-table tbody tr').click(function () {
+    //         var collectionId = $(this).attr('data-id');
+    //         viewCollectionDetails(collectionId, $(this));
+    //     });
+
+    //     $("#team-tag").tagit({
+    //         singleField: true,
+    //         singleFieldNode: $('#team-input')
+    //     });
+
+    //     $('.ui-autocomplete-input').hide();
+
+    //     $('select#team').change(function () {
+    //         $('#team-tag').tagit('createTag', $("#team option:selected").text());
+    //     });
+
+    //     $('#team-input').change(function () {
+    //         teams = $('#team-input').val().split(',');
+    //         //After creating the array tagit leaves an empty string if all elements are removed
+    //         if (teams.length === 1 && teams[0] === "") {
+    //             teams = [];
+    //         }
+    //     });
+
+    //     $('form input[type=radio]').click(function () {
+
+    //         if ($(this).val() === 'manual') {
+    //             $('#scheduledPublishOptions').hide();
+    //         } else if ($(this).val() === 'scheduled') {
+    //             $('#scheduledPublishOptions').show();
+    //         } else if ($(this).val() === 'custom') {
+    //             $('#customScheduleOptions').show();
+    //             $('#releaseScheduleOptions').hide();
+    //         } else if ($(this).val() === 'release') {
+    //             $('#customScheduleOptions').hide();
+    //             $('#releaseScheduleOptions').show();
+    //         }
+    //     });
 
 
-        $('.btn-select-release').on("click", function (e) {
-            e.preventDefault();
-            viewReleaseSelector();
-        });
+    //     $(function () {
+    //         var today = new Date();
+    //         $('#date').datepicker({
+    //             minDate: today,
+    //             dateFormat: 'dd/mm/yy',
+    //             constrainInput: true
+    //         });
+    //     });
 
-        $('.form-create-collection').submit(function (e) {
-            e.preventDefault();
-            createCollection(teams);
-        });
-    });
+
+    //     $('.btn-select-release').on("click", function (e) {
+    //         e.preventDefault();
+    //         viewReleaseSelector();
+    //     });
+
+    //     $('.form-create-collection').submit(function (e) {
+    //         e.preventDefault();
+    //         createCollection(teams);
+    //     });
+    // });
 }


### PR DESCRIPTION
### What

Fix the bug where 'Submit and review' and other actions in the workspace would direct to the old collections screen.

So I've updated the `viewCollections` function to always redirect to the new collections screen, making sure the legacy collections screen never gets rendered. 

### How to review

You don't need the CMD stack running for this, just Zebedee (on any develop/master branch) and Florence on this branch.

Check that submitting a page for review save it and then returns you to the active collection on the refactored collections screen.

### Who can review

Anyone but me.
