### PR TITLE
Fix/persistent images

### DIFF
--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -135,7 +135,6 @@ export class EditHomepageController extends Component {
     };
 
     mapfeaturedContentToState = featuredContent => {
-        console.log("FEATURED CONTENT:", featuredContent);
         try {
             return featuredContent.map((item, index) => {
                 return {

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -135,12 +135,14 @@ export class EditHomepageController extends Component {
     };
 
     mapfeaturedContentToState = featuredContent => {
+        console.log("FEATURED CONTENT:", featuredContent);
         try {
             return featuredContent.map((item, index) => {
                 return {
                     id: index,
                     description: item.description,
                     uri: item.uri,
+                    image: item.image,
                     title: item.title,
                     simpleListHeading: item.title,
                     simpleListDescription: item.description
@@ -298,7 +300,8 @@ export class EditHomepageController extends Component {
             featuredContent = this.state.homepageData.featuredContent.map(entry => ({
                 title: entry.title,
                 description: entry.description,
-                uri: entry.uri
+                uri: entry.uri,
+                image: entry.image
             }));
             serviceMessage = this.state.homepageData.serviceMessage;
             initialHomepageData = this.state.initialHomepageData;


### PR DESCRIPTION
### What

Persist the `image` reference for featured content entries that is in the initial Zebedee page model response. This is so that the current homepage images aren't changed to defaults if any of their content is edited.

### How to review

- Check code change makes sense
- Upon making any type of edit on the Edit Homepage screen, check the network tab for the POST and confirm that the image reference is being saved in the `featuredContent` array

### Who can review

Anyone but me
