### PR TITLE
Alert: toggle correction

### DIFF
--- a/src/app/views/datasets/metadata/VersionMetadata.jsx
+++ b/src/app/views/datasets/metadata/VersionMetadata.jsx
@@ -97,7 +97,8 @@ export class VersionMetadata extends Component {
             changes: [],
             editKey: "",
             titleInput: "",
-            descInput: ""
+            descInput: "",
+            checkboxInput: false
         }
 
         this.handleSelectChange = this.handleSelectChange.bind(this);
@@ -654,6 +655,7 @@ export class VersionMetadata extends Component {
             showModal: true,
             modalType: type,
             editKey: key,
+            checkboxInput: relatedItem.type === "correction",
             titleInput: type === "alerts" ? relatedItem.date : relatedItem.name,
             descInput: relatedItem.description,
             hasChanges: true
@@ -889,6 +891,7 @@ export class VersionMetadata extends Component {
             editKey: "",
             titleInput: "",
             descInput: "",
+            checkboxInput: false,
             hasChanges: true
         }
 
@@ -900,7 +903,7 @@ export class VersionMetadata extends Component {
                 date: newAlert.date,
                 description: newAlert.description,
                 hasChanged: true,
-                type: "alert"
+                type: newAlert.isCorrection ? "correction" : ""
             }];
             this.setState({
                 ...newState,
@@ -920,7 +923,8 @@ export class VersionMetadata extends Component {
                     ...alert,
                     hasChanged: true,
                     date: newAlert.date,
-                    description: newAlert.description
+                    description: newAlert.description,
+                    type: newAlert.isCorrection ? "correction" : ""
                 }
             });
 
@@ -938,7 +942,7 @@ export class VersionMetadata extends Component {
             date: newAlert.date,
             description: newAlert.description,
             hasChanged: true,
-            type: "alert"
+            type: newAlert.isCorrection ? "correction" : ""
         })
 
         this.setState({
@@ -1153,6 +1157,7 @@ export class VersionMetadata extends Component {
                     <AlertController
                         date={this.state.titleInput}
                         description={this.state.descInput}
+                        isCorrection={this.state.checkboxInput}
                         onSave={this.handleAlertSave}
                         onCancel={this.handleRelatedContentCancel}
                         id={this.state.editKey}

--- a/src/app/views/datasets/metadata/alert/AlertController.jsx
+++ b/src/app/views/datasets/metadata/alert/AlertController.jsx
@@ -7,6 +7,7 @@ import uuid from 'uuid/v4';
 const propTypes = {
     date: PropTypes.string,
     description: PropTypes.string,
+    isCorrection: PropTypes.bool,
     onCancel: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     id: PropTypes.string
@@ -26,13 +27,15 @@ class AlertController extends Component {
                 value: "",
                 errorMsg: ""
             },
-            newID: ""
+            newID: "",
+            newIsCorrectionBoolean: null,
         };
 
         this.maximumAlertDate = date.format(date.addYear(10), "yyyy-mm-dd");
 
         this.handleDateChange = this.handleDateChange.bind(this);
         this.handleDescriptionChange = this.handleDescriptionChange.bind(this);
+        this.handleIsCorrectionChange = this.handleIsCorrectionChange.bind(this);
         this.handleSave = this.handleSave.bind(this);
     }
 
@@ -76,6 +79,11 @@ class AlertController extends Component {
         });
     }
     
+    handleIsCorrectionChange(isCorrection) {
+        console.log(isCorrection);
+        this.setState({newIsCorrectionBoolean: isCorrection});
+    }
+    
     handleSave(event) {
         event.preventDefault();
         let hasError = false;
@@ -108,9 +116,16 @@ class AlertController extends Component {
             return;
         }
 
+        let isCorrection = this.props.isCorrection || false;
+
+        if (this.state.newIsCorrectionBoolean !== null) {
+            isCorrection = this.state.newIsCorrectionBoolean
+        }
+
         const alert = {
-            description: this.state.newDescription.value,
+            description: this.state.newDescription.value || this.props.description || "",
             date: new Date(this.state.newDate.value || this.state.currentDate).toISOString(),
+            isCorrection,
             id: this.props.id || this.state.newID
         }
         this.props.onSave(alert);
@@ -128,6 +143,10 @@ class AlertController extends Component {
                     value: this.state.newDescription.value || this.props.description,
                     errorMsg: this.state.newDescription.errorMsg,
                     onChange: this.handleDescriptionChange
+                }}
+                isCorrection={{
+                    value: this.state.newIsCorrectionBoolean || this.props.isCorrection,
+                    onChange: this.handleIsCorrectionChange
                 }}
                 onSave={this.handleSave}
                 onCancel={this.props.onCancel}

--- a/src/app/views/datasets/metadata/alert/AlertView.jsx
+++ b/src/app/views/datasets/metadata/alert/AlertView.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '../../../../components/Modal'
 import Input from '../../../../components/Input'
+import Checkbox from '../../../../components/Checkbox'
 
 const propTypes = {
     date: PropTypes.shape({
@@ -13,6 +14,10 @@ const propTypes = {
         onChange: PropTypes.func.isRequired,
         value: PropTypes.string,
         errorMsg: PropTypes.string
+    }).isRequired,
+    isCorrection: PropTypes.shape({
+        onChange: PropTypes.func.isRequired,
+        value: PropTypes.bool
     }).isRequired,
     onCancel: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
@@ -34,7 +39,7 @@ class AlertView extends Component {
                     <div className="modal__body">
                         <div className="grid grid__col-4">
                             <Input 
-                                id="correction-date" 
+                                id="alert-date" 
                                 type="datetime-local"
                                 value={this.props.date.value}
                                 error={this.props.date.errorMsg}
@@ -44,11 +49,17 @@ class AlertView extends Component {
                         </div>
                         <Input
                             type="textarea"
-                            id="correction-description"
+                            id="alert-description"
                             value={this.props.description.value}
                             error={this.props.description.errorMsg}
                             label="Description"
                             onChange={this.props.description.onChange}
+                        />
+                        <Checkbox 
+                            id="alert-is-correction"
+                            onChange={this.props.isCorrection.onChange}
+                            isChecked={this.props.isCorrection.value}
+                            label="Correction"
                         />
                     </div>
                     <div className="modal__footer">


### PR DESCRIPTION
### What

Allow a user to toggle an alert to be a correction or not.

Also a fix for the description disappearing if an existing alert is opened and then saved without editing the description.

### How to review

In a version of a dataset add/edit an alert. You should have a checkbox which you can check/uncheck, save and submit to the API - which then saves as `type: "correction"` in the data.

### Who can review

Anyone but me
