### PR TITLE
Hot fix for not being able to add external links to static_pages

### DIFF
--- a/dist/legacy-assets/js/main.js
+++ b/dist/legacy-assets/js/main.js
@@ -42499,7 +42499,8 @@ function initialiseLinks(collectionId, data, templateData, field, idField) {
             if (!data[field]) {
                 data[field] = [];
             }
-            var modal = templates.linkExternalModal;
+            var linkData = {showTitleField: true};
+            var modal = templates.linkExternalModal(linkData);
             var uri, title;
             $('.modal').remove();
             $('.workspace-menu').append(modal);

--- a/src/legacy/js/functions/_editIntLinks.js
+++ b/src/legacy/js/functions/_editIntLinks.js
@@ -199,7 +199,8 @@ function initialiseLinks(collectionId, data, templateData, field, idField) {
             if (!data[field]) {
                 data[field] = [];
             }
-            var modal = templates.linkExternalModal;
+            var linkData = {showTitleField: true};
+            var modal = templates.linkExternalModal(linkData);
             var uri, title;
             $('.modal').remove();
             $('.workspace-menu').append(modal);

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -6878,7 +6878,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6948,7 +6949,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "combined-stream": {
           "version": "1.0.5",
@@ -6966,7 +6968,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7191,6 +7194,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7235,6 +7239,7 @@
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7340,7 +7345,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "oauth-sign": {
           "version": "0.8.2",
@@ -7564,6 +7570,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7582,6 +7589,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7671,7 +7679,8 @@
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
### What

Static pages modal for external links is now passed in a title: true option. A previous update made the title appear only if it was told to. (Rather than at all times) this was given to most pages on BAU but one, static_page was missed. This has now been added
### How to review

Create  a generic static page under about us section on florence. Add related link, select external link. Ensure title field appears, populate modal then save.
If no errors then this is a success.
### Who can review

Anyone except me