### PR TITLE
Trim collection name whitespace on blur or submit

### DIFF
--- a/src/app/components/Input.jsx
+++ b/src/app/components/Input.jsx
@@ -6,6 +6,7 @@ const propTypes = {
     label: PropTypes.string,
     type: PropTypes.string,
     onChange: PropTypes.func,
+    onBlur: PropTypes.func,
     error: PropTypes.string,
     disabled: PropTypes.bool,
     isFocused: PropTypes.bool,
@@ -62,6 +63,7 @@ export default class Input extends Component {
                         name={this.props.id}
                         disabled={this.props.disabled}
                         onChange={this.props.onChange}
+                        onBlur={this.props.onBlur}
                         autoFocus={this.props.isFocused}
                         placeholder={this.props.inline ? this.props.label : ""}
                         accept={this.props.accept}
@@ -76,6 +78,7 @@ export default class Input extends Component {
                         name={this.props.id}
                         disabled={this.props.disabled}
                         onChange={this.props.onChange}
+                        onBlur={this.props.onBlur}
                         autoFocus={this.props.isFocused}
                         placeholder={this.props.inline ? this.props.label : ""}
                     >

--- a/src/app/views/collections/create/CollectionCreate.jsx
+++ b/src/app/views/collections/create/CollectionCreate.jsx
@@ -21,6 +21,7 @@ const propTypes = {
         scheduleType: PropTypes.string.isRequired,
     }).isRequired,
     handleCollectionNameChange: PropTypes.func.isRequired,
+    handleCollectionNameBlur: PropTypes.func,
     handleTeamSelection: PropTypes.func.isRequired,
     handleRemoveTeam: PropTypes.func.isRequired,
     handleCollectionTypeChange: PropTypes.func.isRequired,
@@ -127,6 +128,7 @@ class CollectionCreate extends Component {
                         error={this.props.newCollectionDetails.name.errorMsg}
                         value={this.props.newCollectionDetails.name.value}
                         onChange={this.props.handleCollectionNameChange}
+                        onBlur={this.props.handleCollectionNameBlur}
                     />
 
                     <Select

--- a/src/app/views/collections/create/CollectionCreateController.jsx
+++ b/src/app/views/collections/create/CollectionCreateController.jsx
@@ -61,6 +61,7 @@ export class CollectionCreateController extends Component {
         this.blankNewCollectionDetails = this.state.newCollectionDetails;
 
         this.handleCollectionNameChange = this.handleCollectionNameChange.bind(this);
+        this.handleCollectionNameBlur = this.handleCollectionNameBlur.bind(this);
         this.handleTeamSelection = this.handleTeamSelection.bind(this);
         this.handleRemoveTeam = this.handleRemoveTeam.bind(this);
         this.handleCollectionTypeChange = this.handleCollectionTypeChange.bind(this);
@@ -149,6 +150,17 @@ export class CollectionCreateController extends Component {
             name: collectionName
         };
         this.setState({newCollectionDetails: newCollectionDetails});
+    }
+
+    handleCollectionNameBlur(event) {
+        const newCollectionDetails = {
+            ...this.state.newCollectionDetails,
+            name: {
+                ...this.state.newCollectionDetails.name,
+                value: event.target.value.trim()
+            }
+        }
+        this.setState({newCollectionDetails});
     }
 
     handleTeamSelection(event) {
@@ -299,15 +311,28 @@ export class CollectionCreateController extends Component {
 
     handleSubmit(event) {
         event.preventDefault();
-        this.setState({isSubmitting: true});
+
+        // Trim the name so that it never has extra white space around it (since we'll do this on successful submit anyway)
+        // and update state so that this change renders even if there's a validation error
+        const trimmedCollectionName = this.state.newCollectionDetails.name.value.trim();
+        let newCollectionDetails = {
+            ...this.state.newCollectionDetails,
+            name: {
+                ...this.state.newCollectionDetails.name,
+                value: this.state.newCollectionDetails.name.value.trim()
+            }
+        };
+        this.setState({
+            newCollectionDetails,
+            isSubmitting: true
+        });
 
         let hasError = false;
-        let newCollectionDetails = this.state.newCollectionDetails;
 
-        const validatedName = collectionValidation.name(this.state.newCollectionDetails.name.value);
+        const validatedName = collectionValidation.name(trimmedCollectionName);
         if (!validatedName.isValid) {
             const collectionName = {
-                value: this.state.newCollectionDetails.name.value,
+                value: trimmedCollectionName,
                 errorMsg: validatedName.errorMsg
             };
 
@@ -462,6 +487,7 @@ export class CollectionCreateController extends Component {
                 <CollectionCreate 
                     newCollectionDetails={this.state.newCollectionDetails}
                     handleCollectionNameChange={this.handleCollectionNameChange}
+                    handleCollectionNameBlur={this.handleCollectionNameBlur}
                     handleTeamSelection={this.handleTeamSelection}
                     handleRemoveTeam={this.handleRemoveTeam}
                     handleCollectionTypeChange={this.handleCollectionTypeChange}

--- a/src/app/views/collections/edit/CollectionEdit.jsx
+++ b/src/app/views/collections/edit/CollectionEdit.jsx
@@ -14,6 +14,7 @@ const propTypes = {
     nameErrorMsg: PropTypes.string,
     onCancel: PropTypes.func.isRequired,
     onNameChange: PropTypes.func.isRequired,
+    onNameBlur: PropTypes.func.isRequired,
     onRemoveTeam: PropTypes.func.isRequired,
     onTeamSelect: PropTypes.func.isRequired,
     onPublishTypeChange: PropTypes.func.isRequired,
@@ -54,6 +55,7 @@ class CollectionEdit extends Component {
         this.handleTeamSelection = this.handleTeamSelection.bind(this);
         this.handleTeamRemove = this.handleTeamRemove.bind(this);
         this.handleNameChange = this.handleNameChange.bind(this);
+        this.handleNameBlur = this.handleNameBlur.bind(this);
         this.handlePublishTypeChange = this.handlePublishTypeChange.bind(this);
         this.handlePublishDateChange = this.handlePublishDateChange.bind(this);
         this.handlePublishTimeChange = this.handlePublishTimeChange.bind(this);
@@ -70,6 +72,10 @@ class CollectionEdit extends Component {
 
     handleNameChange(event) {
         this.props.onNameChange(event.target.value);
+    }
+    
+    handleNameBlur(event) {
+        this.props.onNameBlur(event.target.value);
     }
 
     handlePublishTypeChange(event) {
@@ -136,6 +142,7 @@ class CollectionEdit extends Component {
                                 value={this.props.name}
                                 error={this.props.nameErrorMsg}
                                 onChange={this.handleNameChange}
+                                onBlur={this.handleNameBlur}
                             />
                             <Select
                                 id="collection-edit-teams"

--- a/src/app/views/collections/edit/CollectionEditController.jsx
+++ b/src/app/views/collections/edit/CollectionEditController.jsx
@@ -64,6 +64,7 @@ export class CollectionEditController extends Component {
         this.handlePublishDateChange = this.handlePublishDateChange.bind(this);
         this.handlePublishTimeChange = this.handlePublishTimeChange.bind(this);
         this.handleNameChange = this.handleNameChange.bind(this);
+        this.handleNameBlur = this.handleNameBlur.bind(this);
         this.handleAddTeam = this.handleAddTeam.bind(this);
         this.handleRemoveTeam = this.handleRemoveTeam.bind(this);
     }
@@ -128,6 +129,16 @@ export class CollectionEditController extends Component {
             name: {
                 value: name,
                 errorMsg: ""
+            }
+        });
+    }
+    
+    handleNameBlur(name) {
+        console.log({name});
+        this.setState({
+            name: {
+                ...this.state.name,
+                value: name.trim()
             }
         });
     }
@@ -230,14 +241,24 @@ export class CollectionEditController extends Component {
     handleSave() {
         let hasError = false;
         
-        const validatedName = collectionValidation.name(this.state.name.value);
+        const trimmedName = this.state.name.value.trim();
+
+        // Update state with trimmed name, so that we never show a name with whitespace longer than we have to
+        // i.e. the user has completed their typing by saving, confirming that they have finished typing the name
+        this.setState({name: {
+            ...this.state.name,
+            value: trimmedName
+        }});
+
+
+        const validatedName = collectionValidation.name(trimmedName);
         if (!validatedName.isValid) {
-            this.setState(state => ({
+            this.setState({
                 name: {
-                    ...state.name,
+                    value: trimmedName,
                     errorMsg: validatedName.errorMsg
                 }
-            }));
+            });
             hasError = true;
         }
 
@@ -419,6 +440,7 @@ export class CollectionEditController extends Component {
                 onCancel={this.handleCancel}
                 onSave={this.handleSave}
                 onNameChange={this.handleNameChange}
+                onNameBlur={this.handleNameBlur}
                 onTeamSelect={this.handleAddTeam}
                 onRemoveTeam={this.handleRemoveTeam}
                 onPublishTypeChange={this.handlePublishTypeChange}


### PR DESCRIPTION
### What

When creating or editing a collection any whitespace is trimmed from the beginning or end of the input on loss of focus from the input or on save of the form (by hitting `Enter`).

### How to review

Create new collection / edit an existing collection and check that all the inputs that need to trim whitespace do so at a convenient time for the user.

### Who can review

@jondewijones 
