### PR TITLE
Buttons no longer disappear and on second retry it works

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -6660,9 +6660,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -9801,9 +9801,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",


### PR DESCRIPTION
### What

Before this, if an error happened during the file upload, then the upload button would disappear. I have reproduced this by blocking the PUT request to the images-API. Now when that happens, the button will reappear, and the user can try again.

However, I did note there is a second issue that prob should also be addressed.

If the user uploads an image, but the images-API is down, and the request therefore fails. Then a new image record is made behind the scene. However, it is going to be unsuccessful as to make a new record it needs to talk to the image-API. As a result, the 'state' is incorrect at this point. If the user stays on the screen and the image-API comes back up, then they will not be able to upload a new image on first attempt - where really there is no practical reason why they shouldn't be able to. Instead, they will have to try one more time. This is because the second time they try (the first attempt after the image-API has come back up) it will error, and in the 'catch' it will attempt to create a new image record, and this will now succeed. Now that there is a new image record when they go and try again, the image-API will be happy, and the user can successfully upload.

### How to review

1. Block a request to for the PUT (images/image). Recieve an error. 
2. Note that the button reappears to try again.
3. Unblock the request and try again
4. Note the image is uploaded

### Who can review

Anyone except me
