### PR TITLE
Fix for updating both versionMetadata and datasetMetadata in same save

### DIFF
--- a/src/app/views/datasets-new/edit-metadata/DatasetMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata/DatasetMetadataController.jsx
@@ -510,7 +510,7 @@ export class DatasetMetadataController extends Component {
             fieldName === "nextReleaseDate") {
                 return true;
         }
-        return false;
+        return this.state.datasetMetadataHasChanges;
     }
 
     versionMetadataHasChanges = (fieldName) => {
@@ -520,7 +520,7 @@ export class DatasetMetadataController extends Component {
             fieldName === "latestChanges") {
             return true;
         }
-        return false;
+        return this.state.versionMetadataHasChanges;
     }
 
     handleBackButton = () => {
@@ -822,4 +822,5 @@ export class DatasetMetadataController extends Component {
 DatasetMetadataController.propTypes = propTypes;
 
 export default DatasetMetadataController;
+
 


### PR DESCRIPTION
### What

If the user attempted to edit version information and dataset information in the same save then only the last changes would be saved.

### How to review

1. Checkout this branch 
2. Change either version meta information:
- releaseDate
- notices
- usageNotes
- latestChanges

3. Change the dataset meta information
- title
- summary
- keywords
- nationalStatistics
- license
- contactName
- contactEmail
- contactTelephone
- relatedDatasets
- relatedPublications
- relatedMethodologies
- relatedFrequency
- unitOfMeasure
- qmi
- nextReleaseDate
Or swap step 2 and 3 around, both work.
4. Click save
5. Reload the page
6. One should see all their changes, note previously only the dataset or version data would have changed - whichever was last updated.

### Who can review

Anyone except me
