### PR TITLE
update static pages label: 'Release date' -> 'Last updated'

### DIFF
--- a/src/legacy/templates/workEditT7.handlebars
+++ b/src/legacy/templates/workEditT7.handlebars
@@ -79,7 +79,7 @@
                             </label>
                         </div>
                         <div class="release-date">
-                            <label for="releaseDate">Release date
+                            <label for="releaseDate">Last updated
                                 <input id="releaseDate" type="text" placeholder="Day month year"
                                        value="{{this.description.releaseDate}}"/>
                             </label>


### PR DESCRIPTION
### What

Update the label in the Florence workspace for static pages from "Release date" to "Last updated".

I was intending to update the markup too, however the jQuery logic for the datepicker is tied to the ID being `releaseDate`, and it looks as though there would be knock-on effects for other aspects of the workspace if the datepicker was refactored. Owing to the time required to rework it, I felt such a group of changes is probably out of scope for this ticket.

### How to review

Check code change makes sense

### Who can review

Anyone but me
