### PR TITLE
Remove whitespace trimming on old Florence

### DIFF
--- a/dist/legacy-assets/js/main.js
+++ b/dist/legacy-assets/js/main.js
@@ -50755,29 +50755,32 @@ function setShortcuts(field, callback) {
         }
     }
 
-    function trimInputWhitespace($input) {
-        // We don't trim on the file input type because it's value
-        // can't be set for security reasons, which it causes a runtime error
-        if ($input.type === "file") {
-            return;
-        }
+    // FIXME this break the chart builder data input, if it starts with whitespace (which it often needs to for formating)
+    // I've commented the function out for now so a release can go live, but we should fix this properly.
+    
+    // function trimInputWhitespace($input) {
+    //     // We don't trim on the file input type because it's value
+    //     // can't be set for security reasons, which it causes a runtime error
+    //     if ($input.type === "file") {
+    //         return;
+    //     }
 
-        var trimmed = $input.val().trim();
-        $input.val(trimmed);
-        $input.change();
-        $input.trigger("input");
-    }
+    //     var trimmed = $input.val().trim();
+    //     $input.val(trimmed);
+    //     $input.change();
+    //     $input.trigger("input");
+    // }
 
-    $(document).on('blur', 'input, textarea', function() {
-        trimInputWhitespace($(this));
-    });
+    // $(document).on('blur', 'input, textarea', function() {
+    //     trimInputWhitespace($(this));
+    // });
 
-    $(document).on('keypress', 'input, textarea', function(event) {
-        if (event.which !== 13) {
-            return;
-        }
-        trimInputWhitespace($(this));
-    });
+    // $(document).on('keypress', 'input, textarea', function(event) {
+    //     if (event.which !== 13) {
+    //         return;
+    //     }
+    //     trimInputWhitespace($(this));
+    // });
 }
 
 function releaseEditor(collectionId, data) {

--- a/src/legacy/js/functions/_setupFlorence.js
+++ b/src/legacy/js/functions/_setupFlorence.js
@@ -369,28 +369,31 @@ function setupFlorence() {
         }
     }
 
-    function trimInputWhitespace($input) {
-        // We don't trim on the file input type because it's value
-        // can't be set for security reasons, which it causes a runtime error
-        if ($input.type === "file") {
-            return;
-        }
+    // FIXME this break the chart builder data input, if it starts with whitespace (which it often needs to for formating)
+    // I've commented the function out for now so a release can go live, but we should fix this properly.
+    
+    // function trimInputWhitespace($input) {
+    //     // We don't trim on the file input type because it's value
+    //     // can't be set for security reasons, which it causes a runtime error
+    //     if ($input.type === "file") {
+    //         return;
+    //     }
 
-        var trimmed = $input.val().trim();
-        $input.val(trimmed);
-        $input.change();
-        $input.trigger("input");
-    }
+    //     var trimmed = $input.val().trim();
+    //     $input.val(trimmed);
+    //     $input.change();
+    //     $input.trigger("input");
+    // }
 
-    $(document).on('blur', 'input, textarea', function() {
-        trimInputWhitespace($(this));
-    });
+    // $(document).on('blur', 'input, textarea', function() {
+    //     trimInputWhitespace($(this));
+    // });
 
-    $(document).on('keypress', 'input, textarea', function(event) {
-        if (event.which !== 13) {
-            return;
-        }
-        trimInputWhitespace($(this));
-    });
+    // $(document).on('keypress', 'input, textarea', function(event) {
+    //     if (event.which !== 13) {
+    //         return;
+    //     }
+    //     trimInputWhitespace($(this));
+    // });
 }
 


### PR DESCRIPTION
### What

Remove whitespace trimming on old Florence to temporarily fix chart builder input. Currently chart builder will break if the first heading is white space, which is very common for charts because quite often it's only from the second column onwards that chart have a heading.

I have just disabled the whitespace trimming function in old Florence because this issue is stopping a chart being built for release tomorrow.

### How to review

Check that code is commented out correctly.

### Who can review

Anyone.
