### PR TITLE
added image to the EditHomepageItems so image ID can persist

### DIFF
--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -12,6 +12,7 @@ const propTypes = {
         id: PropTypes.number,
         description: PropTypes.string,
         uri: PropTypes.string,
+        image: PropTypes.string,
         title: PropTypes.string
     }),
     handleSuccessClick: PropTypes.func.isRequired,
@@ -21,10 +22,10 @@ const propTypes = {
 export default class EditHomepageItem extends Component {
     constructor(props) {
         super(props);
-
         this.state = {
             id: this.props.data ? this.props.data.id : null,
             description: this.props.data ? this.props.data.description : "",
+            image: this.props.data ? this.props.data.image : "",
             uri: this.props.data ? this.props.data.uri : "",
             title: this.props.data ? this.props.data.title : ""
         };


### PR DESCRIPTION
### What

Add `image` to the `EditHomepageItem` props so that the property is stored when editing/adding a new homepage featured content entry

### How to review

Check the image property persists when saving an edited homepage field

### Who can review

Anyone but me
