### PR TITLE
Auto populate version dimension inputs

### DIFF
--- a/src/app/components/Input.jsx
+++ b/src/app/components/Input.jsx
@@ -89,7 +89,7 @@ export default class Input extends Component {
                         onChange={this.props.onChange}
                         autoFocus={this.props.isFocused}
                         placeholder={this.props.inline ? this.props.label : ""}
-                        defaultValue={this.props.value}
+                        value={this.props.value}
                     >
                     </textarea>
                 }

--- a/src/app/utilities/api-clients/datasets.js
+++ b/src/app/utilities/api-clients/datasets.js
@@ -1,4 +1,5 @@
 import http from '../http';
+import url from '../url'
 
 export default class datasets {
 
@@ -32,17 +33,20 @@ export default class datasets {
              });
     }
 
-    static getLatestVersion(datasetID, editionID) {
-        const editionURL = `/dataset/datasets/${datasetID}/editions/${editionID}`;
+    static getLatestVersion(datasetID) {
+        const datasetURL = `/dataset/datasets/${datasetID}`;
 
         return new Promise(async (resolve, reject) => {
-            const edition = await http.get(editionURL).catch(error => reject(error));
-            if (edition && edition.current && edition.current.links.latest_version) {
-                const latestVersion = await http.get(`${editionURL}/versions/${edition.current.links.latest_version.id}`).catch(error => reject(error));
-                resolve(latestVersion);
+            const dataset = await http.get(datasetURL).catch(error => reject(error));
+            
+            if (!dataset || !dataset.current || !dataset.current.links.latest_version) {
+                resolve();
                 return;
             }
-            return;
+
+            const latestVersionURL = url.resolve(dataset.current.links.latest_version.href);
+            const latestVersion = await http.get(`/dataset${latestVersionURL}`).catch(error => reject(error));
+            resolve(latestVersion);
         });
     }
 

--- a/src/app/utilities/api-clients/datasets.js
+++ b/src/app/utilities/api-clients/datasets.js
@@ -32,11 +32,30 @@ export default class datasets {
              });
     }
 
+    static getLatestVersion(datasetID, editionID) {
+        const editionURL = `/dataset/datasets/${datasetID}/editions/${editionID}`;
+
+        return new Promise(async (resolve, reject) => {
+            const edition = await http.get(editionURL).catch(error => reject(error));
+            if (edition && edition.current && edition.current.links.latest_version) {
+                const latestVersion = await http.get(`${editionURL}/versions/${edition.current.links.latest_version.id}`).catch(error => reject(error));
+                resolve(latestVersion);
+                return;
+            }
+            return;
+        });
+    }
+
     static getVersionDimensions(datasetID, edition, version) {
         return http.get(`/dataset/datasets/${datasetID}/editions/${edition}/versions/${version}/dimensions`)
              .then(response => {
                  return response;
              });
+    }
+
+    static updateInstanceDimensions(instanceID, dimensions) {
+        const body = {dimensions};
+        return http.put(`/instances/${instanceID}`, body);
     }
 
     static updateDimensionLabelAndDescription(instanceID, dimension, name, description) {

--- a/src/app/views/datasets/metadata/VersionMetadata.jsx
+++ b/src/app/views/datasets/metadata/VersionMetadata.jsx
@@ -114,6 +114,7 @@ export class VersionMetadata extends Component {
         this.handleSaveAndMarkAsReviewed = this.handleSaveAndMarkAsReviewed.bind(this);
         this.handleRelatedContentCancel = this.handleRelatedContentCancel.bind(this);
         this.handleBackButton = this.handleBackButton.bind(this);
+        this.populateDimensionInputs = this.populateDimensionInputs.bind(this);
     }
 
     componentWillMount() {
@@ -1033,7 +1034,7 @@ export class VersionMetadata extends Component {
     render() {
         return (
             <div className="grid grid--justify-center">
-                <div className="grid__col-4">
+                <div className="grid__col-xs-10 grid__col-md-6 grid__col-lg-4">
                     <div className="margin-top--2">
                         &#9664; <button type="button" className="btn btn--link" onClick={this.handleBackButton}>Back</button>
                     </div>
@@ -1072,7 +1073,10 @@ export class VersionMetadata extends Component {
                                     disabled={this.state.isReadOnly || this.state.isSavingData}
                               />
                             </div>
-                            <h2> In this dataset </h2>
+                            <div className="grid grid--justify-space-between">
+                                <h2 className="inline-block"> In this dataset </h2>
+                                <div><button onClick={this.populateDimensionInputs} className="btn btn--primary margin-left--1" type="button">Fill from latest version</button></div>
+                            </div>
                             {this.mapDimensionsToInputs(this.state.dimensions)}
                             <div className="margin-bottom--1">
                                 <h2 className="margin-top--2 margin-bottom--1">What's changed</h2>

--- a/src/app/views/datasets/metadata/VersionMetadata.jsx
+++ b/src/app/views/datasets/metadata/VersionMetadata.jsx
@@ -82,6 +82,7 @@ export class VersionMetadata extends Component {
             isSavingData: false,
             isReadOnly: false,
             isFetchingCollectionData: false,
+            isFetchingDimensionsData: false,
             isInstance: null,
             hasChanges: false,
             edition: null,
@@ -173,7 +174,7 @@ export class VersionMetadata extends Component {
                     dimensions: this.props.instance.dimensions,
                     edition: this.props.instance.edition,
                 });
-                this.populateDimensionInputs(this.props.instance.edition);
+                this.populateDimensionInputs();
             }
 
             if (this.props.params.version) {
@@ -290,20 +291,24 @@ export class VersionMetadata extends Component {
         action();
     }
 
-    populateDimensionInputs(edition) {
-        this.setState({isFetchingData: true});
-        datasets.getLatestVersion(this.props.params.datasetID, edition).then(latestVersion => {
+    populateDimensionInputs() {
+        this.setState({isFetchingDimensionsData: true});
+        datasets.getLatestVersion(this.props.params.datasetID).then(latestVersion => {
+            if (!latestVersion) {
+                this.setState({isFetchingDimensionsData: false});
+                return;
+            }
+
             this.setState({
                 dimensions: latestVersion.dimensions.map(dimension => ({
                     ...dimension,
                     hasChanged: true
                 })),
-                isFetchingData: false
+                isFetchingDimensionsData: false
             });
         }).catch(error => {
             console.error(error);
-            // handle error
-            this.setState({isFetchingData: false});
+            this.setState({isFetchingDimensionsData: false});
         });
     }
 
@@ -628,7 +633,7 @@ export class VersionMetadata extends Component {
                     name="dimension-name"
                     label="Dimension title"
                     onChange={this.handleInputChange}
-                    disabled={this.state.isReadOnly || this.state.isSavingData}
+                    disabled={this.state.isReadOnly || this.state.isSavingData || this.state.isFetchingDimensionsData}
                 />
                 <Input
                     value={dimension.description}                  
@@ -637,7 +642,7 @@ export class VersionMetadata extends Component {
                     name="dimension-description"
                     label="Learn more (optional)"
                     onChange={this.handleInputChange}
-                    disabled={this.state.isReadOnly || this.state.isSavingData}
+                    disabled={this.state.isReadOnly || this.state.isSavingData || this.state.isFetchingDimensionsData}
                 />
             </div>
             )

--- a/src/app/views/datasets/metadata/VersionMetadata.jsx
+++ b/src/app/views/datasets/metadata/VersionMetadata.jsx
@@ -475,6 +475,11 @@ export class VersionMetadata extends Component {
     }
 
     updateDimensions(instanceID) {
+        const dimensionsHaveUpdated = this.state.dimensions.some(dimension => dimension.hasChanged);
+        if (!dimensionsHaveUpdated) {
+            return Promise.resolve();
+        }
+
         return datasets.updateInstanceDimensions(instanceID, this.state.dimensions)
             .catch(error => {
                 this.handleRequestError(`save updates to dimensions`, error.status);

--- a/src/app/views/datasets/metadata/VersionMetadata.jsx
+++ b/src/app/views/datasets/metadata/VersionMetadata.jsx
@@ -309,8 +309,10 @@ export class VersionMetadata extends Component {
                 isFetchingDimensionsData: false
             });
         }).catch(error => {
-            console.error(error);
             this.setState({isFetchingDimensionsData: false});
+            this.handleRequestError("auto-populate the dimension metadata", error.status);
+            console.error("Error getting latest published version to auto-populate dimensions inputs", error);
+            log.add(eventTypes.unexpectedRuntimeError, {message: `Error getting latest published version to auto-populate dimensions inputs. Error: ${JSON.stringify(error)}`});
         });
     }
 

--- a/src/app/views/datasets/metadata/__snapshots__/VersionMetadata.test.js.snap
+++ b/src/app/views/datasets/metadata/__snapshots__/VersionMetadata.test.js.snap
@@ -5,7 +5,7 @@ exports[`Dataset version metadata page matches stored snapshot 1`] = `
   className="grid grid--justify-center"
 >
   <div
-    className="grid__col-4"
+    className="grid__col-xs-10 grid__col-md-6 grid__col-lg-4"
   >
     <div
       className="margin-top--2"


### PR DESCRIPTION
### What

On load of the version metadata page, if the user is looking at an instance, the dimension label and description inputs are autopopulated from that latest published version.

There's also the options to fill them at any point from the latest published version (by clicking a button next to the form)

### How to review

1) Have a published dataset version with some description/s and labels for the dimensions.
2) Uplolad a new version of that dataset - when first opening it (as an instance) the dimension inputs should been autopopulated with the descriptions and labels from the published version.
3) For a version or an instance the 'Fill from latest version' wipes the input values and replaces them with those from the published version. These changes aren't saved until the user hits 'Save' though.

### Who can review

Anyone but me.
