### PR TITLE
Feature/alphabetise recipes list

### DIFF
--- a/src/app/views/uploads/dataset/DatasetUploadsController.jsx
+++ b/src/app/views/uploads/dataset/DatasetUploadsController.jsx
@@ -177,6 +177,7 @@ export class DatasetUploadsController extends Component {
 
     mapDatasetsToState = datasets => {
         try {
+            datasets.sort((a, b) => a.alias.localeCompare(b.alias));
             return datasets.map(dataset => {
                 return {
                     alias: dataset.alias || dataset.id,

--- a/src/app/views/uploads/dataset/DatasetUploadsController.jsx
+++ b/src/app/views/uploads/dataset/DatasetUploadsController.jsx
@@ -177,7 +177,8 @@ export class DatasetUploadsController extends Component {
 
     mapDatasetsToState = datasets => {
         try {
-            datasets.sort((a, b) => a.alias.localeCompare(b.alias));
+            const collator = new Intl.Collator("en", { numeric: true, sensitivity: "base" });
+            datasets.sort((a, b) => collator.compare(a.alias, b.alias));
             return datasets.map(dataset => {
                 return {
                     alias: dataset.alias || dataset.id,


### PR DESCRIPTION
### What

Added a couple of lines to ensure that recipes are sorted alphabetically when on the Upload a dataset page (first page of the upload journey)

The changes make use of `Intl.Collator` - this is a faster implementation than `localeCompare` but also enables language-sensitive string comparisons and better symbol parsing. Bearing in the size of the recipes array and the potential for there to be symbols included in the strings, this seemed like the better method to go with

### How to review

- Check that update makes sense
- Check on your local Florence that the recipes are now in alphabetical order

### Who can review

Anyone but me
