### PR TITLE
Readded required go-bindata dependency

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,7 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/jteeuwen/go-bindata v3.0.8-0.20180305030458-6025e8de665b+incompatible h1:eX6cWzw+KSwhN430wwbdWPgqnlbnK5ux76/q5ko+Qu8=
 github.com/jteeuwen/go-bindata v3.0.8-0.20180305030458-6025e8de665b+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=


### PR DESCRIPTION
### What

A dependency looks to have been removed added.
There seems to have been an attempt to readded it however it wasn't complete. This PR adds the indirect dependency go.sum entry back in.

The project will build without this dependency however if you were to run make debug then the project would fail to run. It would throw:
```bash
# Generate the debug assets version
cd assets; go run github.com/jteeuwen/go-bindata/go-bindata -debug -o data.go -pkg assets ../dist/...
missing go.sum entry for module providing package github.com/jteeuwen/go-bindata/go-bindata; 
```

After running `go mod download github.com/jteeuwen/go-bindata` the go.sum entry is added and the project is runnable again.

### How to review

Checkout this branch and run `make debug ENABLE_DATASET_IMPORT=true ENCRYPTION_DISABLED=true` Make sure to go to  `...:8081/florence/login` locally and that the page loads. Alternativly ensure you don't see the above error in the terminal above the green text that says:
```bash
Rendering Complete, saving .css file...
Wrote CSS to /Users/danielwalford/dev/GoMod/florence/dist/legacy-assets/css/main.min.css
```

### Who can review

Anyone except me
