### PR TITLE
Feature/edit homepage add edit handlers

### DIFF
--- a/src/app/views/datasets-new/edit-metadata/DatasetMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata/DatasetMetadataController.jsx
@@ -613,7 +613,6 @@ export class DatasetMetadataController extends Component {
                 value: "",
                 error: "You must set a release date"
             };
-            console.log(newReleaseDateState);
             const newMetadataState = {
                 ...this.state.metadata,
                 releaseDate: newReleaseDateState

--- a/src/app/views/homepage/edit/EditHomepage.jsx
+++ b/src/app/views/homepage/edit/EditHomepage.jsx
@@ -27,7 +27,7 @@ class EditHomepage extends Component {
                 />
                 <h2 className="margin-top--1">Service Message</h2>
                 <Input
-                    id="service-message"
+                    id="serviceMessage"
                     label=""
                     type="textarea"
                     value={this.props.homepageData.serviceMessage}
@@ -48,6 +48,7 @@ const propTypes = {
     handleSimpleEditableListAdd: PropTypes.func.isRequired,
     handleSimpleEditableListDelete: PropTypes.func.isRequired,
     handleSimpleEditableListEdit: PropTypes.func.isRequired,
+    handleStringInputChange: PropTypes.func.isRequired,
     maximumNumberOfEntries: PropTypes.number,
     disableForm: PropTypes.bool.isRequired
 };

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -106,7 +106,7 @@ class EditHomepageController extends Component {
     };
 
     checkForHomepageDataChanges = fieldName => {
-        if (fieldName === "highlightedContent") {
+        if (fieldName === "highlightedContent" || "serviceMessage") {
             return true;
         }
         return this.state.hasChangesMade;
@@ -175,6 +175,16 @@ class EditHomepageController extends Component {
         this.props.dispatch(push(url.resolve("../../../")));
     };
 
+    handleStringInputChange = event => {
+        const fieldName = event.target.name;
+        const value = event.target.value;
+        const newHomepageDataState = { ...this.state.homepageData, [fieldName]: value };
+        this.setState({
+            homepageData: newHomepageDataState,
+            hasChangesMade: this.checkForHomepageDataChanges(fieldName)
+        });
+    };
+
     renderModal = () => {
         const modal = React.Children.map(this.props.children, child => {
             return React.cloneElement(child, {
@@ -197,6 +207,7 @@ class EditHomepageController extends Component {
                     handleSimpleEditableListAdd={this.handleSimpleEditableListAdd}
                     handleSimpleEditableListEdit={this.handleSimpleEditableListEdit}
                     handleSimpleEditableListDelete={this.handleSimpleEditableListDelete}
+                    handleStringInputChange={this.handleStringInputChange}
                 />
 
                 {this.props.params.homepageDataField && this.props.params.homepageDataFieldID ? this.renderModal() : null}

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -106,11 +106,11 @@ class EditHomepageController extends Component {
         });
     };
 
-    homepageDataHasChanges = fieldName => {
-        if (fieldName === "releaseDate" || fieldName === "notices" || fieldName === "usageNotes" || fieldName === "latestChanges") {
+    checkForHomepageDataChnges = fieldName => {
+        if (fieldName === "highlightedContent") {
             return true;
         }
-        return this.state.versionMetadataHasChanges;
+        return this.state.hasChangesMade;
     };
 
     handleSimpleEditableListEditSuccess = (newField, stateFieldName) => {
@@ -121,7 +121,8 @@ class EditHomepageController extends Component {
             newHomepageDataState = this.updateHomepageDataField(newField, stateFieldName);
         }
         this.setState({
-            homepageData: newHomepageDataState
+            homepageData: newHomepageDataState,
+            hasChangesMade: this.homepageDataHasChanges(stateFieldName)
         });
         this.props.dispatch(push(url.resolve("../../../")));
     };
@@ -162,7 +163,9 @@ class EditHomepageController extends Component {
     };
 
     renderModal = () => {
+        console.log("called");
         const modal = React.Children.map(this.props.children, child => {
+            console.log(this.state.homepageData);
             return React.cloneElement(child, {
                 data: this.state.homepageData[this.props.params.homepageDataField][this.props.params.homepageDataFieldID],
                 handleSuccessClick: this.handleSimpleEditableListEditSuccess,
@@ -173,6 +176,7 @@ class EditHomepageController extends Component {
     };
 
     render() {
+        console.log(this.props.params);
         return (
             <div className="grid grid--justify-center">
                 <EditHomepage
@@ -185,7 +189,7 @@ class EditHomepageController extends Component {
                     handleSimpleEditableListDelete={this.handleSimpleEditableListDelete}
                 />
 
-                {/* {this.props.params.homepageDataField && this.props.params.homepageDataFieldID ? this.renderModal() : null} */}
+                {this.props.params.homepageDataField && this.props.params.homepageDataFieldID ? this.renderModal() : null}
             </div>
         );
     }

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -3,7 +3,6 @@ import EditHomepage from "./EditHomepage";
 import PropTypes from "prop-types";
 
 import url from "../../../utilities/url";
-import notifications from "../../../utilities/notifications";
 import log from "../../../utilities/logging/log";
 
 import { push } from "react-router-redux";
@@ -106,7 +105,7 @@ class EditHomepageController extends Component {
         });
     };
 
-    checkForHomepageDataChnges = fieldName => {
+    checkForHomepageDataChanges = fieldName => {
         if (fieldName === "highlightedContent") {
             return true;
         }
@@ -122,7 +121,7 @@ class EditHomepageController extends Component {
         }
         this.setState({
             homepageData: newHomepageDataState,
-            hasChangesMade: this.checkForHomepageDataChnges(stateFieldName)
+            hasChangesMade: this.checkForHomepageDataChanges(stateFieldName)
         });
         this.props.dispatch(push(url.resolve("../../../")));
     };

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -44,25 +44,30 @@ class EditHomepageController extends Component {
         // API call to be set up at a later point
         const highlightedContent = [
             {
-                id: 0,
-                simpleListHeading: "Headline One",
-                simpleListDescription: "Description for Headline One"
+                title: "Headline One",
+                description: "Description for Headline One",
+                uri: "/",
+                image: null
             },
             {
-                id: 1,
-                simpleListHeading: "Headline Two",
-                simpleListDescription: "Description for Headline Two"
+                title: "Headline Two",
+                description: "Description for Headline Two",
+                uri: "/",
+                image: null
             },
             {
-                id: 2,
-                simpleListHeading: "Headline Three",
-                simpleListDescription: "Description for Headline Three"
+                title: "Headline Three",
+                description: "Description for Headline Three",
+                uri: "/",
+                image: null
             }
         ];
         const serviceMessage = "";
 
+        const mappedHighlightedContent = this.mapHighlightedContentToState(highlightedContent);
+
         this.setState({
-            homepageData: { highlightedContent, serviceMessage },
+            homepageData: { highlightedContent: mappedHighlightedContent, serviceMessage },
             isGettingHomepageData: false
         });
     }
@@ -107,17 +112,37 @@ class EditHomepageController extends Component {
     mapHomepageDataFieldToState = (newState, stateFieldName) => {
         switch (stateFieldName) {
             case "homepageData": {
-                return this.mapNoticesToState(newState);
+                return this.mapHighlightedContentToState(newState);
             }
             default: {
                 log.event("Error mapping metadata field to state. Unknown field name.", log.data({ fieldName: stateFieldName }), log.error());
                 notifications.add({
                     type: "warning",
-                    message: `An when adding metadata item, changes or additions won't be save. Refresh the page and try again`,
+                    message: `An error occurred when adding a homepage item item, changes or additions won't be save. Refresh the page and try again`,
                     isDismissable: true
                 });
-                console.error(`Error mapping metadata field to state. Unknown field name '${stateFieldName}'`);
+                console.error(`Error mapping homepage data field to state. Unknown field name '${stateFieldName}'`);
             }
+        }
+    };
+
+    mapHighlightedContentToState = highlightedContent => {
+        try {
+            return highlightedContent.map((item, index) => {
+                return {
+                    id: index,
+                    description: item.description,
+                    href: item.uri,
+                    title: item.title,
+                    simpleListHeading: item.title,
+                    simpleListDescription: item.description
+                };
+            });
+        } catch (error) {
+            log.event("Error mapping highlighted content to state", log.data({ collectionID: this.props.params.collectionID }), log.error(error));
+            // throw an error to let parent mapper catch and display notification
+            // this will prevent the page loading with half loaded/mapped data
+            throw new Error(`Error mapping highlighted content to state \n ${error}`);
         }
     };
 
@@ -126,9 +151,7 @@ class EditHomepageController extends Component {
     };
 
     renderModal = () => {
-        console.log("called");
         const modal = React.Children.map(this.props.children, child => {
-            console.log("called:", child);
             return React.cloneElement(child, {
                 data: this.state.homepageData[this.props.params.homepageDataField][this.props.params.homepageDataFieldID],
                 handleSuccessClick: this.handleSimpleEditableListEditSuccess,

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -42,32 +42,34 @@ class EditHomepageController extends Component {
     getHomepageData() {
         this.setState({ isGettingHomepageData: true });
         // API call to be set up at a later point
-        const highlightedContent = [
-            {
-                title: "Headline One",
-                description: "Description for Headline One",
-                uri: "/",
-                image: null
-            },
-            {
-                title: "Headline Two",
-                description: "Description for Headline Two",
-                uri: "/",
-                image: null
-            },
-            {
-                title: "Headline Three",
-                description: "Description for Headline Three",
-                uri: "/",
-                image: null
-            }
-        ];
-        const serviceMessage = "";
+        const mockAPIResponse = {
+            highlightedContent: [
+                {
+                    title: "Headline One",
+                    description: "Description for Headline One",
+                    uri: "/",
+                    image: null
+                },
+                {
+                    title: "Headline Two",
+                    description: "Description for Headline Two",
+                    uri: "/",
+                    image: null
+                },
+                {
+                    title: "Headline Three",
+                    description: "Description for Headline Three",
+                    uri: "/",
+                    image: null
+                }
+            ],
+            serviceMessage: "This is a default service message for mock testing"
+        };
 
-        const mappedHighlightedContent = this.mapHighlightedContentToState(highlightedContent);
+        const mappedHighlightedContent = this.mapHighlightedContentToState(mockAPIResponse.highlightedContent);
 
         this.setState({
-            homepageData: { highlightedContent: mappedHighlightedContent, serviceMessage },
+            homepageData: { highlightedContent: mappedHighlightedContent, serviceMessage: mockAPIResponse.serviceMessage },
             isGettingHomepageData: false
         });
     }

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -122,7 +122,7 @@ class EditHomepageController extends Component {
         }
         this.setState({
             homepageData: newHomepageDataState,
-            hasChangesMade: this.homepageDataHasChanges(stateFieldName)
+            hasChangesMade: this.checkForHomepageDataChnges(stateFieldName)
         });
         this.props.dispatch(push(url.resolve("../../../")));
     };
@@ -144,7 +144,7 @@ class EditHomepageController extends Component {
                 return {
                     id: index,
                     description: item.description,
-                    href: item.uri,
+                    uri: item.uri,
                     title: item.title,
                     simpleListHeading: item.title,
                     simpleListDescription: item.description
@@ -158,14 +158,26 @@ class EditHomepageController extends Component {
         }
     };
 
+    updateHomepageDataField = (updatedField, stateFieldName) => {
+        const newFieldState = this.state.homepageData[stateFieldName].map(field => {
+            if (field.id === updatedField.id) {
+                return updatedField;
+            }
+            return field;
+        });
+        const mappedNewFieldState = this.mapHighlightedContentToState(newFieldState, stateFieldName);
+        return {
+            ...this.state.homepageData,
+            [stateFieldName]: mappedNewFieldState
+        };
+    };
+
     handleSimpleEditableListEditCancel = () => {
         this.props.dispatch(push(url.resolve("../../../")));
     };
 
     renderModal = () => {
-        console.log("called");
         const modal = React.Children.map(this.props.children, child => {
-            console.log(this.state.homepageData);
             return React.cloneElement(child, {
                 data: this.state.homepageData[this.props.params.homepageDataField][this.props.params.homepageDataFieldID],
                 handleSuccessClick: this.handleSimpleEditableListEditSuccess,
@@ -176,7 +188,6 @@ class EditHomepageController extends Component {
     };
 
     render() {
-        console.log(this.props.params);
         return (
             <div className="grid grid--justify-center">
                 <EditHomepage

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -31,6 +31,7 @@ class EditHomepageController extends Component {
                 serviceMessage: ""
             },
             isGettingHomepageData: false,
+            hasChangesMade: false,
             maximumNumberOfEntries: 4
         };
     }
@@ -45,20 +46,26 @@ class EditHomepageController extends Component {
         const mockAPIResponse = {
             highlightedContent: [
                 {
-                    title: "Headline One",
-                    description: "Description for Headline One",
+                    title: "Weekly deaths",
+                    description: "The most up-to-date provisional figures for deaths involving the coronavirus (COVID-19) in England and Wales.",
                     uri: "/",
                     image: null
                 },
                 {
-                    title: "Headline Two",
-                    description: "Description for Headline Two",
+                    title: "Coronavirus - faster indicators",
+                    description: "The latest data and experimental indicators on the UK economy and society.",
                     uri: "/",
                     image: null
                 },
                 {
-                    title: "Headline Three",
-                    description: "Description for Headline Three",
+                    title: "Coronavirus roundup",
+                    description: "Our summary of the latest data and analysis related to the coronavirus pandemic.",
+                    uri: "/",
+                    image: null
+                },
+                {
+                    title: "ONS blogs",
+                    description: "Find out more about the work ONS is doing to respond to the challenge of the pandemic.",
                     uri: "/",
                     image: null
                 }
@@ -87,6 +94,25 @@ class EditHomepageController extends Component {
         this.props.dispatch(push(`${this.props.location.pathname}/edit/${stateFieldName}/${editedField.id}`));
     };
 
+    handleSimpleEditableListDelete = (deletedField, stateFieldName) => {
+        const newFieldState = this.state.homepageData[stateFieldName].filter(item => item.id !== deletedField.id);
+        const newHomepageDataState = {
+            ...this.state.homepageData,
+            [stateFieldName]: newFieldState
+        };
+        this.setState({
+            homepageData: newHomepageDataState,
+            hasChangesMade: true
+        });
+    };
+
+    homepageDataHasChanges = fieldName => {
+        if (fieldName === "releaseDate" || fieldName === "notices" || fieldName === "usageNotes" || fieldName === "latestChanges") {
+            return true;
+        }
+        return this.state.versionMetadataHasChanges;
+    };
+
     handleSimpleEditableListEditSuccess = (newField, stateFieldName) => {
         let newHomepageDataState;
         if (newField.id === null) {
@@ -104,28 +130,11 @@ class EditHomepageController extends Component {
         const newFieldState = [...this.state.homepageData[stateFieldName]];
         newField.id = newFieldState.length;
         newFieldState.push(newField);
-        const mappedNewFieldState = this.mapHomepageDataFieldToState(newFieldState, stateFieldName);
+        const mappedNewFieldState = this.mapHighlightedContentToState(newFieldState);
         return {
             ...this.state.homepageData,
             [stateFieldName]: mappedNewFieldState
         };
-    };
-
-    mapHomepageDataFieldToState = (newState, stateFieldName) => {
-        switch (stateFieldName) {
-            case "homepageData": {
-                return this.mapHighlightedContentToState(newState);
-            }
-            default: {
-                log.event("Error mapping metadata field to state. Unknown field name.", log.data({ fieldName: stateFieldName }), log.error());
-                notifications.add({
-                    type: "warning",
-                    message: `An error occurred when adding a homepage item item, changes or additions won't be save. Refresh the page and try again`,
-                    isDismissable: true
-                });
-                console.error(`Error mapping homepage data field to state. Unknown field name '${stateFieldName}'`);
-            }
-        }
     };
 
     mapHighlightedContentToState = highlightedContent => {
@@ -173,9 +182,10 @@ class EditHomepageController extends Component {
                     maximumNumberOfEntries={this.state.maximumNumberOfEntries}
                     handleSimpleEditableListAdd={this.handleSimpleEditableListAdd}
                     handleSimpleEditableListEdit={this.handleSimpleEditableListEdit}
+                    handleSimpleEditableListDelete={this.handleSimpleEditableListDelete}
                 />
 
-                {this.props.params.homepageDataField && this.props.params.homepageDataFieldID ? this.renderModal() : null}
+                {/* {this.props.params.homepageDataField && this.props.params.homepageDataFieldID ? this.renderModal() : null} */}
             </div>
         );
     }

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -3,7 +3,23 @@ import EditHomepage from "./EditHomepage";
 import PropTypes from "prop-types";
 
 import url from "../../../utilities/url";
+import notifications from "../../../utilities/notifications";
+import log from "../../../utilities/logging/log";
+
 import { push } from "react-router-redux";
+
+const propTypes = {
+    location: PropTypes.shape({
+        pathname: PropTypes.string.isRequired
+    }),
+    params: PropTypes.shape({
+        collectionID: PropTypes.string.isRequired,
+        homepageDataField: PropTypes.string,
+        homepageDataFieldID: PropTypes.string
+    }),
+    children: PropTypes.element,
+    dispatch: PropTypes.func.isRequired
+};
 
 class EditHomepageController extends Component {
     constructor(props) {
@@ -28,14 +44,17 @@ class EditHomepageController extends Component {
         // API call to be set up at a later point
         const highlightedContent = [
             {
+                id: 0,
                 simpleListHeading: "Headline One",
                 simpleListDescription: "Description for Headline One"
             },
             {
+                id: 1,
                 simpleListHeading: "Headline Two",
                 simpleListDescription: "Description for Headline Two"
             },
             {
+                id: 2,
                 simpleListHeading: "Headline Three",
                 simpleListDescription: "Description for Headline Three"
             }
@@ -53,6 +72,72 @@ class EditHomepageController extends Component {
         this.props.dispatch(push(previousUrl));
     };
 
+    handleSimpleEditableListAdd = stateFieldName => {
+        this.props.dispatch(push(`${this.props.location.pathname}/edit/${stateFieldName}/${this.state.homepageData[stateFieldName].length}`));
+    };
+
+    handleSimpleEditableListEdit = (editedField, stateFieldName) => {
+        this.props.dispatch(push(`${this.props.location.pathname}/edit/${stateFieldName}/${editedField.id}`));
+    };
+
+    handleSimpleEditableListEditSuccess = (newField, stateFieldName) => {
+        let newHomepageDataState;
+        if (newField.id === null) {
+            newHomepageDataState = this.addHomepageDataField(newField, stateFieldName);
+        } else {
+            newHomepageDataState = this.updateHomepageDataField(newField, stateFieldName);
+        }
+        this.setState({
+            homepageData: newHomepageDataState
+        });
+        this.props.dispatch(push(url.resolve("../../../")));
+    };
+
+    addHomepageDataField = (newField, stateFieldName) => {
+        const newFieldState = [...this.state.homepageData[stateFieldName]];
+        newField.id = newFieldState.length;
+        newFieldState.push(newField);
+        const mappedNewFieldState = this.mapHomepageDataFieldToState(newFieldState, stateFieldName);
+        return {
+            ...this.state.homepageData,
+            [stateFieldName]: mappedNewFieldState
+        };
+    };
+
+    mapHomepageDataFieldToState = (newState, stateFieldName) => {
+        switch (stateFieldName) {
+            case "homepageData": {
+                return this.mapNoticesToState(newState);
+            }
+            default: {
+                log.event("Error mapping metadata field to state. Unknown field name.", log.data({ fieldName: stateFieldName }), log.error());
+                notifications.add({
+                    type: "warning",
+                    message: `An when adding metadata item, changes or additions won't be save. Refresh the page and try again`,
+                    isDismissable: true
+                });
+                console.error(`Error mapping metadata field to state. Unknown field name '${stateFieldName}'`);
+            }
+        }
+    };
+
+    handleSimpleEditableListEditCancel = () => {
+        this.props.dispatch(push(url.resolve("../../../")));
+    };
+
+    renderModal = () => {
+        console.log("called");
+        const modal = React.Children.map(this.props.children, child => {
+            console.log("called:", child);
+            return React.cloneElement(child, {
+                data: this.state.homepageData[this.props.params.homepageDataField][this.props.params.homepageDataFieldID],
+                handleSuccessClick: this.handleSimpleEditableListEditSuccess,
+                handleCancelClick: this.handleSimpleEditableListEditCancel
+            });
+        });
+        return modal;
+    };
+
     render() {
         return (
             <div className="grid grid--justify-center">
@@ -61,21 +146,15 @@ class EditHomepageController extends Component {
                     handleBackButton={this.handleBackButton}
                     disableForm={this.state.isGettingHomepageData}
                     maximumNumberOfEntries={this.state.maximumNumberOfEntries}
+                    handleSimpleEditableListAdd={this.handleSimpleEditableListAdd}
+                    handleSimpleEditableListEdit={this.handleSimpleEditableListEdit}
                 />
+
+                {this.props.params.homepageDataField && this.props.params.homepageDataFieldID ? this.renderModal() : null}
             </div>
         );
     }
 }
-
-const propTypes = {
-    location: PropTypes.shape({
-        pathname: PropTypes.string.isRequired
-    }),
-    params: PropTypes.shape({
-        collectionID: PropTypes.string.isRequired
-    }),
-    dispatch: PropTypes.func.isRequired
-};
 
 EditHomepageController.propTypes = propTypes;
 

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -1,0 +1,64 @@
+import React from "react";
+import EditHomepageController from "./EditHomepageController";
+import { shallow } from "enzyme";
+
+const mockAPIResponse = {
+    highlightedContent: [
+        {
+            title: "Weekly deaths",
+            description: "The most up-to-date provisional figures for deaths involving the coronavirus (COVID-19) in England and Wales.",
+            uri: "/",
+            image: null
+        },
+        {
+            title: "Coronavirus - faster indicators",
+            description: "The latest data and experimental indicators on the UK economy and society.",
+            uri: "/",
+            image: null
+        },
+        {
+            title: "Coronavirus roundup",
+            description: "Our summary of the latest data and analysis related to the coronavirus pandemic.",
+            uri: "/",
+            image: null
+        },
+        {
+            title: "ONS blogs",
+            description: "Find out more about the work ONS is doing to respond to the challenge of the pandemic.",
+            uri: "/",
+            image: null
+        }
+    ],
+    serviceMessage: "This is a default service message for mock testing"
+};
+
+let dispatchedActions = [];
+
+const defaultProps = {
+    dispatch: event => {
+        dispatchedActions.push(event);
+    },
+    rootPath: "/florence",
+    location: {
+        pathname: "florence/collections/12345/homepage"
+    }
+};
+
+let wrapper;
+beforeEach(() => {
+    wrapper = shallow(<EditHomepageController {...defaultProps} />);
+});
+
+describe("mapping data fetched from API to component state", () => {
+    it("maps the mock response to the state", () => {
+        const highlightedContent = wrapper.state("homepageData").highlightedContent;
+        expect(highlightedContent.length).toBe(4);
+    });
+    it("maps the additional fields to the state", () => {
+        const firstEntryOfHighlightedContent = wrapper.state("homepageData").highlightedContent[0];
+        expect(firstEntryOfHighlightedContent.simpleListHeading).toBe("Weekly deaths");
+        expect(firstEntryOfHighlightedContent.simpleListDescription).toBe(
+            "The most up-to-date provisional figures for deaths involving the coronavirus (COVID-19) in England and Wales."
+        );
+    });
+});

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import EditHomepageController from "./EditHomepageController";
 import { shallow } from "enzyme";
 
+// will need to be mocked and implemented properly when the API request code is implemented
 const mockAPIResponse = {
     highlightedContent: [
         {

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -38,6 +38,10 @@ const defaultProps = {
     dispatch: event => {
         dispatchedActions.push(event);
     },
+    params: {
+        homepageDataField: "",
+        homepageDataFieldID: ""
+    },
     rootPath: "/florence",
     location: {
         pathname: "florence/collections/12345/homepage"

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -14,7 +14,7 @@ const propTypes = {
     data: PropTypes.shape({
         id: PropTypes.string,
         description: PropTypes.string,
-        href: PropTypes.string,
+        uri: PropTypes.string,
         title: PropTypes.string
     }),
     handleSuccessClick: PropTypes.func.isRequired,
@@ -28,13 +28,9 @@ export default class EditHomepageItem extends Component {
         this.state = {
             id: this.props.data ? this.props.data.id : null,
             description: this.props.data ? this.props.data.description : "",
-            href: this.props.data ? this.props.data.href : "",
+            uri: this.props.data ? this.props.data.uri : "",
             title: this.props.data ? this.props.data.title : ""
         };
-    }
-
-    componentDidMount() {
-        console.log("DATA", this.props.data);
     }
 
     handleSuccessClick = () => {
@@ -53,7 +49,7 @@ export default class EditHomepageItem extends Component {
                 return (
                     <div>
                         <Input id="title" type="input" label="Title" value={this.state.title} onChange={this.handleInputChange} />
-                        <Input id="href" type="input" label="URL" value={this.state.href} onChange={this.handleInputChange} />
+                        <Input id="uri" type="input" label="URL" value={this.state.uri} onChange={this.handleInputChange} />
                         <Input
                             id="description"
                             type="textarea"

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -33,6 +33,10 @@ export default class EditHomepageItem extends Component {
         };
     }
 
+    componentDidMount() {
+        console.log("DATA", this.props.data);
+    }
+
     handleSuccessClick = () => {
         this.props.handleSuccessClick(this.state, this.props.params.homepageDataField);
     };
@@ -41,19 +45,6 @@ export default class EditHomepageItem extends Component {
         const value = event.target.value;
         const fieldName = event.target.name;
         this.setState({ [fieldName]: value });
-    };
-
-    handleSelectChange = event => {
-        const value = event.target.value;
-        const fieldName = event.target.name;
-        this.setState({ [fieldName]: value });
-    };
-
-    handleDateInputChange = event => {
-        const fieldName = event.target.name;
-        const value = event.target.value;
-        const ISODate = new Date(value).toISOString();
-        this.setState({ [fieldName]: ISODate });
     };
 
     renderModalBody = () => {

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -12,7 +12,7 @@ const propTypes = {
         homepageDataField: PropTypes.string.isRequired
     }),
     data: PropTypes.shape({
-        id: PropTypes.string,
+        id: PropTypes.number,
         description: PropTypes.string,
         uri: PropTypes.string,
         title: PropTypes.string
@@ -74,10 +74,10 @@ export default class EditHomepageItem extends Component {
                 </div>
                 <div className="modal__body">{this.renderModalBody()}</div>
                 <div className="modal__footer">
-                    <button type="button" className="btn btn--primary btn--margin-right" onClick={this.handleSuccessClick}>
+                    <button id="continue" type="button" className="btn btn--primary btn--margin-right" onClick={this.handleSuccessClick}>
                         Continue
                     </button>
-                    <button type="button" className="btn" onClick={this.props.handleCancelClick}>
+                    <button id="cancel" type="button" className="btn" onClick={this.props.handleCancelClick}>
                         Cancel
                     </button>
                 </div>

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -13,10 +13,8 @@ const propTypes = {
     }),
     data: PropTypes.shape({
         id: PropTypes.string,
-        type: PropTypes.string,
         description: PropTypes.string,
         href: PropTypes.string,
-        date: PropTypes.string,
         title: PropTypes.string
     }),
     handleSuccessClick: PropTypes.func.isRequired,
@@ -29,16 +27,10 @@ export default class EditHomepageItem extends Component {
 
         this.state = {
             id: this.props.data ? this.props.data.id : null,
-            type: this.props.data ? this.props.data.type : "",
             description: this.props.data ? this.props.data.description : "",
             href: this.props.data ? this.props.data.href : "",
-            date: this.props.data ? this.props.data.date : "",
             title: this.props.data ? this.props.data.title : ""
         };
-    }
-
-    componentDidMount() {
-        console.log(this.props);
     }
 
     handleSuccessClick = () => {

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -1,0 +1,110 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+
+import date from "../../../utilities/date";
+
+import Modal from "../../../components/Modal";
+import Input from "../../../components/Input";
+import Select from "../../../components/Select";
+
+const propTypes = {
+    params: PropTypes.shape({
+        homepageDataField: PropTypes.string.isRequired
+    }),
+    data: PropTypes.shape({
+        id: PropTypes.string,
+        type: PropTypes.string,
+        description: PropTypes.string,
+        href: PropTypes.string,
+        date: PropTypes.string,
+        title: PropTypes.string
+    }),
+    handleSuccessClick: PropTypes.func.isRequired,
+    handleCancelClick: PropTypes.func.isRequired
+};
+
+export default class EditHomepageItem extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            id: this.props.data ? this.props.data.id : null,
+            type: this.props.data ? this.props.data.type : "",
+            description: this.props.data ? this.props.data.description : "",
+            href: this.props.data ? this.props.data.href : "",
+            date: this.props.data ? this.props.data.date : "",
+            title: this.props.data ? this.props.data.title : ""
+        };
+    }
+
+    componentDidMount() {
+        console.log(this.props);
+    }
+
+    handleSuccessClick = () => {
+        this.props.handleSuccessClick(this.state, this.props.params.homepageDataField);
+    };
+
+    handleInputChange = event => {
+        const value = event.target.value;
+        const fieldName = event.target.name;
+        this.setState({ [fieldName]: value });
+    };
+
+    handleSelectChange = event => {
+        const value = event.target.value;
+        const fieldName = event.target.name;
+        this.setState({ [fieldName]: value });
+    };
+
+    handleDateInputChange = event => {
+        const fieldName = event.target.name;
+        const value = event.target.value;
+        const ISODate = new Date(value).toISOString();
+        this.setState({ [fieldName]: ISODate });
+    };
+
+    renderModalBody = () => {
+        switch (this.props.params.homepageDataField) {
+            case "highlightedContent": {
+                return (
+                    <div>
+                        <Input id="title" type="input" label="Title" value={this.state.title} onChange={this.handleInputChange} />
+                        <Input id="href" type="input" label="URL" value={this.state.href} onChange={this.handleInputChange} />
+                        <Input
+                            id="description"
+                            type="textarea"
+                            label="Description"
+                            value={this.state.description}
+                            onChange={this.handleInputChange}
+                        />
+                    </div>
+                );
+            }
+            default: {
+                return <p>Something went wrong: unsupported field type</p>;
+            }
+        }
+    };
+
+    render() {
+        return (
+            <Modal>
+                <div className="modal__header">
+                    <h2>Add an item</h2>
+                </div>
+                <div className="modal__body">{this.renderModalBody()}</div>
+                <div className="modal__footer">
+                    <button type="button" className="btn btn--primary btn--margin-right" onClick={this.handleSuccessClick}>
+                        Continue
+                    </button>
+                    <button type="button" className="btn" onClick={this.props.handleCancelClick}>
+                        Cancel
+                    </button>
+                </div>
+            </Modal>
+        );
+    }
+}
+
+EditHomepageItem.propTypes = propTypes;

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -1,11 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-import date from "../../../utilities/date";
-
 import Modal from "../../../components/Modal";
 import Input from "../../../components/Input";
-import Select from "../../../components/Select";
 
 const propTypes = {
     params: PropTypes.shape({

--- a/src/app/views/homepage/edit/EditHomepageItem.test.js
+++ b/src/app/views/homepage/edit/EditHomepageItem.test.js
@@ -1,0 +1,65 @@
+import React from "react";
+import EditHomepageItem from "./EditHomepageItem";
+import { shallow, mount } from "enzyme";
+
+let dispatchedActions = [];
+
+const nullParamProps = {
+    data: {
+        id: 0,
+        description: "Test description",
+        uri: "/",
+        title: "Test title"
+    },
+    params: {
+        homepageDataField: null,
+        homepageDataFieldID: null
+    },
+    handleSuccessClick: () => {},
+    handleCancelClick: () => {}
+};
+
+const successRouteProps = {
+    data: {
+        id: 0,
+        description: "Test description",
+        uri: "/",
+        title: "Test title"
+    },
+    params: {
+        homepageDataField: "highlightedContent",
+        homepageDataFieldID: 0
+    },
+    handleSuccessClick: jest.fn(),
+    handleCancelClick: jest.fn()
+};
+
+describe("different item states", () => {
+    it("maps the propagated data to the fields", () => {
+        const wrapper = mount(<EditHomepageItem {...successRouteProps} />);
+        const inputs = wrapper.find("input");
+        const textarea = wrapper.find("textarea");
+        expect(inputs.length).toBe(2);
+        expect(textarea.length).toBe(1);
+    });
+    it("renders something went wrong message when unsupported field type is passed ", () => {
+        const wrapper = shallow(<EditHomepageItem {...nullParamProps} />);
+        const defaultMessage = wrapper.find("p");
+        expect(defaultMessage.text()).toEqual("Something went wrong: unsupported field type");
+    });
+});
+
+describe("event handlers", () => {
+    it("calls the cancel handler when clicked", () => {
+        const wrapper = shallow(<EditHomepageItem {...successRouteProps} />);
+        const cancelButton = wrapper.find("#cancel");
+        cancelButton.simulate("click");
+        expect(successRouteProps.handleCancelClick).toBeCalled();
+    });
+    it("calls the continue handler when clicked", () => {
+        const wrapper = shallow(<EditHomepageItem {...successRouteProps} />);
+        const cancelButton = wrapper.find("#continue");
+        cancelButton.simulate("click");
+        expect(successRouteProps.handleSuccessClick).toBeCalled();
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import DatasetUploadMetadata from "./app/views/uploads/dataset/upload-details/Da
 import DatasetMetadata from "./app/views/datasets/metadata/DatasetMetadata";
 import VersionMetadata from "./app/views/datasets/metadata/VersionMetadata";
 import EditHomepageController from "./app/views/homepage/edit/EditHomepageController"
+import EditHomepageItem from "./app/views/homepage/edit/EditHomepageItem"
 
 import Logs from "./app/views/logs/Logs";
 
@@ -95,7 +96,15 @@ class Index extends Component {
                                     <Route path="restore-content" component={userIsAuthenticated(CollectionsController)} />
                                 </Route>
                             </Route>
-                            <Route path={`${rootPath}/collections/:collectionID/homepage`} component={userIsAuthenticated(EditHomepageController)} />
+                            <Route component={CollectionRoutesWrapper}>
+                                <Route path={`${rootPath}/collections/:collectionID/homepage`}>
+                                    <IndexRoute component={userIsAuthenticated(EditHomepageController)} />
+                                    <Route
+                                        path={`edit/:homepageDataField/:homepageDataFieldID`}
+                                        component={userIsAuthenticated(EditHomepageItem)}
+                                    />
+                                </Route>
+                            </Route>
                             <Route path={`${rootPath}/collections/:collectionID/preview`} component={userIsAuthenticated(PreviewController)} />
 
                             {config.enableDatasetImport === true && (

--- a/src/index.js
+++ b/src/index.js
@@ -97,8 +97,7 @@ class Index extends Component {
                                 </Route>
                             </Route>
                             <Route component={CollectionRoutesWrapper}>
-                                <Route path={`${rootPath}/collections/:collectionID/homepage`}>
-                                    <IndexRoute component={userIsAuthenticated(EditHomepageController)} />
+                                <Route path={`${rootPath}/collections/:collectionID/homepage`} component={userIsAuthenticated(EditHomepageController)}>
                                     <Route
                                         path={`edit/:homepageDataField/:homepageDataFieldID`}
                                         component={userIsAuthenticated(EditHomepageItem)}


### PR DESCRIPTION
### What

- Implementation of handlers in EditHomepageController and EditHomepageItem (add/edit/delete item from list). This is mostly following the pattern set in the `DatasetMetadata` folder
- Tests

### How to review

- Check that the code makes sense and aligns with requirements
- Visiting the Edit Homepage form you should now be able to add new headlines (up to the limit of 4), edit them with the data persist between modal and form, and delete headlines too

### Who can review

Anyone but me
