### PR TITLE
Feature/editable list limit

### DIFF
--- a/src/app/components/simple-editable-list/SimpleEditableList.jsx
+++ b/src/app/components/simple-editable-list/SimpleEditableList.jsx
@@ -16,7 +16,8 @@ const propTypes = {
     handleAddClick: PropTypes.func.isRequired,
     handleEditClick: PropTypes.func.isRequired,
     handleDeleteClick: PropTypes.func.isRequired,
-    disableActions: PropTypes.bool
+    disableActions: PropTypes.bool,
+    maximumNumberOfEntries: PropTypes.number
 };
 
 export default class SimpleEditableList extends Component {
@@ -34,6 +35,16 @@ export default class SimpleEditableList extends Component {
 
     handleDeleteClick = deletedField => {
         this.props.handleDeleteClick(deletedField, this.props.editingStateFieldName);
+    };
+
+    hasReachedMaximumNumberOfEntries = () => {
+        if (this.props.maximumNumberOfEntries == null || this.props.fields == null) {
+            return false;
+        }
+
+        if (this.props.fields.length >= this.props.maximumNumberOfEntries) {
+            return true;
+        }
     };
 
     render() {
@@ -58,7 +69,7 @@ export default class SimpleEditableList extends Component {
                     type="button"
                     className={"btn btn--link " + (this.props.fields.length ? "margin-top--1" : "")}
                     onClick={this.handleAddClick}
-                    disabled={this.props.disableActions}
+                    disabled={this.props.disableActions || this.hasReachedMaximumNumberOfEntries()}
                 >
                     {this.props.addText ? this.props.addText : "Add a new item"}
                 </button>

--- a/src/app/views/homepage/edit/EditHomepage.jsx
+++ b/src/app/views/homepage/edit/EditHomepage.jsx
@@ -22,6 +22,7 @@ class EditHomepage extends Component {
                     handleAddClick={this.props.handleSimpleEditableListAdd}
                     handleEditClick={this.props.handleSimpleEditableListEdit}
                     handleDeleteClick={this.props.handleSimpleEditableListDelete}
+                    maximumNumberOfEntries={this.props.maximumNumberOfEntries}
                     disableActions={this.props.disableForm}
                 />
                 <h2 className="margin-top--1">Service Message</h2>
@@ -47,6 +48,7 @@ const propTypes = {
     handleSimpleEditableListAdd: PropTypes.func.isRequired,
     handleSimpleEditableListDelete: PropTypes.func.isRequired,
     handleSimpleEditableListEdit: PropTypes.func.isRequired,
+    maximumNumberOfEntries: PropTypes.number,
     disableForm: PropTypes.bool.isRequired
 };
 

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -14,7 +14,8 @@ class EditHomepageController extends Component {
                 highlightedContent: [],
                 serviceMessage: ""
             },
-            isGettingHomepageData: false
+            isGettingHomepageData: false,
+            maximumNumberOfEntries: 4
         };
     }
 
@@ -25,7 +26,20 @@ class EditHomepageController extends Component {
     getHomepageData() {
         this.setState({ isGettingHomepageData: true });
         // API call to be set up at a later point
-        const highlightedContent = [];
+        const highlightedContent = [
+            {
+                simpleListHeading: "Headline One",
+                simpleListDescription: "Description for Headline One"
+            },
+            {
+                simpleListHeading: "Headline Two",
+                simpleListDescription: "Description for Headline Two"
+            },
+            {
+                simpleListHeading: "Headline Three",
+                simpleListDescription: "Description for Headline Three"
+            }
+        ];
         const serviceMessage = "";
 
         this.setState({
@@ -46,6 +60,7 @@ class EditHomepageController extends Component {
                     homepageData={this.state.homepageData}
                     handleBackButton={this.handleBackButton}
                     disableForm={this.state.isGettingHomepageData}
+                    maximumNumberOfEntries={this.state.maximumNumberOfEntries}
                 />
             </div>
         );


### PR DESCRIPTION
### What

- Added a prop to the `SimpleEditableList` component that provides the opportunity to set a limit to how many entries can be added to a list

### How to review

- Check that the editable list changes make sense and work correctly
- The changes here are derived from a previous PR which hasn't yet been merged into this branch. You can look at the last [commit](https://github.com/ONSdigital/florence/pull/433/commits/52b7e3a455ba0615c6156129b856242eee3ba2af) for the changes explicitly made in this PR

### Who can review

Anyone but me
