### PR TITLE
Data visualisations were saving title in the wrong order

### DIFF
--- a/src/legacy/js/functions/_loadEmbedIframe.js
+++ b/src/legacy/js/functions/_loadEmbedIframe.js
@@ -34,7 +34,7 @@ function loadEmbedIframe(onSave) {
             embedUrl = parsedEmbedUrl.pathname;
         }
 
-        onSave('<ons-interactive url="' + embedUrl + '" title="'+ embedTitle +'" full-width="' + fullWidth + '"/>');
+        onSave('<ons-interactive url="' + embedUrl + '" full-width="' + fullWidth + '" title="' + embedTitle + '"/>');
         modal.remove();
 
     }

--- a/src/legacy/package.json
+++ b/src/legacy/package.json
@@ -9,7 +9,7 @@
         "cat": "latest",
         "onchange": "latest",
         "handlebars": "4.7.3",
-        "node-sass": "latest"
+        "node-sass": "^4.13.1"
     },
     "scripts": {
         "watch-js": "npm run build-js && ./node_modules/onchange/cli.js 'js/classes/*.js' 'js/functions/*.js' 'js/components/*.js' 'js/zebedee-api/*.js' -v -- npm run build-js",


### PR DESCRIPTION
### What

Babbage relies on full-width being the second argument and title being the third in the string. At the moment visulisation are being incorrectly saved on disk corrupting the title and not allowing the full-width usage. The longer this goes unfixed the more data fixes required.

### How to review

#### Below is a rough guide
1. Go into Florence
2. Create a new article (or any page type that accepts vis content)
3. Edit the content section and then click add visualisation
4. Go to the ONS website and find an article that has a visualisation on it.
5. append the URL with /data
6. Search the JSON for the visualisation
7. copy the URL of it
8. go back to Florence and under the URL field for the visualisation paste the copied URL
9. tick the box 'make full-width'
10. continue to publish the content
11. Go to the content locally via web
12. Open up the DOM 
13. Go to the visualisation on the DOM
14. Check that the class 'pym-interactive--full-width' has been added

Repeat but without the full-width checkbox being selected and check that the class has not been added to the element

### Who can review

Anyone except me
