### PR TITLE
first pass on implementing blockquote feature in old workspace

### DIFF
--- a/src/legacy/js/functions/_loadBlockquoteBuilder.js
+++ b/src/legacy/js/functions/_loadBlockquoteBuilder.js
@@ -10,7 +10,7 @@ function loadBlockquoteBuilder(onSave) {
         modal.remove();
     }
     function saveBlockquote() {
-        var quoteContent = $('input#blockquote-quote').val();
+        var quoteContent = $('textarea#blockquote-quote').val();
         var quoteAttribution = $('input#blockquote-attribution').val();
 
         if (!quoteContent) {

--- a/src/legacy/js/functions/_loadBlockquoteBuilder.js
+++ b/src/legacy/js/functions/_loadBlockquoteBuilder.js
@@ -1,0 +1,44 @@
+function loadBlockquoteBuilder(onSave) {
+    // add modal window
+    $('.workspace-menu').append(templates.blockquoteBuilder());
+
+    // variables
+    var modal = $(".modal");
+
+    // modal functions
+    function closeModal() {
+        modal.remove();
+    }
+    function saveBlockquote() {
+        var quoteContent = $('input#blockquote-quote').val();
+        var quoteAttribution = $('input#blockquote-attribution').val();
+
+        if (!quoteContent) {
+            sweetAlert('Quote field is empty', 'Please add a quote and save again');
+            return;
+        }
+
+        onSave('<ons-quote content="' + quoteContent + renderAttributionIfPopulated(quoteAttribution) + '" />');
+        modal.remove();
+    }
+
+    function renderAttributionIfPopulated(attribution) {
+        return attribution ? '" attr="' + attribution : ''
+    }
+
+    // bind events
+    $('.btn-blockquote-cancel').click(function() {
+        closeModal();
+    });
+    $('.btn-blockquote-save').click(function() {
+        saveBlockquote();
+    });
+    modal.keyup(function(e) {
+        if (e.keyCode == 27) { //close on esc key
+            closeModal()
+        }
+        if (e.keyCode == 13) { //save on enter key
+            saveBlockquote();
+        }
+    });
+}

--- a/src/legacy/js/functions/_loadMarkdownEditor.js
+++ b/src/legacy/js/functions/_loadMarkdownEditor.js
@@ -94,6 +94,12 @@ function loadMarkdownEditor(content, onSave, pageData, notEmpty) {
 
     $("#js-editor--warning-box").click(function () {
         loadPulloutWarningBox();
+    });    
+    
+    $("#js-editor--blockquote").click(function () {
+        loadBlockquoteBuilder(function(markdown) {
+            onInsertSave('', markdown)
+        });
     });
 
     $("#wmd-input").on('click', function () {
@@ -219,6 +225,17 @@ function markdownEditor() {
         });
         return newText;
     });
+
+    // output blockquote tag as text instead of the actual tag.
+    converter.hooks.chain("preBlockGamut", function (text) {
+        var onsQuoteTag = text.replace(/(<ons-quote\scontent=\"(.*?)\"\s?(attr=\"(.*?)\")?\s*\/>)/ig, function (match) {
+            var content = $(match).attr('content');
+            var attr = $(match).attr('attr');
+            return attr ? '[blockquote content="' + content + '" attr="' + attr + '"]' :
+             '[blockquote content="' + content + '"]';
+        });
+        return onsQuoteTag;
+    })
 
     converter.hooks.chain("plainLinkText", function (link) {
         console.log("link done, innit");

--- a/src/legacy/scss/components/_markdown-editor.scss
+++ b/src/legacy/scss/components/_markdown-editor.scss
@@ -313,6 +313,38 @@
                 content: '!';
             }
         }
+
+        &--blockquote {
+            float: left;
+            background-color: transparent;
+            margin: 15.5px 0 0 20px;
+            padding-right: 10px;
+            width: 30px;
+            height: 32px;
+            font-weight: 400;
+
+            // Over-ride default button hover effect
+            &:after {
+                font-size: 36px;
+                color: $cadet-blue;
+                width: 30px !important;
+                height: 32px !important;
+                top: 11px !important;
+                left: 0 !important;
+                position: absolute !important;
+                content: '❞' !important;
+                background-color: transparent !important;
+            }
+
+            &:hover {
+                float: left;
+                background-color: transparent;
+                margin: 15.5px 0 0 20px;
+                width: 30px;
+                height: 32px;
+                content: '❞';
+            }
+        }
     }
 
     &__line-numbers {

--- a/src/legacy/scss/partials/_workspace.scss
+++ b/src/legacy/scss/partials/_workspace.scss
@@ -729,6 +729,16 @@
     &__label {
         font-size: 16px;
     }
+
+    &__textarea {
+        width: 100%;
+        border: 3px solid $scarpa-flow;
+        background-color: $white;
+        word-wrap: normal;
+        resize: vertical;
+        padding: 7px 20px;
+        margin: 21px 0;
+    }
 }
 
 .child-page {

--- a/src/legacy/templates/blockquoteBuilder.handlebars
+++ b/src/legacy/templates/blockquoteBuilder.handlebars
@@ -2,7 +2,7 @@
     <div class='modal-box modal--tall'>
         <form class="embed__form">
             <label for="blockquote-quote" class="embed__label">Enter quote</label>
-            <input id="blockquote-quote" class="embed__input" type="text" placeholder="Enter quote here">
+            <textarea id="blockquote-quote" class="embed__textarea" type="text" placeholder="Enter quote here" rows="3"></textarea>
             <label for="blockquote-attribution" class="embed__label">Attribution (optional)</label>
             <input id="blockquote-attribution" class="embed__input" type="text" placeholder="Enter attribution details for the quote">
         </form>

--- a/src/legacy/templates/blockquoteBuilder.handlebars
+++ b/src/legacy/templates/blockquoteBuilder.handlebars
@@ -1,0 +1,14 @@
+<div class='modal'>
+    <div class='modal-box modal--tall'>
+        <form class="embed__form">
+            <label for="blockquote-quote" class="embed__label">Enter quote</label>
+            <input id="blockquote-quote" class="embed__input" type="text" placeholder="Enter quote here">
+            <label for="blockquote-attribution" class="embed__label">Attribution (optional)</label>
+            <input id="blockquote-attribution" class="embed__input" type="text" placeholder="Enter attribution details for the quote">
+        </form>
+        <div class='modal-nav'>
+            <button class='btn btn--positive btn-blockquote-save'>Save</button>
+            <button class='btn btn-blockquote-cancel'>Cancel</button>
+        </div>
+    </div>
+</div>

--- a/src/legacy/templates/markdownEditor.handlebars
+++ b/src/legacy/templates/markdownEditor.handlebars
@@ -8,6 +8,7 @@
         <button id="js-editor--equation" class="markdown-editor__button markdown-editor__button--custom markdown-editor__button--equation" title="Build equation"></button>
         <button id="js-editor--box" class="markdown-editor__button markdown-editor__button--custom markdown-editor__button--box" title="Add pull out box"></button>
         <button id="js-editor--warning-box" class="markdown-editor__button markdown-editor__button--custom markdown-editor__button--warning-box" title="Add warning"></button>
+        <button id="js-editor--blockquote" class="markdown-editor__button markdown-editor__button--custom markdown-editor__button--blockquote" title="Add blockquote"></button>
         <div id="wmd-button-bar"></div>
     </div>
     <div class="markdown-editor__content">


### PR DESCRIPTION
### What

This PR introduces a blockquote feature into the old workspace, so that the publishing team can create content that includes standout quotes.

### How to review

- Sense check the code

#### If you want to test locally in the UI

- Pull latest Develop branch of Babbage. This includes the blockquote tag parser logic
- Pull this branch, run `npm install` and then make sure `npm run watch` is running. Both need to be run from the `/src` directory
- Create a collection, click "Create/edit content" and venture into the old workspace to an existing article page (or create one)
- Click on "Content" and then "Edit Content"

On the screen that pops up, the header should now include a blockquote button next to the paperclip (quotation marks icon):

![image](https://user-images.githubusercontent.com/23668262/114042446-59ceef80-987d-11eb-8c7e-26c30f51367a.png)

Click that and you should see a new modal pop up that lets you enter a quote - the attribution field should be optional

![image](https://user-images.githubusercontent.com/23668262/114042671-8b47bb00-987d-11eb-912e-f96fabee38eb.png)


Test by adding a quote with and without attribution. When you save both of those, you should see the following back in the text editor:

![image](https://user-images.githubusercontent.com/23668262/114042789-a3b7d580-987d-11eb-9b59-ae0c18904125.png)

Click "Save changes and exit" which should take you back to the old workspace screen.

The preview on the right side should have updated and you should now be able to see the blockquotes correctly formatted:

![image](https://user-images.githubusercontent.com/23668262/114042999-d1048380-987d-11eb-87d4-763e514797a0.png)

### Who can review

Anyone
