### PR TITLE
Fix/latest dataset entry

### DIFF
--- a/src/app/views/datasets-new/create/CreateVersionController.jsx
+++ b/src/app/views/datasets-new/create/CreateVersionController.jsx
@@ -165,9 +165,10 @@ export class CreateVersionController extends Component {
         return datasets
             .getCompletedInstancesForDataset(datasetID)
             .then(instances => {
+                const sortedInstancesByLastUpdated = instances.items.sort(this.sortByLastUpdated);
                 this.setState({
                     isFetchingInstances: false,
-                    instances: this.mapInstancesToState(instances.items.reverse())
+                    instances: this.mapInstancesToState(sortedInstancesByLastUpdated)
                 });
             })
             .catch(error => {
@@ -179,7 +180,7 @@ export class CreateVersionController extends Component {
     mapInstancesToState = instances => {
         try {
             const instancesList = instances.map((instance, index) => {
-                const latest = index + 1 === instances.length ? "(latest)" : null;
+                const latest = index === 0 ? "(latest)" : null;
                 return {
                     id: instance.id,
                     value: instance.id,
@@ -187,7 +188,7 @@ export class CreateVersionController extends Component {
                     subLabel: `Upload date: ${date.format(instance.last_updated, "h:MMtt dd mmmm yyyy")}`
                 };
             });
-            return instancesList.reverse();
+            return instancesList;
         } catch (error) {
             const notification = {
                 type: "warning",
@@ -197,6 +198,10 @@ export class CreateVersionController extends Component {
             notifications.add(notification);
             console.error("Error getting mapping instances to state:\n", error);
         }
+    };
+
+    sortByLastUpdated = (a, b) => {
+        return a.last_updated - b.last_updated;
     };
 
     handleSelectedInstanceChange = event => {

--- a/src/app/views/datasets-new/create/CreateVersionController.jsx
+++ b/src/app/views/datasets-new/create/CreateVersionController.jsx
@@ -167,7 +167,7 @@ export class CreateVersionController extends Component {
             .then(instances => {
                 this.setState({
                     isFetchingInstances: false,
-                    instances: this.mapInstancesToState(instances.items)
+                    instances: this.mapInstancesToState(instances.items.reverse())
                 });
             })
             .catch(error => {
@@ -184,7 +184,7 @@ export class CreateVersionController extends Component {
                     id: instance.id,
                     value: instance.id,
                     label: `New data ${latest ? latest : ""}`,
-                    subLabel: `Upload date: ${date.format(instance.last_updated, "h:MMtt dd mmmm yyyy")}`
+                    subLabel: `Upload dates: ${date.format(instance.last_updated, "h:MMtt dd mmmm yyyy")}`
                 };
             });
             return instancesList.reverse();

--- a/src/app/views/datasets-new/create/CreateVersionController.jsx
+++ b/src/app/views/datasets-new/create/CreateVersionController.jsx
@@ -184,7 +184,7 @@ export class CreateVersionController extends Component {
                     id: instance.id,
                     value: instance.id,
                     label: `New data ${latest ? latest : ""}`,
-                    subLabel: `Upload dates: ${date.format(instance.last_updated, "h:MMtt dd mmmm yyyy")}`
+                    subLabel: `Upload date: ${date.format(instance.last_updated, "h:MMtt dd mmmm yyyy")}`
                 };
             });
             return instancesList.reverse();


### PR DESCRIPTION
### What

`dp-dataset-api` was updated to return dataset instances in reverse order. The argument passed to `mapInstancesToState` in the controller has subsequently been reversed to align with this. 

This ultimately means that the "(latest)" text now appears beside the most recent dataset, rather than the oldest, when attaching new data to a collection in Florence

### How to review

- Log into Florence with `ENABLE_DATASET_IMPORT` flag set to `true`
- Create a collection
- Click on "Create/edit CMD dataset page"
- Select a dataset
- Select time-series edition
- Select "Create New Version"
- On this page check that the "(latest)" text appears next to the most recent dataset

### Who can review

Anyone but me
