### PR TITLE
Update publish queue screen to use 'light' collection details endpoint

### DIFF
--- a/src/legacy/js/functions/_viewPublishDetails.js
+++ b/src/legacy/js/functions/_viewPublishDetails.js
@@ -13,7 +13,7 @@ function viewPublishDetails(collections) {
     $.each(collections, function (i, collectionId) {
         onlyOne += 1;
         pageDataRequests.push(
-            getCollectionDetails(collectionId,
+            getPublishingQueueCollectionDetails(collectionId,
                 success = function (response) {
                     if (result.date === manual) {
                         result.collectionDetails.push({

--- a/src/legacy/js/zebedee-api/_getCollection.js
+++ b/src/legacy/js/zebedee-api/_getCollection.js
@@ -25,3 +25,17 @@ function getCollectionDetails(collectionId, success, error) {
     }
   });
 }
+
+function getPublishingQueueCollectionDetails(collectionId, success, error) {
+  return $.ajax({
+    url: "/zebedee/publishingQueueCollectionDetails/" + collectionId,
+    dataType: 'json',
+    type: 'GET',
+    success: function (response) {
+      success(response);
+    },
+    error: function (response) {
+      error(response);
+    }
+  });
+}


### PR DESCRIPTION
### What
The original endpoint listed all files in the collection, which prevented the screen from loading for sufficiently large collections.

### How to review
Sanity check / test using https://github.com/ONSdigital/zebedee/pull/370
### Who can review
Anyone (Jon :trollface: )
