### PR TITLE
Add new create content journey

### DIFF
--- a/src/app/components/simple-selectable-list/SimpleSelectableList.jsx
+++ b/src/app/components/simple-selectable-list/SimpleSelectableList.jsx
@@ -9,6 +9,7 @@ const propTypes = {
             title: PropTypes.string.isRequired,
             id: PropTypes.string.isRequired,
             url: PropTypes.string.isRequired,
+            externalLink: PropTypes.bool,
             details: PropTypes.arrayOf(PropTypes.string)
         })
     ).isRequired,

--- a/src/app/components/simple-selectable-list/SimpleSelectableListItem.jsx
+++ b/src/app/components/simple-selectable-list/SimpleSelectableListItem.jsx
@@ -20,21 +20,31 @@ export default class SimpleSelectableListItem extends Component {
         super(props);
     }
 
+    renderTitle = () => {
+        if (this.props.disabled) {
+            return <p className="simple-select-list__title simple-select-list__title--disabled">{this.props.title}</p>;
+        }
+
+        if (this.props.externalLink) {
+            return (
+                <a href={this.props.url}>
+                    <p className="simple-select-list__title">{this.props.title}</p>
+                </a>
+            );
+        }
+
+        return (
+            <Link to={this.props.url}>
+                <p className="simple-select-list__title">{this.props.title}</p>
+            </Link>
+        );
+    };
+
     render() {
         const details = this.props.details || [];
         return (
             <li className="simple-select-list__item">
-                {this.props.disabled ? (
-                    <p className="simple-select-list__title simple-select-list__title--disabled">{this.props.title}</p>
-                ) : this.props.externalLink ? (
-                    <a href={this.props.url}>
-                        <p className="simple-select-list__title">{this.props.title}</p>
-                    </a>
-                ) : (
-                    <Link to={this.props.url}>
-                        <p className="simple-select-list__title">{this.props.title}</p>
-                    </Link>
-                )}
+                {this.renderTitle()}
                 {details.map((detail, i) => {
                     return <p key={`detail-${i}`}>{detail}</p>;
                 })}

--- a/src/app/components/simple-selectable-list/SimpleSelectableListItem.jsx
+++ b/src/app/components/simple-selectable-list/SimpleSelectableListItem.jsx
@@ -6,8 +6,13 @@ const propTypes = {
     title: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
+    externalLink: PropTypes.bool.isRequired,
     details: PropTypes.arrayOf(PropTypes.string),
     disabled: PropTypes.bool
+};
+
+const defaultProps = {
+    externalLink: false
 };
 
 export default class SimpleSelectableListItem extends Component {
@@ -21,6 +26,10 @@ export default class SimpleSelectableListItem extends Component {
             <li className="simple-select-list__item">
                 {this.props.disabled ? (
                     <p className="simple-select-list__title simple-select-list__title--disabled">{this.props.title}</p>
+                ) : this.props.externalLink ? (
+                    <a href={this.props.url}>
+                        <p className="simple-select-list__title">{this.props.title}</p>
+                    </a>
                 ) : (
                     <Link to={this.props.url}>
                         <p className="simple-select-list__title">{this.props.title}</p>
@@ -35,3 +44,4 @@ export default class SimpleSelectableListItem extends Component {
 }
 
 SimpleSelectableListItem.propTypes = propTypes;
+SimpleSelectableListItem.defaultProps = defaultProps;

--- a/src/app/views/collections/details/CollectionDetails.jsx
+++ b/src/app/views/collections/details/CollectionDetails.jsx
@@ -369,26 +369,9 @@ export class CollectionDetails extends Component {
                 <div className="grid grid--justify-space-around">
                     <div className="grid__col-8 grid--align-start margin-top--1 margin-bottom--1">
                         <div>
-                            <a
-                                href={url.resolve("/workspace") + "?collection=" + this.props.id}
-                                className={"btn btn--primary" + (this.props.isLoadingNameAndDate ? " btn--disabled" : "")}
-                            >
-                                Create/edit page
-                            </a>
-                            {this.props.enableDatasetImport && (
-                                <Link id="import-dataset-link" to={`${location.pathname}/datasets`} className="btn btn--primary btn--margin-left">
-                                    Create/edit CMD dataset page
-                                </Link>
-                            )}
-                            {this.props.enableHomepagePublishing && (
-                                <Link
-                                    id="edit-homepage"
-                                    to={`/florence/collections/${this.props.id}/homepage`}
-                                    className="btn btn--primary btn--margin-left"
-                                >
-                                    Edit Homepage
-                                </Link>
-                            )}
+                            <Link id="create-edit-content" to={`${location.pathname}/create`} className="btn btn--primary">
+                                Create/edit content
+                            </Link>
                             <button
                                 disabled={this.props.isLoadingNameAndDate}
                                 className="btn btn--margin-left"

--- a/src/app/views/collections/details/CollectionDetails.test.js
+++ b/src/app/views/collections/details/CollectionDetails.test.js
@@ -386,25 +386,3 @@ describe("Delete collection button", () => {
         expect(component.find("#delete-collection").exists()).toEqual(false);
     });
 });
-
-describe("Dataset import functionality", () => {
-    it("doesn't display when it is disabled in props", () => {
-        const props = {
-            ...defaultProps,
-            enableDatasetImport: false
-        };
-        const component = shallow(<CollectionDetails {...props} />);
-
-        expect(component.find("#import-dataset-link").exists()).toBe(false);
-    });
-
-    it("displays when it is enabled in props", () => {
-        const props = {
-            ...defaultProps,
-            enableDatasetImport: true
-        };
-        const component = shallow(<CollectionDetails {...props} />);
-
-        expect(component.find("#import-dataset-link").exists()).toBe(true);
-    });
-});

--- a/src/app/views/content/CreateContent.jsx
+++ b/src/app/views/content/CreateContent.jsx
@@ -1,0 +1,84 @@
+import React, { Component } from "react";
+import { push } from "react-router-redux";
+import PropTypes from "prop-types";
+
+import url from "../../utilities/url";
+
+import SimpleSelectableList from "../../components/simple-selectable-list/SimpleSelectableList";
+import Input from "../../components/Input";
+
+const propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    location: PropTypes.shape({
+        pathname: PropTypes.string.isRequired
+    }).isRequired
+};
+
+export class CreateContent extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            contentTypes: [
+                {
+                    title: "Old workspace",
+                    id: "workspace",
+                    details: ["Create/edit content via the old workspace"],
+                    url: `${url.resolve("../../../")}/workspace?collection=${this.props.params.collectionID}`,
+                    externalLink: true
+                },
+                {
+                    title: "Filterable dataset",
+                    id: "cmd-filterable-datasets",
+                    details: ["Create/edit datasets and/or versions for filterable (CMD) datasets"],
+                    url: url.resolve("../") + "/datasets"
+                },
+                {
+                    title: "Homepage",
+                    id: "homepage",
+                    url: url.resolve("../") + "/homepage"
+                }
+            ],
+            filteredContentTypes: [],
+            searchTerm: ""
+        };
+    }
+
+    handleBackButton = () => {
+        const previousUrl = url.resolve("../");
+        this.props.dispatch(push(previousUrl));
+    };
+
+    handleSearchInput = event => {
+        const searchTerm = event.target.value.toLowerCase();
+        const filteredContentTypes = this.state.contentTypes.filter(
+            contentType => contentType.title.toLowerCase().search(searchTerm) !== -1 || contentType.id.toLowerCase().search(searchTerm) !== -1
+        );
+        this.setState({
+            filteredContentTypes,
+            searchTerm
+        });
+    };
+
+    render() {
+        return (
+            <div className="grid grid--justify-center">
+                <div className="grid__col-9">
+                    <div className="margin-top--2">
+                        &#9664;{" "}
+                        <button type="button" className="btn btn--link" onClick={this.handleBackButton}>
+                            Back
+                        </button>
+                    </div>
+                    <h1 className="margin-top--1 margin-bottom--1">Select a content type to create/edit</h1>
+                    <Input id="search-content-types" placeholder="Search by name" onChange={this.handleSearchInput} />
+                    <SimpleSelectableList rows={this.state.filteredContentTypes.length ? this.state.filteredContentTypes : this.state.contentTypes} />
+                </div>
+            </div>
+        );
+    }
+}
+
+CreateContent.propTypes = propTypes;
+
+export default CreateContent;

--- a/src/app/views/content/CreateContent.test.js
+++ b/src/app/views/content/CreateContent.test.js
@@ -1,0 +1,62 @@
+import React from "react";
+import { CreateContent } from "./CreateContent";
+import { shallow, mount } from "enzyme";
+import url from "../../utilities/url";
+
+console.error = () => {};
+
+jest.mock("../../utilities/url", () => {
+    return {
+        resolve: function() {}
+    };
+});
+
+const contentTypes = [
+    {
+        title: "Bulletin",
+        id: "content-type-1",
+        url: url.resolve("../") + "/bulletins"
+    },
+    {
+        title: "Dataset",
+        id: "dataset-cmd",
+        url: url.resolve("../") + "/datasets"
+    },
+    {
+        title: "Static content",
+        id: "static-content",
+        url: url.resolve("../") + "/static"
+    }
+];
+
+const defaultProps = {
+    dispatch: event => {
+        dispatchedActions.push(event);
+    },
+    rootPath: "/florence",
+    params: {
+        collectionID: "test-collection"
+    },
+    location: {
+        pathname: "florence/collections/12345/datasets"
+    }
+};
+
+const mountComponent = () => {
+    return mount(<CreateContent {...defaultProps} />);
+};
+
+let component;
+
+beforeEach(() => {
+    component = mountComponent();
+});
+
+it("handle search returns correct results", () => {
+    component.setState({ contentTypes });
+    component.instance().handleSearchInput({ target: { value: "bulletin" } });
+    expect(component.state().filteredContentTypes[0]).toBe(contentTypes[0]);
+    component.instance().handleSearchInput({ target: { value: "cmd" } });
+    expect(component.state().filteredContentTypes[0]).toBe(contentTypes[1]);
+    //expect(component.state().datasets.length).toBe(mockedAllDatasets.length + 1);
+});

--- a/src/app/views/content/CreateContent.test.js
+++ b/src/app/views/content/CreateContent.test.js
@@ -58,5 +58,4 @@ it("handle search returns correct results", () => {
     expect(component.state().filteredContentTypes[0]).toBe(contentTypes[0]);
     component.instance().handleSearchInput({ target: { value: "cmd" } });
     expect(component.state().filteredContentTypes[0]).toBe(contentTypes[1]);
-    //expect(component.state().datasets.length).toBe(mockedAllDatasets.length + 1);
 });

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ import ChangeUserPasswordController from "./app/views/users/change-password/Chan
 import ConfirmUserDeleteController from "./app/views/users/confirm-delete/ConfirmUserDeleteController";
 import CollectionRoutesWrapper from "./app/global/collection-wrapper/CollectionRoutesWrapper";
 import WorkflowPreview from "./app/views/workflow-preview/WorkflowPreview";
+import CreateContent from "./app/views/content/CreateContent";
 
 
 const config = window.getEnv();
@@ -108,6 +109,8 @@ class Index extends Component {
                             <Route path={`${rootPath}/collections/:collectionID/homepage/preview`} component={userIsAuthenticated(WorkflowPreview)} />
                                 
                             <Route path={`${rootPath}/collections/:collectionID/preview`} component={userIsAuthenticated(PreviewController)} />
+
+                            <Route path={`${rootPath}/collections/:collectionID/create`} component={userIsAuthenticated(userIsAdminOrEditor(CreateContent))} />
 
                             {config.enableDatasetImport === true && (
                                 <Route component={CollectionRoutesWrapper}>


### PR DESCRIPTION
### What

- Added new create content journey

### How to review

- Content creation buttons such as "create/edit page", "edit homepage" etc should be replace by new "Create/edit content" button
- New content create journey page should link correctly to content types. 
- Create/edit some workspace content and check it saves to collection correctly
- Edit homepage and check it saves to collection correctly

### Who can review

Anyone
