### PR TITLE
add enableHomepagePublishing feature flag and Edit Homepage button in…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,8 @@ type Config struct {
 
 // SharedConfig represents the configuration made available to the client-side application from the server
 type SharedConfig struct {
-	EnableDatasetImport bool `envconfig:"ENABLE_DATASET_IMPORT" json:"enableDatasetImport"`
+	EnableDatasetImport      bool `envconfig:"ENABLE_DATASET_IMPORT" json:"enableDatasetImport"`
+	EnableHomepagePublishing bool `envconfig:"ENABLE_HOMEPAGE_PUBLISHING" json:"enableHomepagePublishing"`
 }
 
 var cfg *Config
@@ -51,7 +52,7 @@ func Get() (*Config, error) {
 		DatasetControllerURL:       "http://localhost:24000",
 		AwsRegion:                  "eu-west-1",
 		UploadBucketName:           "dp-frontend-florence-file-uploads",
-		SharedConfig:               SharedConfig{EnableDatasetImport: false},
+		SharedConfig:               SharedConfig{EnableDatasetImport: false, EnableHomepagePublishing: false},
 		EncryptionDisabled:         false,
 		TableRendererURL:           "http://localhost:23300",
 		VaultAddr:                  "http://localhost:8200",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/ONSdigital/go-ns v0.0.0-20200205115900-a11716f93bad
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/aws/aws-sdk-go v1.29.9 // indirect
+	github.com/davecgh/go-spew v1.1.1
 	github.com/frankban/quicktest v1.9.0 // indirect
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.4 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -202,7 +202,8 @@ func TestMain(t *testing.T) {
 	Convey("Environment variables are set", t, func() {
 		cfg := &config.Config{
 			SharedConfig: config.SharedConfig{
-				EnableDatasetImport: true,
+				EnableDatasetImport:      true,
+				EnableHomepagePublishing: true,
 			},
 		}
 		getAsset = func(path string) ([]byte, error) {
@@ -221,7 +222,7 @@ func TestMain(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":true}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":true,"enableHomepagePublishing":true}`), ShouldBeTrue)
 		})
 
 		Convey("Shared config written into refactored HTML contains the correct config", func() {
@@ -231,7 +232,7 @@ func TestMain(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":true}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":true,"enableHomepagePublishing":true}`), ShouldBeTrue)
 		})
 
 	})
@@ -251,7 +252,8 @@ func TestMain(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":false}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":false,"enableHomepagePublishing":false}`), ShouldBeTrue)
+
 		})
 
 		Convey("Shared config written into refactored HTML contains the correct config", func() {
@@ -261,7 +263,7 @@ func TestMain(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":false}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"enableDatasetImport":false,"enableHomepagePublishing":false}`), ShouldBeTrue)
 		})
 
 	})

--- a/src/app/config/initialState.js
+++ b/src/app/config/initialState.js
@@ -1,6 +1,7 @@
 export const initialState = {
     config: {
-        enableDatasetImport: false
+        enableDatasetImport: false,
+        enableHomepagePublishing: false
     },
     user: {
         isAuthenticated: false,

--- a/src/app/config/reducer.js
+++ b/src/app/config/reducer.js
@@ -44,7 +44,8 @@ export default function reducer(state = initialState, action) {
             return {
                 ...state,
                 config: {
-                    enableDatasetImport: action.config.enableDatasetImport
+                    enableDatasetImport: action.config.enableDatasetImport,
+                    enableHomepagePublishing: action.config.enableHomepagePublishing
                 }
             };
         }

--- a/src/app/views/collections/CollectionsController.test.js
+++ b/src/app/views/collections/CollectionsController.test.js
@@ -142,7 +142,8 @@ const defaultProps = {
     activeCollection: null,
     collectionsToDelete: {},
     routes: [{}],
-    enableDatasetImport: false
+    enableDatasetImport: false,
+    enableHomepagePublishing: false
 };
 
 const component = shallow(<CollectionsController {...defaultProps} />);
@@ -285,7 +286,8 @@ describe("mapStateToProps function", () => {
             },
             rootPath: "/florence",
             config: {
-                enableDatasetImport: false
+                enableDatasetImport: false,
+                enableHomepagePublishing: false
             }
         }
     };

--- a/src/app/views/collections/details/CollectionDetails.jsx
+++ b/src/app/views/collections/details/CollectionDetails.jsx
@@ -39,6 +39,7 @@ const propTypes = {
     activePageURI: PropTypes.string,
     name: PropTypes.string,
     enableDatasetImport: PropTypes.bool,
+    enableHomepagePublishing: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
     onPageClick: PropTypes.func.isRequired,
     onEditPageClick: PropTypes.func.isRequired,
@@ -377,6 +378,15 @@ export class CollectionDetails extends Component {
                             {this.props.enableDatasetImport && (
                                 <Link id="import-dataset-link" to={`${location.pathname}/datasets`} className="btn btn--primary btn--margin-left">
                                     Create/edit CMD dataset page
+                                </Link>
+                            )}
+                            {this.props.enableHomepagePublishing && (
+                                <Link
+                                    id="edit-homepage"
+                                    to={`/florence/collections/${this.props.id}/homepage`}
+                                    className="btn btn--primary btn--margin-left"
+                                >
+                                    Edit Homepage
                                 </Link>
                             )}
                             <button

--- a/src/app/views/collections/details/CollectionDetailsController.jsx
+++ b/src/app/views/collections/details/CollectionDetailsController.jsx
@@ -34,6 +34,7 @@ const propTypes = {
     dispatch: PropTypes.func.isRequired,
     rootPath: PropTypes.string.isRequired,
     enableDatasetImport: PropTypes.bool,
+    enableHomepagePublishing: PropTypes.bool,
     user: PropTypes.object.isRequired,
     collectionID: PropTypes.string,
     collections: PropTypes.array,
@@ -629,6 +630,7 @@ export class CollectionDetailsController extends Component {
             <CollectionDetails
                 {...this.props.activeCollection}
                 enableDatasetImport={this.props.enableDatasetImport}
+                enableHomepagePublishing={this.props.enableHomepagePublishing}
                 activePageURI={this.props.activePageURI}
                 inProgress={collectionMapper.pagesExcludingPendingDeletedPages(
                     this.props.activeCollection["inProgress"],
@@ -691,7 +693,8 @@ export function mapStateToProps(state) {
         activeCollection: state.state.collections.active,
         rootPath: state.state.rootPath,
         activePageURI: state.routing.locationBeforeTransitions.hash.replace("#", ""),
-        enableDatasetImport: state.state.config.enableDatasetImport
+        enableDatasetImport: state.state.config.enableDatasetImport,
+        enableHomepagePublishing: state.state.config.enableHomepagePublishing
     };
 }
 

--- a/src/app/views/collections/details/CollectionDetailsController.test.js
+++ b/src/app/views/collections/details/CollectionDetailsController.test.js
@@ -56,6 +56,7 @@ const defaultProps = {
     },
     rootPath: "/florence",
     enableDatasetImport: false,
+    enableHomepagePublishing: false,
     routes: [{}],
     collectionID: undefined,
     activePageURI: undefined,
@@ -375,7 +376,8 @@ describe("Map state to props function", () => {
             },
             rootPath: "/florence",
             config: {
-                enableDatasetImport: false
+                enableDatasetImport: false,
+                enableHomepagePublishing: false
             }
         },
         routing: {
@@ -466,6 +468,33 @@ describe("Clicking 'edit' for a page", () => {
             .instance()
             .handleCollectionPageEditClick({ type: "article", uri: "/economy/grossdomesticproductgdp/articles/ansarticle" });
         expect(pageURL).toBe("/florence/workspace?collection=my-collection-12345&uri=/economy/grossdomesticproductgdp/articles/ansarticle");
+    });
+});
+
+describe("Edit Homepage functionality", () => {
+    it("is disabled in collection details when disabled in global config", () => {
+        const props = {
+            ...defaultProps,
+            collectionID: "test-collection-12345",
+            activeCollection: {
+                id: "test-collection-12345"
+            },
+            enableHomepagePublishing: false
+        };
+        const component = shallow(<CollectionDetailsController {...props} />);
+        expect(component.find(CollectionDetails).props().enableHomepagePublishing).toBe(false);
+    });
+    it("is enabled in collection details when enabled in global config", () => {
+        const props = {
+            ...defaultProps,
+            collectionID: "test-collection-12345",
+            activeCollection: {
+                id: "test-collection-12345"
+            },
+            enableHomepagePublishing: true
+        };
+        const component = shallow(<CollectionDetailsController {...props} />);
+        expect(component.find(CollectionDetails).props().enableHomepagePublishing).toBe(true);
     });
 });
 

--- a/src/legacy/js/functions/_setupFlorence.js
+++ b/src/legacy/js/functions/_setupFlorence.js
@@ -137,7 +137,7 @@ function setupFlorence() {
     Florence.globalVars.activeTab = false;
 
     var config = window.getEnv();
-    Florence.globalVars.config = config || { enableDatasetImport: false };
+    Florence.globalVars.config = config || { enableDatasetImport: false, enableHomepagePublishing: false };
  
     // load main florence template
     var florence = templates.florence;


### PR DESCRIPTION
### What

The new homepage publishing journey will give users in Florence the ability to edit the homepage content. This PR adds a new feature flag, `enableHomepagePublishing`, as well as the "Edit Homepage" button to enable them to edit content:

![image](https://user-images.githubusercontent.com/23668262/81910407-d270f180-95c3-11ea-8819-06d5cf3fb9b5.png)

😱 (this is the MVP; improved styling to come at a later date...)

### How to review

- For feature flags, I noticed we have a `SharedConfig` implementation for when we want them to be available for the React app as well. I essentially followed what was done for `enableDatasetImport`. While setting `ENABLE_HOMEPAGE_PUBLISHING=true` when running Florence seems to work, it'd be worth checking to make sure there aren't any steps I've missed with the feature flag
- Check to make sure that, when `ENABLE_HOMEPAGE_PUBLISHING=true`, the "Edit Homepage" button appears in the Collection Details section of the page.

### Who can review

Anyone but me