### PR TITLE
Separate version alert component

### DIFF
--- a/src/app/views/datasets/metadata/VersionMetadata.jsx
+++ b/src/app/views/datasets/metadata/VersionMetadata.jsx
@@ -18,6 +18,8 @@ import RelatedContentForm from './related-content/RelatedContentForm';
 import log, {eventTypes} from '../../../utilities/log'
 import collections from '../../../utilities/api-clients/collections'
 import DatasetReviewActions from '../DatasetReviewActions'
+import AlertController from './alert/AlertController'
+import date from '../../../utilities/date'
 
 const propTypes = {
     dispatch: PropTypes.func.isRequired,
@@ -110,6 +112,7 @@ export class VersionMetadata extends Component {
         this.handleSaveAndSubmitForReview = this.handleSaveAndSubmitForReview.bind(this);
         this.handleSaveAndMarkAsReviewed = this.handleSaveAndMarkAsReviewed.bind(this);
         this.handleRelatedContentCancel = this.handleRelatedContentCancel.bind(this);
+        this.handleAlertSave = this.handleAlertSave.bind(this);
         this.handleBackButton = this.handleBackButton.bind(this);
     }
 
@@ -589,7 +592,7 @@ export class VersionMetadata extends Component {
     mapTypeContentsToCard(items, type){
         return items.map(item => {
             return {
-                title: type === "alerts" ? item.date : item.name,
+                title: type === "alerts" ? date.format(item.date, "dddd, dd/mm/yyyy h:MMTT") : item.name,
                 id: item.key,
             }
         });
@@ -696,7 +699,7 @@ export class VersionMetadata extends Component {
                         ...item,
                         date: this.state.titleInput,
                         description: this.state.descInput,
-                        type: "correction",
+                        type: "alert",
                         hasChanged: true
                     }
                 }
@@ -856,7 +859,7 @@ export class VersionMetadata extends Component {
                 if (this.state.editKey != "") {
                     this.editRelatedLink("alerts", this.state.editKey);
                 } else {
-                    const alerts = this.state.alerts.concat({date: this.state.titleInput, description: this.state.descInput, key: uuid(), hasChanged:true, type: "correction"});
+                    const alerts = this.state.alerts.concat({date: this.state.titleInput, description: this.state.descInput, key: uuid(), hasChanged:true, type: "alert"});
                     this.setState({alerts: alerts});
                 }
             } else if (this.state.modalType === "changes") {
@@ -878,6 +881,71 @@ export class VersionMetadata extends Component {
             });
         }
      }
+
+    handleAlertSave(newAlert) {
+        const newState = {
+            showModal: false,
+            modalType: "",
+            editKey: "",
+            titleInput: "",
+            descInput: "",
+            hasChanges: true
+        }
+
+        // No existing alerts so we just add our new one into state - stops any runtime errors if we set 
+        // 'alerts' to null or undefined anywhere (because `.some()` would fail later)
+        if (!this.state.alerts || this.state.alerts.length === 0) {
+            const alerts = [{
+                key: newAlert.id,
+                date: newAlert.date,
+                description: newAlert.description,
+                hasChanged: true,
+                type: "alert"
+            }];
+            this.setState({
+                ...newState,
+                alerts
+            });
+            return;
+        }
+
+        const isExistingAlert = this.state.alerts.some(alert => alert.key === newAlert.id);
+        
+        if (isExistingAlert) {
+            const alerts = this.state.alerts.map(alert => {
+                if (alert.key !== newAlert.id) {
+                    return alert;
+                }
+                return {
+                    ...alert,
+                    hasChanged: true,
+                    date: newAlert.date,
+                    description: newAlert.description
+                }
+            });
+
+            this.setState({
+                ...newState,
+                alerts,
+            });
+
+            return;
+        }
+
+        const alerts = [...this.state.alerts];
+        alerts.push({
+            key: newAlert.id,
+            date: newAlert.date,
+            description: newAlert.description,
+            hasChanged: true,
+            type: "alert"
+        })
+
+        this.setState({
+            ...newState,
+            alerts
+        });
+    }
 
     handleSave(event, isSubmittingForReview, isMarkingAsReviewed) {
         event.preventDefault();
@@ -1043,17 +1111,16 @@ export class VersionMetadata extends Component {
                       </div>
                     }
                 </div>
-                {this.state.showModal &&
-
+                {(this.state.showModal && this.state.modalType !== "alerts") &&
                 <Modal sizeClass="grid__col-3">
                         {this.state.modalType ?
 
                           <RelatedContentForm
                               name="related-content-modal"
-                              formTitle={this.state.modalType === "alerts" ? "Add an alert" : "Add latest change"}
+                              formTitle={"Add latest change"}
                               titleInput={this.state.titleInput}
                               descInput={this.state.descInput}
-                              titleLabel={this.state.modalType === "alerts" ? "Date (e.g 01 September 2017)" : "Name"}
+                              titleLabel={"Name"}
                               descLabel={"Description"}
                               onCancel={this.handleRelatedContentCancel}
                               onFormInput={this.handleInputChange}
@@ -1081,6 +1148,15 @@ export class VersionMetadata extends Component {
                       }
                       </Modal>
 
+                }
+                {(this.state.showModal && this.state.modalType === "alerts") &&
+                    <AlertController
+                        date={this.state.titleInput}
+                        description={this.state.descInput}
+                        onSave={this.handleAlertSave}
+                        onCancel={this.handleRelatedContentCancel}
+                        id={this.state.editKey}
+                    />
                 }
             </div>
         )

--- a/src/app/views/datasets/metadata/VersionMetadata.test.js
+++ b/src/app/views/datasets/metadata/VersionMetadata.test.js
@@ -22,6 +22,14 @@ jest.mock('../../../utilities/url', () => {
     }
 });
 
+jest.mock('../../../utilities/date', () => {
+    return {
+        format: function() {
+            return "a formatted date"
+        }
+    }
+});
+
 jest.mock('../../../utilities/notifications', () => {
     return {
         add: jest.fn(() => {
@@ -376,7 +384,7 @@ test("Alert items map to card element correctly", async () => {
     const cardProps = component.instance().mapTypeContentsToCard(component.state("alerts"),"alerts");
     component.state("alerts").forEach((alert, index) => {
         expect(cardProps[index]).toMatchObject({
-            title: alert.date,
+            title: "a formatted date",
             id: alert.key
         });
     })

--- a/src/app/views/datasets/metadata/VersionMetadata.test.js
+++ b/src/app/views/datasets/metadata/VersionMetadata.test.js
@@ -7,6 +7,7 @@ import renderer from 'react-test-renderer';
 import { shallow, mount } from 'enzyme';
 
 console.error = jest.fn();
+console.warn = jest.fn();
 
 jest.mock('uuid/v4', () => () => {
     return "12345";

--- a/src/app/views/datasets/metadata/alert/AlertController.jsx
+++ b/src/app/views/datasets/metadata/alert/AlertController.jsx
@@ -1,0 +1,142 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import date from '../../../../utilities/date'
+import AlertView from './AlertView'
+import uuid from 'uuid/v4';
+
+const propTypes = {
+    date: PropTypes.string,
+    description: PropTypes.string,
+    onCancel: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    id: PropTypes.string
+};
+
+class AlertController extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            currentDate: "",
+            newDate: {
+                value: "",
+                errorMsg: ""
+            },
+            newDescription: {
+                value: "",
+                errorMsg: ""
+            },
+            newID: ""
+        };
+
+        this.maximumAlertDate = date.format(date.addYear(10), "yyyy-mm-dd");
+
+        this.handleDateChange = this.handleDateChange.bind(this);
+        this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
+        this.handleSave = this.handleSave.bind(this);
+    }
+
+    componentWillMount() {
+        if (!this.props.id) {
+            this.setState({newID: uuid()});
+        }
+
+        if (this.props.date) {
+            this.setState({
+                currentDate: this.formatDateToInput(new Date(this.props.date))
+            });
+            return;
+        }
+
+        this.setState({
+            currentDate: this.formatDateToInput(new Date())
+        });
+    }
+
+    formatDateToInput(dateObject) {
+        return date.format(dateObject.toISOString(), "yyyy-mm-dd'T'HH:MM");
+    }
+
+    handleDateChange(event) {
+        this.setState({
+            newDate: {
+                value: event.target.value || "",
+                errorMsg: ""
+            },
+            currentDate: ""
+        });
+    }
+
+    handleDescriptionChange(event) {
+        this.setState({
+            newDescription: {
+                value: event.target.value || "",
+                errorMsg: "",
+            }
+        });
+    }
+    
+    handleSave(event) {
+        event.preventDefault();
+        let hasError = false;
+        let newState = {};
+
+        if (!this.state.newDate.value && !this.state.currentDate) {
+            newState = {
+                ...newState,
+                newDate: {
+                    ...this.state.newDate,
+                    errorMsg: "A date and time must be chosen",
+                }
+            };
+            hasError = true;
+        }
+
+        if (!this.state.newDescription.value && !this.props.description) {
+            newState = {
+                ...newState,
+                newDescription: {
+                    ...this.state.newDescription,
+                    errorMsg: "An alert must have a description",
+                }
+            };
+            hasError = true;
+        }
+
+        if (hasError) {
+            this.setState(newState);
+            return;
+        }
+
+        const alert = {
+            description: this.state.newDescription.value,
+            date: new Date(this.state.newDate.value || this.state.currentDate).toISOString(),
+            id: this.props.id || this.state.newID
+        }
+        this.props.onSave(alert);
+    }
+
+    render() {
+        return (
+            <AlertView
+                date={{
+                    value: this.state.newDate.value || this.state.currentDate,
+                    errorMsg: this.state.newDate.errorMsg,
+                    onChange: this.handleDateChange
+                }}
+                description={{
+                    value: this.state.newDescription.value || this.props.description,
+                    errorMsg: this.state.newDescription.errorMsg,
+                    onChange: this.handleDescriptionChange
+                }}
+                onSave={this.handleSave}
+                onCancel={this.props.onCancel}
+                isEditing={(Boolean(this.props.date) || Boolean(this.props.description))}
+            />
+        )
+    }
+}
+
+AlertController.propTypes = propTypes;
+
+export default AlertController;

--- a/src/app/views/datasets/metadata/alert/AlertView.jsx
+++ b/src/app/views/datasets/metadata/alert/AlertView.jsx
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import Modal from '../../../../components/Modal'
+import Input from '../../../../components/Input'
+
+const propTypes = {
+    date: PropTypes.shape({
+        onChange: PropTypes.func.isRequired,
+        value: PropTypes.string,
+        errorMsg: PropTypes.string
+    }).isRequired,
+    description: PropTypes.shape({
+        onChange: PropTypes.func.isRequired,
+        value: PropTypes.string,
+        errorMsg: PropTypes.string
+    }).isRequired,
+    onCancel: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    isEditing: PropTypes.bool
+};
+
+class AlertView extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <Modal sizeClass="grid__col-5">
+                <form onSubmit={this.props.onSave}>
+                    <div className="modal__header">
+                        <h2>{this.props.isEditing ? "Edit" : "Add"} alert</h2>
+                    </div>
+                    <div className="modal__body">
+                        <div className="grid grid__col-4">
+                            <Input 
+                                id="correction-date" 
+                                type="datetime-local"
+                                value={this.props.date.value}
+                                error={this.props.date.errorMsg}
+                                label="Date"
+                                onChange={this.props.date.onChange}
+                            />
+                        </div>
+                        <Input
+                            type="textarea"
+                            id="correction-description"
+                            value={this.props.description.value}
+                            error={this.props.description.errorMsg}
+                            label="Description"
+                            onChange={this.props.description.onChange}
+                        />
+                    </div>
+                    <div className="modal__footer">
+                        <button className="btn btn--primary" type="submit">Save</button>
+                        <button className="btn margin-left--1" type="button" onClick={this.props.onCancel}>Cancel</button>
+                    </div>
+                </form>
+            </Modal>
+        )
+    }
+}
+
+AlertView.propTypes = propTypes;
+
+export default AlertView;


### PR DESCRIPTION
### What

Made a separate version alert component so that it could have two changes:
- Use a date input for alert
- Increase size of description input

### How to review

Check that you can add and edit an alert for a version. There are existing bugs where editing an alert, saving the version and refreshing will duplicate the alert you edited. This is a problem between the API not allowing editing of alerts and the client expecting that it does.

### Who can review

Anyone but me.
