### PR TITLE
Fix publishing queue collections details failures

### DIFF
--- a/src/legacy/js/functions/_viewPublishDetails.js
+++ b/src/legacy/js/functions/_viewPublishDetails.js
@@ -35,8 +35,12 @@ function viewPublishDetails(collections) {
                         });
                     }
                 },
-                error = function (response) {
-                    handleApiError(response);
+                error = function () {
+                    result.collectionDetails.push({
+                        id: getCollectionIDWithoutUUID(collectionId),
+                        error: true,
+                        pageType: result.date === manual ? "manual" : ""
+                    })
                 }
             )
         );
@@ -48,7 +52,13 @@ function viewPublishDetails(collections) {
         result.subtitle = 'The following collections have been approved';
     }
 
-    $.when.apply($, pageDataRequests).then(function () {
+    Promise.allSettled(pageDataRequests).then(() => {
+        displayPublishDetailsPanel()
+    }).catch(err => {
+        handleApiError(err);
+    })
+
+    function displayPublishDetailsPanel() {
         var publishDetails = templates.publishDetails(result);
         $('.panel--off-canvas').html(publishDetails);
         bindAccordions();
@@ -108,5 +118,10 @@ function viewPublishDetails(collections) {
 
             hidePanel(hidePanelOptions);
         });
-    });
+    }
+
+    // return collection id without unique identifier on the end
+    function getCollectionIDWithoutUUID(collectionID) {
+        return collectionID.split("-")[0]
+    }
 }

--- a/src/legacy/templates/publishDetails.handlebars
+++ b/src/legacy/templates/publishDetails.handlebars
@@ -8,67 +8,72 @@
         {{#each collectionDetails}}
             <div class="accordion js-accordion">
                 <div class="accordion__title js-accordion__title">
-                    <h3 class="collection-name" data-id="{{id}}">{{name}}</h3>
+                    <h3 class="collection-name" data-id="{{id}}">{{#if name}}{{name}}{{else}}{{id}}{{/if}}</h3>
                 </div>
                 <div class="accordion__content accordion__content--padded disable-animation js-accordion__content">
                     {{#if pageType}}
-                        <button class="btn btn--positive margin-top--1 margin-bottom--0 btn-collection-publish">Publish collection</button>
+                            <button class="btn btn--positive margin-top--1 margin-bottom--0 btn-collection-publish">Publish collection</button>
                     {{/if}}
                     <button class="btn btn--primary margin-top--1 margin-bottom--0 btn-collection-unlock">Unlock collection</button>
-                    {{#if_any pageDetails datasets datasetVersions}}
-                        <h4>Approved pages in this collection</h4>
-                        <ul class="page-list">
-                            {{#if pageDetails}}
-                                {{#each pageDetails}}
-                                    <li class="page-list__item"><span class="page__item page__item--{{type}}"
-                                              data-path="{{uri}}">{{description.title}}{{#if description.edition}}
-                                        : {{description.edition}}{{/if}}</span>
-                                        <div class="page__buttons page__buttons--list">
-                                            <button class="btn btn--warning btn-page-delete">Remove from this publish</button>
-                                        </div>
+                    {{#if error}} 
+                        <p>This collection details has failed to load.</p>
+                    {{else}}
+                        
+                        {{#if_any pageDetails datasets datasetVersions}}
+                            <h4>Approved pages in this collection</h4>
+                            <ul class="page-list">
+                                {{#if pageDetails}}
+                                    {{#each pageDetails}}
+                                        <li class="page-list__item"><span class="page__item page__item--{{type}}"
+                                                data-path="{{uri}}">{{description.title}}{{#if description.edition}}
+                                            : {{description.edition}}{{/if}}</span>
+                                            <div class="page__buttons page__buttons--list">
+                                                <button class="btn btn--warning btn-page-delete">Remove from this publish</button>
+                                            </div>
+                                        </li>
+                                    {{/each}}
+                                {{/if}}
+                                {{#if datasets}}
+                                    {{#each datasets}}
+                                        <li class="page-list__item"><span class="page__item page__item--dataset"
+                                                                        data-path="{{uri}}">{{title}}</span>
+                                            <div class="page__buttons page__buttons--list">
+                                                <button class="btn btn--warning btn--disabled btn-page-delete">Remove from this publish</button>
+                                            </div>
+                                        </li>
+                                    {{/each}}
+                                {{/if}}
+                                {{#if datasetVersions}}
+                                    {{#each datasetVersions}}
+                                        <li class="page-list__item"><span class="page__item page__item--dataset_version"
+                                                                        data-path="{{uri}}">{{title}}: {{edition}} (version {{version}})</span>
+                                            <div class="page__buttons page__buttons--list">
+                                                <button class="btn btn--warning btn--disabled btn-page-delete">Remove from this publish</button>
+                                            </div>
+                                        </li>
+                                    {{/each}}
+                                {{/if}}
+                            </ul>
+                        {{/if_any}}
+                        {{#if pendingDeletes}}
+                            <h4>Deleted pages in this collection</h4>
+                            <ul class="page-list">
+                                {{#each pendingDeletes}}
+                                    <li class="page-list__item">
+                                        <span class="page__item page__item--{{root.type}}">
+                                            {{root.description.title}}{{#if root.description.edition}}: {{root.description.edition}}{{/if}}<br/>
+                                            {{root.uri}}
+                                        </span>
+                                        {{#if root.children}} {{!-- Within the context of the current item --}}
+                                            <div class="page__children">
+                                                <h4>This delete contains</h4>
+                                                {{> childDeletes}} {{!-- Recursively render the partial --}}
+                                            </div>
+                                        {{/if}}
                                     </li>
                                 {{/each}}
-                            {{/if}}
-                            {{#if datasets}}
-                                {{#each datasets}}
-                                    <li class="page-list__item"><span class="page__item page__item--dataset"
-                                                                      data-path="{{uri}}">{{title}}</span>
-                                        <div class="page__buttons page__buttons--list">
-                                            <button class="btn btn--warning btn--disabled btn-page-delete">Remove from this publish</button>
-                                        </div>
-                                    </li>
-                                {{/each}}
-                            {{/if}}
-                            {{#if datasetVersions}}
-                                {{#each datasetVersions}}
-                                    <li class="page-list__item"><span class="page__item page__item--dataset_version"
-                                                                      data-path="{{uri}}">{{title}}: {{edition}} (version {{version}})</span>
-                                        <div class="page__buttons page__buttons--list">
-                                            <button class="btn btn--warning btn--disabled btn-page-delete">Remove from this publish</button>
-                                        </div>
-                                    </li>
-                                {{/each}}
-                            {{/if}}
-                        </ul>
-                    {{/if_any}}
-                    {{#if pendingDeletes}}
-                        <h4>Deleted pages in this collection</h4>
-                        <ul class="page-list">
-                            {{#each pendingDeletes}}
-                                <li class="page-list__item">
-                                    <span class="page__item page__item--{{root.type}}">
-                                        {{root.description.title}}{{#if root.description.edition}}: {{root.description.edition}}{{/if}}<br/>
-                                        {{root.uri}}
-                                    </span>
-                                    {{#if root.children}} {{!-- Within the context of the current item --}}
-                                        <div class="page__children">
-                                            <h4>This delete contains</h4>
-                                            {{> childDeletes}} {{!-- Recursively render the partial --}}
-                                        </div>
-                                    {{/if}}
-                                </li>
-                            {{/each}}
-                        </ul>
+                            </ul>
+                        {{/if}}
                     {{/if}}
                 </div>
             </div>

--- a/src/legacy/templates/publishDetails.handlebars
+++ b/src/legacy/templates/publishDetails.handlebars
@@ -16,7 +16,7 @@
                     {{/if}}
                     <button class="btn btn--primary margin-top--1 margin-bottom--0 btn-collection-unlock">Unlock collection</button>
                     {{#if error}} 
-                        <p>This collection details has failed to load.</p>
+                        <p>This collection's details have failed to load.</p>
                     {{else}}
                         
                         {{#if_any pageDetails datasets datasetVersions}}


### PR DESCRIPTION
### What

Wait for all requests to complete even if there's failures. Capture fails and present them back to user

### How to review

- Check the publishing queues works as normal when no errors
- When there are errors the publishing queue should continue with work with the error collection accordion displaying the error and others working as normal

To simulate requests error you can edit the `getCollectionDetails` function so that certain errors fail. E.g. on a certain collection ID change the url so it will 404

### Who can review

Anyone
