### PR TITLE
Cancel delete updates collection state

### DIFF
--- a/src/app/views/collections/details/CollectionDetailsController.jsx
+++ b/src/app/views/collections/details/CollectionDetailsController.jsx
@@ -271,6 +271,7 @@ export class CollectionDetailsController extends Component {
                     return deletedPage.root.uri !== uri;
                 })
             };
+            updatedActiveCollection.canBeDeleted = collectionMapper.collectionCanBeDeleted(updatedActiveCollection)
             this.props.dispatch(updateActiveCollection(updatedActiveCollection));
         }).catch(error => {
             this.setState({isCancellingDelete: {

--- a/src/app/views/collections/details/CollectionDetailsController.jsx
+++ b/src/app/views/collections/details/CollectionDetailsController.jsx
@@ -271,6 +271,7 @@ export class CollectionDetailsController extends Component {
                     return deletedPage.root.uri !== uri;
                 })
             };
+            updatedActiveCollection.canBeApproved = collectionMapper.collectionCanBeApproved(updatedActiveCollection);
             updatedActiveCollection.canBeDeleted = collectionMapper.collectionCanBeDeleted(updatedActiveCollection)
             this.props.dispatch(updateActiveCollection(updatedActiveCollection));
         }).catch(error => {


### PR DESCRIPTION
### What

https://trello.com/c/pEtUUUwQ/3277-cancel-delete-doesnt-update-collection-deleteable-state
added "updatedActiveCollection.canBeDeleted = collectionMapper.collectionCanBeDeleted(updatedActiveCollection)" to CollectionDetailsController

### How to review

Actions to recreate bug:

Create a collection (doesn't matter about it's name, publish type etc)
Click 'Create/edit page'
In browse tree of pages select a page (possibly something small like an 'About us' page)
Click in hamburger icon and select 'Delete'. The page should show as greyed out and crossed through. You've now selected this page to be deleted from the website.
Return to your collection in the collections screen. You should see the page you've deleted listed in the collection.
Note that at the bottom of the collection it should only have the 'Close' button displaying.
Click on the page and click 'Cancel delete'.
There should be a 'Delete' button displaying at the bottom of the collection, next to 'Close' but there isn't.

### Who can review

jon - crispin
