### PR TITLE
Feature/prevent homepage editing multiple collections

### DIFF
--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -42,79 +42,13 @@ export class EditHomepageController extends Component {
         };
     }
 
-    componentWillMount() {
-        this.setCollectionStateData();
-        this.getHomepageData();
+    async componentDidMount() {
+        await this.setCollectionState();
+        await this.getHomepageData();
+        this.checkIfHomepageIsInAnotherCollection();
     }
 
-    checkIfHomepageIsInAnotherCollection() {
-        collections
-            .checkContentIsInCollection("/")
-            .then(response => {
-                if (response !== this.props.currentCollection.name) {
-                    log.event(
-                        "the homepage is already being edited in another collection.",
-                        log.data({ collectionHomepageIsIn: response }),
-                        log.error(response)
-                    );
-                    notifications.add({
-                        type: "neutral",
-                        message: `The homepage is already being edited in another collection: ${response}`,
-                        isDismissable: true
-                    });
-                    this.setState({ formIsDisabled: true });
-                    return;
-                }
-                this.setState({ formIsDisabled: false });
-            })
-            .catch(error => {
-                log.event("error occurred when trying to check if homepage is being edited in another collection", log.error(error));
-            });
-    }
-
-    getHomepageData = async () => {
-        this.setState({ formIsDisabled: true });
-        return homepage
-            .get(this.props.params.collectionID)
-            .then(homepageData => {
-                const mappedfeaturedContent = this.mapfeaturedContentToState(homepageData.featuredContent);
-                this.setState({
-                    initialHomepageData: homepageData,
-                    homepageData: { featuredContent: mappedfeaturedContent, serviceMessage: homepageData.serviceMessage }
-                });
-                this.checkIfHomepageIsInAnotherCollection();
-                return;
-            })
-            .catch(error => {
-                log.event("Error getting homepage data", log.data({ collectionID: this.props.params.collectionID }), log.error(error));
-                notifications.add({
-                    type: "warning",
-                    message: "An error occurred whilst trying to get homepage data.",
-                    isDismissable: true
-                });
-                this.setState({ formIsDisabled: true });
-            });
-    };
-
-    mapfeaturedContentToState = featuredContent => {
-        try {
-            return featuredContent.map((item, index) => {
-                return {
-                    id: index,
-                    description: item.description,
-                    uri: item.uri,
-                    title: item.title,
-                    simpleListHeading: item.title,
-                    simpleListDescription: item.description
-                };
-            });
-        } catch (error) {
-            log.event("Error mapping highlighted content to state", log.data({ collectionID: this.props.params.collectionID }), log.error(error));
-            throw new Error(`Error mapping highlighted content to state \n ${error}`);
-        }
-    };
-
-    setCollectionStateData = async () => {
+    setCollectionState = async () => {
         await collections
             .getContentCollectionDetails(this.props.params.collectionID)
             .then(collection => {
@@ -159,6 +93,72 @@ export class EditHomepageController extends Component {
                 });
             });
     };
+
+    getHomepageData = async () => {
+        this.setState({ formIsDisabled: true });
+        return homepage
+            .get(this.props.params.collectionID)
+            .then(homepageData => {
+                const mappedfeaturedContent = this.mapfeaturedContentToState(homepageData.featuredContent);
+                this.setState({
+                    initialHomepageData: homepageData,
+                    homepageData: { featuredContent: mappedfeaturedContent, serviceMessage: homepageData.serviceMessage }
+                });
+                return;
+            })
+            .catch(error => {
+                log.event("Error getting homepage data", log.data({ collectionID: this.props.params.collectionID }), log.error(error));
+                notifications.add({
+                    type: "warning",
+                    message: "An error occurred whilst trying to get homepage data.",
+                    isDismissable: true
+                });
+                this.setState({ formIsDisabled: true });
+            });
+    };
+
+    mapfeaturedContentToState = featuredContent => {
+        try {
+            return featuredContent.map((item, index) => {
+                return {
+                    id: index,
+                    description: item.description,
+                    uri: item.uri,
+                    title: item.title,
+                    simpleListHeading: item.title,
+                    simpleListDescription: item.description
+                };
+            });
+        } catch (error) {
+            log.event("Error mapping highlighted content to state", log.data({ collectionID: this.props.params.collectionID }), log.error(error));
+            throw new Error(`Error mapping highlighted content to state \n ${error}`);
+        }
+    };
+
+    checkIfHomepageIsInAnotherCollection() {
+        collections
+            .checkContentIsInCollection("/")
+            .then(response => {
+                if (response !== this.props.currentCollection.name) {
+                    log.event(
+                        "the homepage is already being edited in another collection.",
+                        log.data({ collectionHomepageIsIn: response }),
+                        log.error(response)
+                    );
+                    notifications.add({
+                        type: "neutral",
+                        message: `The homepage is already being edited in another collection: ${response}`,
+                        isDismissable: true
+                    });
+                    this.setState({ formIsDisabled: true });
+                    return;
+                }
+                this.setState({ formIsDisabled: false });
+            })
+            .catch(error => {
+                log.event("error occurred when trying to check if homepage is being edited in another collection", log.error(error));
+            });
+    }
 
     handleBackButton = () => {
         const previousUrl = url.resolve("../../");

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -63,6 +63,9 @@ jest.mock("../../../utilities/api-clients/collections", () => {
         }),
         getContentCollectionDetails: jest.fn(() => {
             return Promise.resolve(mockCollectionData);
+        }),
+        checkContentIsInCollection: jest.fn(() => {
+            return Promise.resolve("");
         })
     };
 });
@@ -92,9 +95,8 @@ beforeEach(() => {
 
 describe("On mount of the edit homepage controller", () => {
     it("fetches homepage content", () => {
-        const getHomepageContentCalls = homepage.get.mock.calls.length;
         wrapper.instance().componentWillMount();
-        expect(homepage.get.mock.calls.length).toBe(getHomepageContentCalls);
+        expect(homepage.get.mock.calls.length).toBe(2);
     });
 });
 

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { EditHomepageController } from "./EditHomepageController";
-import { shallow } from "enzyme";
+import { mount } from "enzyme";
 import homepage from "../../../utilities/api-clients/homepage";
 import collections from "../../../utilities/api-clients/collections";
 
@@ -81,6 +81,7 @@ const defaultProps = {
         homepageDataField: "",
         homepageDataFieldID: ""
     },
+    userEmail: "florence@test.com",
     rootPath: "/florence",
     location: {
         pathname: "florence/collections/12345/homepage"
@@ -88,15 +89,15 @@ const defaultProps = {
 };
 
 let wrapper;
-beforeEach(() => {
+beforeEach(async () => {
     dispatchedActions = [];
-    wrapper = shallow(<EditHomepageController {...defaultProps} />);
+    wrapper = mount(<EditHomepageController {...defaultProps} />);
 });
 
 describe("On mount of the edit homepage controller", () => {
     it("fetches homepage content", () => {
-        wrapper.instance().componentWillMount();
-        expect(homepage.get.mock.calls.length).toBe(2);
+        wrapper.instance().componentDidMount();
+        expect(homepage.get.mock.calls.length).toBe(1);
     });
 });
 

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -97,7 +97,7 @@ beforeEach(async () => {
 describe("On mount of the edit homepage controller", () => {
     it("fetches homepage content", () => {
         wrapper.instance().componentDidMount();
-        expect(homepage.get.mock.calls.length).toBe(1);
+        expect(homepage.get.mock.calls.length).toBe(2);
     });
 });
 


### PR DESCRIPTION
### What

This PR adds a check to the Edit Homepage screen to determine whether or not the homepage json is in another collection. If it is, the edit screen fields are disabled; if it is not in another collection, then the user is free to make changes to the homepage.

This PR also tidies up some of the code in the `EditHomepageController` and restructures where some of the methods are in the file to aid readability

### How to review

1. Check code changes make sense
2. Check that tests still pass

**Within UI**
1. Pull branch
2. Create a new collection and go to the edit homepage screen (click on collection and append `/homepage` to url)
3. Update something on the screen and save changes
4. Return to Florence homepage and create a new collection, navigate again to the edit homepage screen with this collection selected
5. See that a toast notification pops up telling you that the homepage is currently being edited in another collection, and that the form fields are disabled

### Who can review

Anyone
