### PR TITLE
Tell user which collection a URI is being edited in

### DIFF
--- a/src/legacy/js/functions/_createWorkspace.js
+++ b/src/legacy/js/functions/_createWorkspace.js
@@ -187,7 +187,22 @@ function createWorkspace(path, collectionId, menu, collectionData, stopEventList
             Florence.globalVars.pagePath = dest;
             $navItem.removeClass('selected');
             $("#edit").addClass('selected');
-            loadPageDataIntoEditor(Florence.globalVars.pagePath, collectionId);
+            $.ajax({
+                url: "/zebedee/checkcollectionsforuri?uri=" + dest,
+                type: 'GET',
+                contentType: 'application/json',
+                cache: false,
+                success: function (response, textStatus, xhr) {
+                    if (xhr.status == 204) {
+                        loadPageDataIntoEditor(Florence.globalVars.pagePath, collectionId);
+                        return;
+                    }
+                    sweetAlert("Cannot edit this page", "This page is already in another collection: " + response, "error");
+                },
+                error: function (response) {
+                    handleApiError(response);
+                }
+            });
         });
 
         $('.workspace-menu').on('click', '.js-browse__menu', function() {

--- a/src/legacy/js/functions/_handleApiError.js
+++ b/src/legacy/js/functions/_handleApiError.js
@@ -18,6 +18,16 @@ function handleApiError(response) {
 
         if (response.responseJSON) {
             message = response.responseJSON.message;
+            
+            if (response.responseJSON.data) {
+                let kvs = [];
+                for (let k in response.responseJSON.data) {
+                    kvs.push(k + ": " + response.responseJSON.data[k]);
+                }
+                if(kvs.length > 0) {
+                    message += "\n\n" + kvs.join("\n");
+                }
+            }
         }
 
         console.log(message);

--- a/src/legacy/js/functions/_saveContent.js
+++ b/src/legacy/js/functions/_saveContent.js
@@ -12,12 +12,7 @@ function saveContent(collectionId, uri, data, collectionData) {
             createWorkspace(uri, collectionId, 'edit', collectionData);
         },
         error = function (response) {
-            if (response.status === 409) {
-                sweetAlert("Cannot create this page", "It already exists.");
-            }
-            else {
-                handleApiError(response);
-            }
+            handleApiError(response);
         }
     );
 }


### PR DESCRIPTION
### What

Tell user which collection a URI is being edited in: 

* Use API response for generic saveContent errors
* Update handleApiError to display the `data` block returned by zebedee
* Check if file is in another collection when clicking the Edit button

### How to review

* Use the `feature/find-collection-by-uri` branch of zebedee
* Edit URI in one collection and save, edit the same URI in another collection and you should get an error telling you it's in the first collection
* Create new URI in one collection, create the same URI again in another collection, you should get an error telling you it's in the first collection

### Who can review

Anyone except @ian-kent