### PR TITLE
Add limit query to recipes request

### DIFF
--- a/src/app/utilities/api-clients/recipes.js
+++ b/src/app/utilities/api-clients/recipes.js
@@ -2,7 +2,7 @@ import http from "../http";
 
 export default class recipes {
     static getAll() {
-        return http.get("/recipes", true).then(response => {
+        return http.get("/recipes?limit=1000", true).then(response => {
             return response;
         });
     }
@@ -13,3 +13,4 @@ export default class recipes {
         });
     }
 }
+ 


### PR DESCRIPTION
### What

`dp-recipe-api` recently had pagination implemented. This means on the "Upload a Dataset" page in Florence, only 20 datasets (default limit) is being displayed. This small PR ensures all datasets can be viewed on this page by adding a `limit` of 1000 (maximum limit as used in APIs). 

There will be further work down the line which will involve implementing a new pagination-specific pattern for this page, but as that will take some time to build, this quick fix will be in place for the time being

#### Without limit

![image](https://user-images.githubusercontent.com/23668262/112818338-54062c80-907b-11eb-9137-900dd6488ddd.png)

#### With limit

![image](https://user-images.githubusercontent.com/23668262/112818031-fe318480-907a-11eb-8251-49a9b4f2f9e5.png)

### How to review

- Pull latest develop version of `dp-recipe-api` and run
- Run Florence with `ENABLE_DATASET_IMPORT=true` flag set
- Click on "Datasets" in the header and see that you should only see 20 datasets
- Change to this branch, run `npm run watch` in `/florence/src` and re-run the app. You should now see all datasets

### Who can review

Anyone but me
