### PR TITLE
update table-builder version

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -6259,9 +6259,9 @@
       }
     },
     "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -6303,40 +6303,39 @@
       }
     },
     "dp-table-builder-ui": {
-      "version": "1.0.20",
-      "resolved": "https://registry.npmjs.org/dp-table-builder-ui/-/dp-table-builder-ui-1.0.20.tgz",
-      "integrity": "sha512-YBa/KPxzo4s2xTNuziqUD9ZngCrmeIZyGrFYPQrJpWIvwAZ7PAeZdZkGMItcSoePbhC+bmdAs2RDH1AP0YJSHw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/dp-table-builder-ui/-/dp-table-builder-ui-1.1.0.tgz",
+      "integrity": "sha512-mApkk5UBSNd+CgV/HkqIOMbo76+UTNgnG6Dorj+9WsuDvpfan3wZDYBEnoWk7RYGqywcljS0kxBkJDVaDrIOFQ==",
       "requires": {
         "babel-polyfill": "^6.26.0",
         "cross-env": "5.1.2",
         "file-saver": "^1.3.3",
-        "react": "16.2.0",
-        "react-dom": "16.2.0",
+        "react": "16.13.1",
+        "react-dom": "16.13.1",
         "react-handsontable": "^0.3.1",
         "react-hot-loader": "4.0.0-beta.1",
         "react-router-dom": "4.2.2"
       },
       "dependencies": {
         "react": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
-          "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+          "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
           "requires": {
-            "fbjs": "^0.8.16",
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
-            "prop-types": "^15.6.0"
+            "prop-types": "^15.6.2"
           }
         },
         "react-dom": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
-          "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
           "requires": {
-            "fbjs": "^0.8.16",
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1",
-            "prop-types": "^15.6.0"
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
           }
         }
       }
@@ -8188,19 +8187,12 @@
       }
     },
     "global": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
-      "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
-        "process": "~0.5.1"
-      },
-      "dependencies": {
-        "process": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-          "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
-        }
+        "process": "^0.11.10"
       }
     },
     "global-modules": {
@@ -10566,9 +10558,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
@@ -10628,9 +10620,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.29.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.0.tgz",
+      "integrity": "sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -11550,12 +11542,9 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "pikaday": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.7.0.tgz",
-      "integrity": "sha512-b1z65oFulNTKOdcg9+wTnZWBzfekf1AqPMCmmK9qH6aT7stqDyh76G6nLeuYr3WqchjW/7QLOBFmok14sCecsA==",
-      "requires": {
-        "moment": "2.x"
-      }
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pikaday/-/pikaday-1.8.0.tgz",
+      "integrity": "sha512-SgGxMYX0NHj9oQnMaSyAipr2gOrbB4Lfs/TJTb6H6hRHs39/5c5VZi73Q8hr53+vWjdn6HzkWcj8Vtl3c9ziaA=="
     },
     "pinkie": {
       "version": "2.0.4",
@@ -12028,9 +12017,9 @@
       }
     },
     "react-handsontable": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/react-handsontable/-/react-handsontable-0.3.1.tgz",
-      "integrity": "sha1-UDIg7FvTuYqZuaalsuGIuQ1Hzm4=",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/react-handsontable/-/react-handsontable-0.3.2.tgz",
+      "integrity": "sha512-mMCNDe1yW0av9aroHW4auMLfFp+gbOC7QSW9F1pdQbI5EXuBz6rML/lBkgN6bwdMclSNRp05o1O9wMw7mUmSKA==",
       "requires": {
         "handsontable": "^0.33.0",
         "moment": "^2.17.1",
@@ -12169,15 +12158,16 @@
       },
       "dependencies": {
         "history": {
-          "version": "4.7.2",
-          "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
-          "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+          "version": "4.10.1",
+          "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+          "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
           "requires": {
-            "invariant": "^2.2.1",
+            "@babel/runtime": "^7.1.2",
             "loose-envify": "^1.2.0",
-            "resolve-pathname": "^2.2.0",
-            "value-equal": "^0.4.0",
-            "warning": "^3.0.0"
+            "resolve-pathname": "^3.0.0",
+            "tiny-invariant": "^1.0.2",
+            "tiny-warning": "^1.0.0",
+            "value-equal": "^1.0.1"
           }
         },
         "isarray": {
@@ -12186,25 +12176,35 @@
           "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "path-to-regexp": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
-          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
           "requires": {
             "isarray": "0.0.1"
           }
         },
         "react-router": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
-          "integrity": "sha512-DY6pjwRhdARE4TDw7XjxjZsbx9lKmIcyZoZ+SDO7SBJ1KUeWNxT22Kara2AC7u6/c2SYEHlEDLnzBCcNhLE8Vg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+          "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
           "requires": {
             "history": "^4.7.2",
-            "hoist-non-react-statics": "^2.3.0",
-            "invariant": "^2.2.2",
+            "hoist-non-react-statics": "^2.5.0",
+            "invariant": "^2.2.4",
             "loose-envify": "^1.3.1",
             "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.5.4",
-            "warning": "^3.0.0"
+            "prop-types": "^15.6.1",
+            "warning": "^4.0.1"
+          },
+          "dependencies": {
+            "warning": {
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+              "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+              "requires": {
+                "loose-envify": "^1.0.0"
+              }
+            }
           }
         }
       }
@@ -12757,9 +12757,9 @@
       "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
     },
     "resolve-pathname": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-2.2.0.tgz",
-      "integrity": "sha512-bAFz9ld18RzJfddgrO2e/0S2O81710++chRMUxHjXOYKF6jTAMrUNZrEZ1PvV0zlhfjidm08iRPdTLPno1FuRg=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -13107,6 +13107,15 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
+    },
+    "scheduler": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "schema-utils": {
       "version": "1.0.0",
@@ -13626,9 +13635,9 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
     "sourcemapped-stacktrace": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.9.tgz",
-      "integrity": "sha512-N6SLOT+9OQZdoSpu1PkSjyrxx/B2SGom9LuxjbwZFNNz7+FpMEUpwb3JV+UpaxWvoGM/8k7guuOJxcB6BWEU9Q==",
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.11.tgz",
+      "integrity": "sha512-O0pcWjJqzQFVsisPlPXuNawJHHg9N9UgpJ/aDmvi9+vnS3x1C0NhwkVFzzZ1VN0Xo+bekyweoqYvBw5ZBKiNnQ==",
       "requires": {
         "source-map": "0.5.6"
       },
@@ -14458,6 +14467,16 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tinyqueue": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
@@ -14856,9 +14875,9 @@
       }
     },
     "value-equal": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-0.4.0.tgz",
-      "integrity": "sha512-x+cYdNnaA3CxvMaTX0INdTCN8m8aF2uY9BvEqmxuYp8bL09cs/kWVQPVGcA35fMktdOsP69IgU7wFj/61dJHEw=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/src/package.json
+++ b/src/package.json
@@ -75,7 +75,7 @@
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.5.1",
     "dateformat": "^2.0.0",
-    "dp-table-builder-ui": "^1.0.20",
+    "dp-table-builder-ui": "^1.1.0",
     "file-loader": "^3.0.1",
     "install": "^0.8.7",
     "is-empty-object": "^1.1.1",


### PR DESCRIPTION
### What

Bump `dp-table-builder-ui` package: `1.0.20` => `1.1.0`

This update includes the column/row headers validation work for the table-builder. The validation rules applied should ensure table headings are more appropriate for accessibility

### How to review

Pull changes, run `npm install dp-table-builder-ui` and test that the validation works locally.

You can access the table builder module by going to the old workspace in a collection and opening an article. Click to edit its contents so the markdown editor appears, and click on the table icon to open up the module.

### Who can review

Anyone
