### PR TITLE
Set disabledScreen to true when we get an error calling getMetadata

### DIFF
--- a/src/app/views/datasets-new/edit-metadata/DatasetMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata/DatasetMetadataController.jsx
@@ -90,7 +90,7 @@ export class DatasetMetadataController extends Component {
                 this.handleGETSuccess(metadata);
             })
             .catch(error => {
-                this.setState({ isGettingMetadata: false });
+                this.setState({ isGettingMetadata: false, disableScreen: true });
                 log.event("get metadata: error GETting metadata from controller", log.data({ datasetID, editionID, versionID }), log.error());
                 notifications.add({
                     type: "warning",


### PR DESCRIPTION
### What

Set `disabledScreen` to `true` when we get an error calling getMetadata

### How to review

- Stop running/don't start `dp-publishing-dataset-controller`
- Try edit CMD dataset version metadata e.g. `/florence/collections/{{collectionID}}/datasets/{{datasetID}}/editions/{{editionID}}/versions/{{versionNumber}}`
- The form should now be disabled (grey boxes) to prevent users editing content while Flo is in an error state

### Who can review

Anyone
