### PR TITLE
Update labels on Select an Edition page

### DIFF
--- a/src/app/views/datasets-new/editions/DatasetEditionsController.jsx
+++ b/src/app/views/datasets-new/editions/DatasetEditionsController.jsx
@@ -194,10 +194,10 @@ export class DatasetEditionsController extends Component {
             return editions.map(editionItem => {
                 const edition = editionItem.current || editionItem.next || editionItem;
                 return {
-                    title: this.state.dataset.title,
+                    title: edition.edition,
                     id: edition.edition,
                     url: this.props.location.pathname + "/editions/" + edition.edition,
-                    details: ["Edition: " + edition.edition, "Release date: loading..."],
+                    details: ["Release date: loading..."],
                     latestVersion: edition.links.latest_version.id
                 };
             });
@@ -221,7 +221,7 @@ export class DatasetEditionsController extends Component {
         // if we fail to get latest versions display inline error
         if (!allVersions) {
             const mappedEditions = editions.map(edition => {
-                edition.details[1] = "Release date: error retreiving release date";
+                edition.details[0] = "Release date: error retreiving release date";
                 return edition;
             });
             return mappedEditions;
@@ -229,10 +229,10 @@ export class DatasetEditionsController extends Component {
 
         const mappedEditions = editions.map(edition => {
             allVersions.find(version => {
-                if (version.edition !== edition.id) {
+                if (version.edition !== edition.title) {
                     return;
                 }
-                edition.details[1] = `Release date: ${date.format(version.release_date, "dd mmmm yyyy")}`;
+                edition.details[0] = `Release date: ${date.format(version.release_date, "dd mmmm yyyy")}`;
             });
             return edition;
         });

--- a/src/app/views/datasets-new/editions/DatasetEditionsController.test.js
+++ b/src/app/views/datasets-new/editions/DatasetEditionsController.test.js
@@ -82,17 +82,17 @@ const mockedEditions = {
 
 const mockedMappedEditions = [
     {
-        title: "Test Dataset 1",
+        title: "edition-1",
         id: "edition-1",
         url: "florence/collections/12345/datasets/6789/editions/edition-1",
-        details: ["Edition: edition-1", "Release date: loading..."],
+        details: ["Release date: loading..."],
         latestVersion: "3"
     },
     {
-        title: "Test Dataset 1",
+        title: "edition-2",
         id: "edition-2",
         url: "florence/collections/12345/datasets/6789/editions/edition-2",
-        details: ["Edition: edition-2", "Release date: loading..."],
+        details: ["Release date: loading..."],
         latestVersion: "12"
     }
 ];
@@ -177,10 +177,10 @@ describe("Calling getEditions", () => {
         component.setState({ dataset: { title: mockedDataset.current.title } });
         const editions = await component.instance().getEditions(mockedDataset.id);
         expect(editions[0]).toMatchObject({
-            title: mockedDataset.current.title,
+            title: mockedEditions.items[0].current.edition,
             id: mockedEditions.items[0].current.edition,
             url: `${defaultProps.location.pathname}/editions/${mockedEditions.items[0].current.edition}`,
-            details: [`Edition: ${mockedEditions.items[0].current.edition}`, `Release date: loading...`],
+            details: [`Release date: loading...`],
             latestVersion: mockedEditions.items[0].current.links.latest_version.id
         });
     });
@@ -216,10 +216,10 @@ describe("Mapping version release dates to editions method", () => {
     it("returns mapped editions correctly", async () => {
         const mappedEditions = await component.instance().mapVersionReleaseDatesToEditions(mockedDataset.id, mockedMappedEditions);
         expect(mappedEditions[0]).toMatchObject({
-            title: "Test Dataset 1",
+            title: "edition-1",
             id: "edition-1",
             url: "florence/collections/12345/datasets/6789/editions/edition-1",
-            details: ["Edition: edition-1", "Release date: 07 September 2018"],
+            details: ["Release date: 07 September 2018"],
             latestVersion: "3"
         });
     });
@@ -228,10 +228,10 @@ describe("Mapping version release dates to editions method", () => {
         datasets.getLatestVersionForEditions.mockImplementationOnce(() => Promise.reject({ status: 500 }));
         const mappedEditions = await component.instance().mapVersionReleaseDatesToEditions(mockedDataset.id, mockedMappedEditions);
         expect(mappedEditions[0]).toMatchObject({
-            title: "Test Dataset 1",
+            title: "edition-1",
             id: "edition-1",
             url: "florence/collections/12345/datasets/6789/editions/edition-1",
-            details: ["Edition: edition-1", "Release date: error retreiving release date"],
+            details: ["Release date: error retreiving release date"],
             latestVersion: "3"
         });
     });
@@ -244,10 +244,10 @@ test("Mapping dataset to state", () => {
 
 test("Mapping edition to state", () => {
     const expectedMappedEdition = {
-        title: "Dataset Title",
+        title: mockedEditions.items[0].current.edition,
         id: mockedEditions.items[0].current.edition,
         url: defaultProps.location.pathname + "/editions/" + mockedEditions.items[0].current.edition,
-        details: ["Edition: " + mockedEditions.items[0].current.edition, "Release date: loading..."],
+        details: ["Release date: loading..."],
         latestVersion: mockedEditions.items[0].current.links.latest_version.id
     };
     // componenet gets dataset info and stores in state, so set it for this test


### PR DESCRIPTION
### What

Updated the label on the Select an Edition page of the dataset publishing journey:
- Changed the link label text to display the edition name
- Removed "Edition: {edition}" text
- Restructured the editions object array in the DatasetEditionsController so that these changes would be reflected in the list component accordingly

**Before**
![image](https://user-images.githubusercontent.com/23668262/78636454-45d66380-78a0-11ea-9844-b08288f6b14c.png)

**After**
![image](https://user-images.githubusercontent.com/23668262/78636613-9a79de80-78a0-11ea-8db0-ead06f5ec9e0.png)

### How to review

- Ensure code changes are valid
- Ensure no knock-on effect to other parts of Florence based on these changes. I had a look through parts of the Florence UI and ensured test suites pass, but it would be helpful to get eyes on those with more knowledge of the domain

### Who can review

Anyone but me
