### PR TITLE
Added filterable publications to published report screen

### DIFF
--- a/dist/legacy-assets/js/main.js
+++ b/dist/legacy-assets/js/main.js
@@ -55782,7 +55782,40 @@ function viewReleaseSelector() {
 
 function viewReportDetails(collection, isPublished, $this) {
 
-    var details, reportDetails, published, events;
+    // Enum type of filterable data
+    const filterableReportType = {
+        'dataset': 0,
+        'datasetVersion': 1
+    };
+
+    // Retrieve all information for a specific type of filterable data report
+    function getFilterableReportData(filterableDataTypeToUse, fullDatasetCollectionData) {
+        let listOfReportData = [];
+
+        // Retrieve all mandatory information fields for filterable data report
+        function getMandatoryFilterableReportInformation(datasetCollectionItem) {
+            const url = new URL(datasetCollectionItem.uri);
+            return {
+                uri: url.pathname
+            };
+        }
+
+        if (fullDatasetCollectionData != null) {
+            switch (filterableDataTypeToUse) {
+                case filterableReportType.dataset:
+                case filterableReportType.datasetVersion:
+                    fullDatasetCollectionData.forEach((datasetCollectionItem) => {
+                        let singleReportItem = getMandatoryFilterableReportInformation(datasetCollectionItem);
+                        listOfReportData.push(singleReportItem)
+                    });
+                    break;
+            }
+        }
+        return listOfReportData;
+    }
+
+
+    let details;
 
     // get the event details
     $.ajax({
@@ -55790,7 +55823,6 @@ function viewReportDetails(collection, isPublished, $this) {
         type: "get",
         crossDomain: true,
         success: function (events) {
-
             // format eventDate to user readable date
             $(events).each(function (i) {
                 var formattedDate = events[i].eventDetails.date;
@@ -55805,7 +55837,6 @@ function viewReportDetails(collection, isPublished, $this) {
                     type: "GET",
                     crossDomain: true,
                     success: function (collection) {
-
                         var collection = collection[0];
 
                         var date = collection.publishEndDate;
@@ -55816,7 +55847,10 @@ function viewReportDetails(collection, isPublished, $this) {
                             return;
                         }
 
-                        var success = collection.publishResults[collection.publishResults.length - 1];
+                        const success = collection.publishResults[collection.publishResults.length - 1];
+                        const datasets = getFilterableReportData(filterableReportType.dataset, collection.datasets);
+                        const datasetVersions = getFilterableReportData(filterableReportType.datasetVersion, collection.datasetVersions);
+
                         var duration = (function () {
 
                             if (collection.publishStartDate && collection.publishEndDate) {
@@ -55828,7 +55862,6 @@ function viewReportDetails(collection, isPublished, $this) {
                             }
                             return end - start;
                         })();
-
 
                         if (collection.publishStartDate) {
                             var starting = StringUtils.formatIsoFullSec(collection.publishStartDate);
@@ -55848,6 +55881,8 @@ function viewReportDetails(collection, isPublished, $this) {
                             starting: starting,
                             duration: duration,
                             success: success,
+                            datasets: datasets,
+                            datasetVersions: datasetVersions,
                             events: events
                         };
 
@@ -55865,8 +55900,6 @@ function viewReportDetails(collection, isPublished, $this) {
                         handleApiError(response);
                     }
                 });
-
-
 
             } else {
 
@@ -55897,8 +55930,8 @@ function viewReportDetails(collection, isPublished, $this) {
             handleApiError(response);
         }
     });
-
 }
+
 
 function bindTableOrdering() {
     // Bind table ordering functionality to publish times

--- a/dist/legacy-assets/js/templates.js
+++ b/dist/legacy-assets/js/templates.js
@@ -1631,6 +1631,8 @@ templates['reportPublishedDetails'] = template({"1":function(depth0,helpers,part
     + ((stack1 = helpers['if'].call(depth0,(depth0 != null ? depth0.events : depth0),{"name":"if","hash":{},"fn":this.program(9, data, 0),"inverse":this.program(14, data, 0),"data":data})) != null ? stack1 : "")
     + "                </div>\n            </div>\n            <div class=\"accordion js-accordion\">\n                <div class=\"accordion__title js-accordion__title\">\n                    <h3>Publishing times</h3>\n                </div>\n                <div class=\"accordion__content js-accordion__content disable-animation\">\n                    <table class=\"table table--section publish-times-table\">\n                        <thead>\n                        <tr>\n                            <th class=\"file-name\">Path</th>\n                            <th class=\"file-size\">Size (B)</th>\n                            <th class=\"file-duration\">Time (ms)</th>\n                        </tr>\n                        </thead>\n                        <tbody>\n"
     + ((stack1 = helpers.each.call(depth0,((stack1 = ((stack1 = (depth0 != null ? depth0.success : depth0)) != null ? stack1.transaction : stack1)) != null ? stack1.uriInfos : stack1),{"name":"each","hash":{},"fn":this.program(16, data, 0),"inverse":this.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0,(depth0 != null ? depth0.datasets : depth0),{"name":"each","hash":{},"fn":this.program(21, data, 0),"inverse":this.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0,(depth0 != null ? depth0.datasetVersions : depth0),{"name":"each","hash":{},"fn":this.program(21, data, 0),"inverse":this.noop,"data":data})) != null ? stack1 : "")
     + "                        </tbody>\n                    </table>\n                </div>\n            </div>\n        </div>\n";
 },"9":function(depth0,helpers,partials,data) {
     var stack1;
@@ -1685,6 +1687,12 @@ templates['reportPublishedDetails'] = template({"1":function(depth0,helpers,part
     return "\n                            style=\"color: red;\" ";
 },"19":function(depth0,helpers,partials,data) {
     return "\n                            style=\"color: green;\" ";
+},"21":function(depth0,helpers,partials,data) {
+    var helper;
+
+  return "                            <tr>\n                                <td class=\"file-name\">"
+    + this.escapeExpression(((helper = (helper = helpers.uri || (depth0 != null ? depth0.uri : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0,{"name":"uri","hash":{},"data":data}) : helper)))
+    + "</td>\n                            </tr>\n";
 },"compiler":[6,">= 2.0.0-beta.1"],"main":function(depth0,helpers,partials,data) {
     var stack1, helper, alias1=helpers.helperMissing, alias2="function", alias3=this.escapeExpression;
 

--- a/src/legacy/js/functions/_viewReportDetails.js
+++ b/src/legacy/js/functions/_viewReportDetails.js
@@ -8,7 +8,40 @@
 
 function viewReportDetails(collection, isPublished, $this) {
 
-    var details, reportDetails, published, events;
+    // Enum type of filterable data
+    const filterableReportType = {
+        'dataset': 0,
+        'datasetVersion': 1
+    };
+
+    // Retrieve all information for a specific type of filterable data report
+    function getFilterableReportData(filterableDataTypeToUse, fullDatasetCollectionData) {
+        let listOfReportData = [];
+
+        // Retrieve all mandatory information fields for filterable data report
+        function getMandatoryFilterableReportInformation(datasetCollectionItem) {
+            const url = new URL(datasetCollectionItem.uri);
+            return {
+                uri: url.pathname
+            };
+        }
+
+        if (fullDatasetCollectionData != null) {
+            switch (filterableDataTypeToUse) {
+                case filterableReportType.dataset:
+                case filterableReportType.datasetVersion:
+                    fullDatasetCollectionData.forEach((datasetCollectionItem) => {
+                        let singleReportItem = getMandatoryFilterableReportInformation(datasetCollectionItem);
+                        listOfReportData.push(singleReportItem)
+                    });
+                    break;
+            }
+        }
+        return listOfReportData;
+    }
+
+
+    let details;
 
     // get the event details
     $.ajax({
@@ -16,7 +49,6 @@ function viewReportDetails(collection, isPublished, $this) {
         type: "get",
         crossDomain: true,
         success: function (events) {
-
             // format eventDate to user readable date
             $(events).each(function (i) {
                 var formattedDate = events[i].eventDetails.date;
@@ -31,7 +63,6 @@ function viewReportDetails(collection, isPublished, $this) {
                     type: "GET",
                     crossDomain: true,
                     success: function (collection) {
-
                         var collection = collection[0];
 
                         var date = collection.publishEndDate;
@@ -42,7 +73,10 @@ function viewReportDetails(collection, isPublished, $this) {
                             return;
                         }
 
-                        var success = collection.publishResults[collection.publishResults.length - 1];
+                        const success = collection.publishResults[collection.publishResults.length - 1];
+                        const datasets = getFilterableReportData(filterableReportType.dataset, collection.datasets);
+                        const datasetVersions = getFilterableReportData(filterableReportType.datasetVersion, collection.datasetVersions);
+
                         var duration = (function () {
 
                             if (collection.publishStartDate && collection.publishEndDate) {
@@ -54,7 +88,6 @@ function viewReportDetails(collection, isPublished, $this) {
                             }
                             return end - start;
                         })();
-
 
                         if (collection.publishStartDate) {
                             var starting = StringUtils.formatIsoFullSec(collection.publishStartDate);
@@ -74,6 +107,8 @@ function viewReportDetails(collection, isPublished, $this) {
                             starting: starting,
                             duration: duration,
                             success: success,
+                            datasets: datasets,
+                            datasetVersions: datasetVersions,
                             events: events
                         };
 
@@ -91,8 +126,6 @@ function viewReportDetails(collection, isPublished, $this) {
                         handleApiError(response);
                     }
                 });
-
-
 
             } else {
 
@@ -123,8 +156,8 @@ function viewReportDetails(collection, isPublished, $this) {
             handleApiError(response);
         }
     });
-
 }
+
 
 function bindTableOrdering() {
     // Bind table ordering functionality to publish times

--- a/src/legacy/templates/reportPublishedDetails.handlebars
+++ b/src/legacy/templates/reportPublishedDetails.handlebars
@@ -114,6 +114,16 @@
                                 <td class="file-duration">{{duration}}</td>
                             </tr>
                         {{/each}}
+                        {{#each datasets}}
+                            <tr>
+                                <td class="file-name">{{uri}}</td>
+                            </tr>
+                        {{/each}}
+                        {{#each datasetVersions}}
+                            <tr>
+                                <td class="file-name">{{uri}}</td>
+                            </tr>
+                        {{/each}}
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
### What

Added filterable publications to published report screen (only path has been added) as seen in the image below:
<img width="1371" alt="Screenshot 2019-09-03 at 13 26 21" src="https://user-images.githubusercontent.com/47502916/64173230-b3c03580-ce4e-11e9-8500-cd92bbe5efad.png">

_Note: Comments have been placed over the PR to explain design decisions_

#### Dependencies:

- Zebedee PR: https://github.com/ONSdigital/zebedee/pull/297

### How to review

1. Checkout this PR and dependencies listed above
2. Check the source code for design issues or errors
3. Publish a dataset (or a few) along with a version of an edition (or a few)
4. Publish some BAU pages
4. Check out the reports screen (Note if testing locally you will need to be running a specific version of dp-compose found here: https://github.com/ONSdigital/dp-compose/tree/feature/postgres-version (Note that you should not be running elastic-search outside of dp-compose or the report page will likely still not work)
5. Ensure all the BAU reports are accurate as before and that the new reports are also accurate

### Who can review

Anyone except me