### PR TITLE
Add workflow preview component

### DIFF
--- a/src/app/views/workflow-preview/WorkflowPreview.jsx
+++ b/src/app/views/workflow-preview/WorkflowPreview.jsx
@@ -1,0 +1,91 @@
+import React, { Component } from "react";
+import { push } from "react-router-redux";
+import { Link } from "react-router";
+import PropTypes from "prop-types";
+
+import url from "../../utilities/url";
+import notifications from "../../utilities/notifications";
+
+import Iframe from "../../components/iframe/Iframe";
+
+const propTypes = {
+    location: PropTypes.PropTypes.shape({
+        pathname: PropTypes.string
+    }),
+    params: PropTypes.shape({
+        collectionID: PropTypes.string.isRequired
+    }),
+    dispatch: PropTypes.func.isRequired
+};
+
+export class WorkflowPreview extends Component {
+    constructor(props) {
+        super(props);
+    }
+
+    handleBackButton = () => {
+        const previousUrl = url.resolve("../");
+        this.props.dispatch(push(previousUrl));
+    };
+
+    // getPreviewIframeURL returns the url for the content to be reviewed when the url is
+    // in the format: /florence/collections/collection-id/{content/to/preview/url}/preview
+    // returns '/' incase the url is '/homepage' or errors
+    getPreviewIframeURL = path => {
+        try {
+            const regex = /(?:\/[^\/]+){3}(?<contentURL>.+)\/preview/;
+            const regexResult = regex.exec(path);
+            const contentURL = regexResult.groups.contentURL;
+            if (contentURL === "/homepage") {
+                return "/";
+            }
+            return contentURL;
+        } catch (error) {
+            notifications.add({
+                type: "warning",
+                message:
+                    "There was an error previewing this content so you've bene directed to the homepage. You can navigate to the content or refresh Florence.",
+                isDismissable: true
+            });
+            return "/";
+        }
+    };
+
+    render() {
+        this.getPreviewIframeURL(this.props.location.pathname);
+        return (
+            <div>
+                <div className="grid grid--justify-center">
+                    <div className="grid__col-6 margin-bottom--1">
+                        <div className="margin-top--2">
+                            &#9664;{" "}
+                            <button type="button" className="btn btn--link" onClick={this.handleBackButton}>
+                                Back
+                            </button>
+                        </div>
+                        <h1 className="margin-top--1 margin-bottom--1">Preview</h1>
+                    </div>
+                </div>
+                <div className="preview--half preview--borders">
+                    <Iframe path={this.getPreviewIframeURL(this.props.location.pathname)} />
+                </div>
+                <div className="grid grid--justify-center">
+                    <div className="grid__col-6">
+                        <div className="margin-top--1 margin-bottom--1">
+                            <Link
+                                className="btn btn--positive margin-right--1"
+                                to={window.location.origin + "/florence/collections/" + this.props.params.collectionID}
+                            >
+                                Continue
+                            </Link>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+WorkflowPreview.propTypes = propTypes;
+
+export default WorkflowPreview;

--- a/src/app/views/workflow-preview/WorkflowPreview.jsx
+++ b/src/app/views/workflow-preview/WorkflowPreview.jsx
@@ -33,7 +33,7 @@ export class WorkflowPreview extends Component {
     // returns '/' incase the url is '/homepage' or errors
     getPreviewIframeURL = path => {
         try {
-            const regex = /(?:\/[^\/]+){3}(?<contentURL>.+)\/preview/;
+            const regex = /(?:\/[^/]+){3}(?<contentURL>.+)\/preview/;
             const regexResult = regex.exec(path);
             const contentURL = regexResult.groups.contentURL;
             if (contentURL === "/homepage") {

--- a/src/app/views/workflow-preview/WorkflowPreview.jsx
+++ b/src/app/views/workflow-preview/WorkflowPreview.jsx
@@ -33,6 +33,8 @@ export class WorkflowPreview extends Component {
     // returns '/' incase the url is '/homepage' or errors
     getPreviewIframeURL = path => {
         try {
+            // regex will capture the value between /florence/collections/collection-id and /preview
+            // e.g. /florence/collections/collection-id/capture/group/preview => /capture/group
             const regex = /(?:\/[^/]+){3}(?<contentURL>.+)\/preview/;
             const regexResult = regex.exec(path);
             const contentURL = regexResult.groups.contentURL;

--- a/src/app/views/workflow-preview/WorkflowPreview.test.js
+++ b/src/app/views/workflow-preview/WorkflowPreview.test.js
@@ -1,0 +1,67 @@
+import React from "react";
+import { WorkflowPreview } from "./WorkflowPreview";
+import { shallow, mount } from "enzyme";
+
+console.error = () => {};
+
+jest.mock("../../utilities/logging/log", () => {
+    return {
+        event: function() {}
+    };
+});
+
+jest.mock("../../utilities/notifications", () => {
+    return {
+        add: jest.fn(notification => {
+            mockNotifications.push(notification);
+        }),
+        remove: () => {}
+    };
+});
+
+let dispatchedActions,
+    mockNotifications = [];
+
+const defaultProps = {
+    dispatch: event => {
+        dispatchedActions.push(event);
+    },
+    rootPath: "/florence",
+    location: {
+        pathname: "florence/collections/testcollection-001/test-content/preview"
+    },
+    params: {
+        collectionID: "testcollection-001"
+    }
+};
+
+const component = shallow(<WorkflowPreview {...defaultProps} />);
+
+beforeEach(() => {
+    mockNotifications = [];
+});
+
+describe("getting preview iframe url", () => {
+    it("gets correct value from correctly formatted url", () => {
+        const testURLs = [
+            { path: "/florence/collections/collection-001/homepage/preview", expected: "/" },
+            {
+                path: "/florence/collections/collection-002/datasets/cpih01/editions/time-series/version/2/preview",
+                expected: "/datasets/cpih01/editions/time-series/version/2"
+            },
+            { path: "/florence/collections/collection-003/bulletins/cpih01/preview", expected: "/bulletins/cpih01" },
+            { path: "/florence/collections/collection-003/test/test/test/preview", expected: "/test/test/test" }
+        ];
+        testURLs.forEach(url => {
+            const path = component.instance().getPreviewIframeURL(url.path);
+            expect(path).toBe(url.expected);
+        });
+    });
+
+    it("handles errors and displays notification", () => {
+        expect(mockNotifications.length).toBe(0);
+        const path = component.instance().getPreviewIframeURL("rubbish/url/to/test");
+        expect(path).toBe("/");
+        expect(mockNotifications.length).toBe(1);
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ import EditMetadataItem from "./app/views/datasets-new/edit-metadata/EditMetadat
 import ChangeUserPasswordController from "./app/views/users/change-password/ChangeUserPasswordController";
 import ConfirmUserDeleteController from "./app/views/users/confirm-delete/ConfirmUserDeleteController";
 import CollectionRoutesWrapper from "./app/global/collection-wrapper/CollectionRoutesWrapper";
+import WorkflowPreview from "./app/views/workflow-preview/WorkflowPreview";
 
 
 const config = window.getEnv();
@@ -96,6 +97,8 @@ class Index extends Component {
                                 </Route>
                             </Route>
                             <Route path={`${rootPath}/collections/:collectionID/homepage`} component={userIsAuthenticated(EditHomepageController)} />
+                            <Route path={`${rootPath}/collections/:collectionID/homepage/preview`} component={userIsAuthenticated(WorkflowPreview)} />
+                                
                             <Route path={`${rootPath}/collections/:collectionID/preview`} component={userIsAuthenticated(PreviewController)} />
 
                             {config.enableDatasetImport === true && (


### PR DESCRIPTION
### What

Created a workflow preview component (name can change) that can work as preview for any content type (even datasets as i see that preview moving towards the design of this one) and set up to act as preview for the new homepage publishing journey for this PR.

### How to review

You can access the page directly by going to `/collections/{collection_id}/homepage/preview`

### Who can review

Anyone
