### PR TITLE
removed Feature/version-reloading

### DIFF
--- a/src/legacy/js/functions/_setupFlorence.js
+++ b/src/legacy/js/functions/_setupFlorence.js
@@ -371,27 +371,5 @@ function setupFlorence() {
             this.collection = collectionTemp
         }
     }
-
-    // Check running version versus latest and notify user if they don't match
-    var runningVersion,
-        userWarned = false;
-    function checkVersion() {
-        return fetch('/florence/dist/legacy-assets/version.json')
-            .then(function(response) {
-                return response.json();
-            })
-            .then(function(responseJson) {
-                return responseJson;
-            })
-            .catch(function(err) {
-                console.log("Error getting latest Florence version: ", err);
-                return err
-            });
-    }
-
-    checkVersion().then(function(response) {
-        runningVersion = response;
-    });
-
 }
 

--- a/src/legacy/js/functions/_setupFlorence.js
+++ b/src/legacy/js/functions/_setupFlorence.js
@@ -393,36 +393,5 @@ function setupFlorence() {
         runningVersion = response;
     });
 
-    setInterval(function() {
-        // Get the latest version and alert user if it differs from version stored on load (but only if the user hasn't been warned already, so they don't get spammed after being warned already)
-        if (!userWarned) {
-            checkVersion().then(function (response) {
-                if (response instanceof TypeError) {
-                    // FIXME do something more useful with this
-                    return
-                }
-                if (response.major !== runningVersion.major || response.minor !== runningVersion.minor || response.build !== runningVersion.build) {
-                    console.log("New version of Florence available: ", response.major + "." + response.minor + "." + response.build);
-                    swal({
-                        title: "New version of Florence available",
-                        type: "info",
-                        showCancelButton: true,
-                        closeOnCancel: false,
-                        closeOnConfirm: false,
-                        confirmButtonText: "Refresh Florence",
-                        cancelButtonText: "Don't refresh"
-                    }, function (isConfirm) {
-                        userWarned = true;
-                        if (isConfirm) {
-                            location.reload();
-                        } else {
-                            swal("Warning", "Florence could be unstable without the latest version", "warning")
-                        }
-                    });
-                    runningVersion = response;
-                }
-            });
-        }
-    }, 10000)
 }
 


### PR DESCRIPTION
### What

Removed prompt for user to reload Florence when a new version has been deployed and they are on an older version
https://trello.com/c/oOILiXNd/3257-remove-new-version-of-florence-available-fuctionality-2
original Feature/version-reloading
https://github.com/ONSdigital/florence/pull/15

### How to review

??? (no prompt in Florence)

### Who can review

jon - crispin
