### PR TITLE
Fix/visualisations preview

### DIFF
--- a/src/legacy/js/functions/_createWorkspace.js
+++ b/src/legacy/js/functions/_createWorkspace.js
@@ -342,18 +342,6 @@ function updateBrowserURL(url) {
         url = Florence.globalVars.pagePath;
     }
     $('.browser-location').val(Florence.babbageBaseUrl + url);
-
-    // Disable preview for visualisations
-    var isVisualisation = url.split('/')[1] === "visualisations";
-    if (isVisualisation && $('#browse.selected').length > 0) {
-        $('.browser').addClass('disabled');
-        return;
-    }
-
-    // Enable the preview if we're viewing a normal page and the preview is currently disabled
-    if ($('.browser.disabled').length > 0) {
-        $('.browser.disabled').removeClass('disabled');
-    }
 }
 
 // toggle delete button from 'delete' to 'revert' for content marked as to be deleted and remove/show other buttons in item

--- a/src/legacy/js/functions/_loadPageDataIntoEditor.js
+++ b/src/legacy/js/functions/_loadPageDataIntoEditor.js
@@ -7,23 +7,7 @@
 
 function loadPageDataIntoEditor(path, collectionId, click) {
 
-    if (Florence.globalVars.welsh) {
-        if (path === '/') {       //add whatever needed to read content in Welsh
-            var pageUrlData = path + '&lang=cy';
-            var toApproveUrlData = '/data_cy.json';
-        } else {
-            var pageUrlData = path + '&lang=cy';
-            var toApproveUrlData = path + '/data_cy.json';
-        }
-    } else {
-        if (path === '/') {       //add whatever needed to read content in English
-            var pageUrlData = path;
-            var toApproveUrlData = '/data.json';
-        } else {
-            var pageUrlData = path;
-            var toApproveUrlData = path + '/data.json';
-        }
-    }
+    var { pageUrlData, toApproveUrlData } = buildUrls(path)
 
     var pageData, isPageComplete;
     var ajaxRequests = [];
@@ -62,4 +46,75 @@ function loadPageDataIntoEditor(path, collectionId, click) {
             renderAccordionSections(collectionId, pageData, isPageComplete);
         }
     });
+}
+
+function loadVisualisationPreviewer(path, collectionId, click) {
+
+    var { pageUrlData, toApproveUrlData } = buildUrls(path)
+    
+
+    var pageData, isPageComplete;
+    var ajaxRequests = [];
+    ajaxRequests.push(
+        getPageData(collectionId, pageUrlData,
+            success = function (response) {
+                pageData = response;
+            },
+            error = function (response) {
+                handleApiError(response);
+            }
+        )
+    );
+
+    ajaxRequests.push(
+        getCollection(collectionId,
+            success = function (response) {
+                var lastCompletedEvent = getLastCompletedEvent(response, toApproveUrlData);
+                isPageComplete = !(!lastCompletedEvent || lastCompletedEvent.email === Florence.Authentication.loggedInEmail());
+            },
+            error = function (response) {
+                handleApiError(response);
+            })
+    );
+
+    $.when.apply($, ajaxRequests).then(function () {
+        if (click) {
+            var iframe = getPreviewUrl();
+            if (iframe !== pageData.uri) {
+                setTimeout(loadVisualisationPreviewer(path, collectionId), 200);
+            } else {
+                visualisationEditor(collectionId, pageData);
+            }
+        } else {
+            visualisationEditor(collectionId, pageData);
+        }
+    });
+}
+
+function buildUrls(path) {
+    if (Florence.globalVars.welsh) {
+        if (path === '/') {       //add whatever needed to read content in Welsh
+            return {
+                pageUrlData: path + '&lang=cy',
+                toApproveUrlData: '/data_cy.json'
+            }
+        } else {
+            return {
+                pageUrlData: path + '&lang=cy',
+                toApproveUrlData: path + '/data_cy.json'
+            }
+        }
+    } else {
+        if (path === '/') {       //add whatever needed to read content in English
+            return {
+                pageUrlData: path,
+                toApproveUrlData: '/data.json'
+            }
+        } else {
+            return {
+                pageUrlData: path,
+                toApproveUrlData: path + '/data.json'
+            }
+        }
+    }
 }

--- a/src/legacy/js/functions/_loadPageDataIntoEditor.js
+++ b/src/legacy/js/functions/_loadPageDataIntoEditor.js
@@ -52,7 +52,6 @@ function loadVisualisationPreviewer(path, collectionId, click) {
 
     var { pageUrlData, toApproveUrlData } = buildUrls(path)
     
-
     var pageData, isPageComplete;
     var ajaxRequests = [];
     ajaxRequests.push(

--- a/src/legacy/js/functions/_treeNodeSelect.js
+++ b/src/legacy/js/functions/_treeNodeSelect.js
@@ -5,6 +5,14 @@ function treeNodeSelect(url) {
     $('.js-browse__item.selected').removeClass('selected');
     $selectedListItem.addClass('selected');
 
+    var selectWrapper = $('#select-vis-wrapper');
+    if (isVisualisation($selectedListItem)) {
+        loadVisualisationPreviewer($selectedListItem.attr('data-url'), Florence.collection.id)
+    } else if (selectWrapper) {
+        selectWrapper.hide();
+        $('#browser-location').show();
+    }
+
     // Hide container for item and buttons for previous and show selected one
     $('.page__container.selected').removeClass('selected');
     $selectedListItem.find('.page__container:first').addClass('selected');
@@ -25,4 +33,8 @@ function treeNodeSelect(url) {
 
     // Open active directories
     selectParentDirectories($selectedListItem);
+}
+
+function isVisualisation(node) {
+    return node.attr("data-url").split("/").includes("visualisations")
 }

--- a/src/legacy/js/functions/_treeNodeSelect.js
+++ b/src/legacy/js/functions/_treeNodeSelect.js
@@ -5,6 +5,8 @@ function treeNodeSelect(url) {
     $('.js-browse__item.selected').removeClass('selected');
     $selectedListItem.addClass('selected');
 
+    // Check to see if the user has selected a visualisation. If so, start the process of fetching visualisation data 
+    // and rendering the select element so users can preview the visualisation without having to go to the Edit screen
     var selectWrapper = $('#select-vis-wrapper');
     if (isVisualisation($selectedListItem)) {
         loadVisualisationPreviewer($selectedListItem.attr('data-url'), Florence.collection.id)

--- a/src/legacy/js/functions/_visualisationEditor.js
+++ b/src/legacy/js/functions/_visualisationEditor.js
@@ -31,7 +31,6 @@ function visualisationEditor(collectionId, data) {
     $selectWrapper.find('select').empty().append(selectOptions.join(''));
     $selectWrapper.show();
     $('#browser-location').hide();
-    // $('.browser.disabled').removeClass('disabled');
 
     // Bind to select's change and toggle preview to selected HTML file
     $('#select-vis-preview').change(function() {
@@ -42,7 +41,6 @@ function visualisationEditor(collectionId, data) {
     $('#browse').one('click', function() {
         $selectWrapper.hide();
         $('#browser-location').show();
-        $('.browser').addClass('disabled');
         var browseURL = data.uri;
         $('#iframe').attr('src', Florence.babbageBaseUrl + browseURL);
         updateBrowserURL(browseURL);

--- a/src/legacy/js/functions/_visualisationEditor.js
+++ b/src/legacy/js/functions/_visualisationEditor.js
@@ -25,9 +25,17 @@ function visualisationEditor(collectionId, data) {
     var selectOptions = ["<option value=''>-- Select an HTML file to preview --</option>"],
         $selectWrapper = $('#select-vis-wrapper');
 
-    for (i = 0; i < data.filenames.length; i++) {
-        selectOptions.push("<option value='" + data.filenames[i] + "'>" + data.filenames[i] + "</option>")
+    if (data.filenames.length > 0) {
+        for (i = 0; i < data.filenames.length; i++) {
+            if (i === 0) {
+                selectOptions.push("<option value='" + data.filenames[i] + "' selected>" + data.filenames[i] + "</option>")
+            } else {
+                selectOptions.push("<option value='" + data.filenames[i] + "'>" + data.filenames[i] + "</option>")
+            }
+        }
+        refreshVisPreview("/" + data.filenames[0])
     }
+
     $selectWrapper.find('select').empty().append(selectOptions.join(''));
     $selectWrapper.show();
     $('#browser-location').hide();
@@ -37,7 +45,7 @@ function visualisationEditor(collectionId, data) {
         refreshVisPreview("/" + $(this).val());
     });
 
-    // Disable preview when navigating back to browse tab
+    // Hide preview select element and re-display the browser URL when navigating away from the visualisation
     $('#browse').one('click', function() {
         $selectWrapper.hide();
         $('#browser-location').show();


### PR DESCRIPTION
### What

There would be a bug where an overlay would applied to the preview screen in the old workspace, when moving from a visualisations page to a non-vis one in the browse tree. This PR fixes that and also updates the logic so that users will be able to go through the various html files in a visualisation upload from the browse tree rather than having to go to the Edit Visualisations page

The implementation specifically is as follows:

- A new conditional in the `treeNodeSelect` function checks to see whether the user has clicked on a visualisation in the browse tree, determined by the value of the `data-url` attribute
- If it is a visualisation selected, then a new function is called that fetches the visualisation data, which then in turn calls the `visualisationEditor` function that renders the `<select>` element in lieu of the URL field on the preview screen
- The logic in this function has been tweaked slightly to ensure that the first html file in the visualisation is selected by default, too. Previously, visualisations would look incomplete / improperly loaded when viewing from the browse screen
- Code related to the overlay has been removed as it no longer seems to serve a purpose

#### Before

A visualisation page on the browse screen:
![image](https://user-images.githubusercontent.com/23668262/97297686-41789480-184a-11eb-9543-298c80a2e9b8.png)

Going to a non-vis page after being on the Edit Vis screen:
![image](https://user-images.githubusercontent.com/23668262/97297786-67059e00-184a-11eb-9bd3-27b72cba8e71.png)

#### After

Visualisations can now be previewed from the browse tree (URL changes to a select dropdown)
![image](https://user-images.githubusercontent.com/23668262/97297900-8d2b3e00-184a-11eb-9440-dda32dabe740.png)

Navigating to a non-vis page afterwards no longer has the obscuring overlay
![image](https://user-images.githubusercontent.com/23668262/97297978-ad5afd00-184a-11eb-8448-5acd50434264.png)

### How to review

- Ensure code changes make sense
- I extracted some logic into its own function for reuse. I've been able to upload a visualisation and approve a collection with a mix of visualisations and non-vis pages, and that all works as intended. It may be worthwhile having another set of eyes on this, though

### Who can review

Anyone familiar with Florence
