### PR TITLE
Restrict deployment to non-mount instances

### DIFF
--- a/florence.nomad
+++ b/florence.nomad
@@ -17,7 +17,7 @@ job "florence" {
     constraint {
       attribute = "${node.class}"
       operator  = "regexp"
-      value     = "publishing.*"
+      value     = "publishing"
     }
 
     restart {


### PR DESCRIPTION
### What

Restrict deployment to only non-mount instances to ensure the special mount instances are kept clear for the apps that require them.

### How to review

Ensure the node pattern no longer matches the mount nodes.

### Who can review

Anyone but me.