### PR TITLE
feature/job-restart-stanza

### DIFF
--- a/florence.nomad
+++ b/florence.nomad
@@ -20,6 +20,13 @@ job "florence" {
       value     = "publishing.*"
     }
 
+    restart {
+      attempts = 3
+      delay    = "15s"
+      interval = "1m"
+      mode     = "delay"
+    }
+
     task "florence" {
       driver = "docker"
 


### PR DESCRIPTION
### What

Add restart stanza to job plan. Once upgraded to Nomad 0.8.4 we can control how our jobs our restarted.

### How to review

Check the plan is valid with Nomad 0.8+ and looks OK.

### Who can review

Not me.
