### PR TITLE
remove alt text and image title inputs

### DIFF
--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -155,7 +155,7 @@ export default class EditHomepageItem extends Component {
                 this.stopPollingForUpdates(imageID);
                 this.setState({
                     imageData: {
-                        url: "",
+                        url: ""
                     },
                     imageState: "created",
                     upload: {},

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -45,9 +45,7 @@ export default class EditHomepageItem extends Component {
             uri: this.props.data ? this.props.data.uri : "",
             title: this.props.data ? this.props.data.title : "",
             imageData: {
-                url: "",
-                title: "",
-                altText: ""
+                url: ""
             },
             imageState: "",
             upload: {},
@@ -158,8 +156,6 @@ export default class EditHomepageItem extends Component {
                 this.setState({
                     imageData: {
                         url: "",
-                        title: "",
-                        altText: ""
                     },
                     imageState: "created",
                     upload: {},
@@ -295,9 +291,7 @@ export default class EditHomepageItem extends Component {
         this.setState({
             image: "",
             imageData: {
-                url: "",
-                title: "",
-                altText: ""
+                url: ""
             },
             upload: {},
             imageImportStatus: STATUS_IMAGE_RECORD_CREATED
@@ -368,22 +362,6 @@ export default class EditHomepageItem extends Component {
                             onChange={this.handleInputChange}
                         />
                         {this.renderImageUpload()}
-                        <Input
-                            id="image-title"
-                            type="input"
-                            label="Image title"
-                            disabled={isDisabled}
-                            value={this.state.imageData.title}
-                            onChange={this.handleInputChange}
-                        />
-                        <Input
-                            id="image-alt-text"
-                            type="input"
-                            label="Alt text (leave blank if decorative)"
-                            disabled={isDisabled}
-                            value={this.state.imageData.altText}
-                            onChange={this.handleInputChange}
-                        />
                     </div>
                 );
             }

--- a/src/app/views/homepage/edit/EditHomepageItem.test.js
+++ b/src/app/views/homepage/edit/EditHomepageItem.test.js
@@ -101,7 +101,7 @@ describe("different item states", () => {
         const wrapper = mount(<EditHomepageItem {...successRouteProps} />);
         const inputs = wrapper.find("input");
         const textarea = wrapper.find("textarea");
-        expect(inputs.length).toBe(5);
+        expect(inputs.length).toBe(3);
         expect(textarea.length).toBe(1);
     });
     it("renders something went wrong message when unsupported field type is passed ", () => {


### PR DESCRIPTION
### What

Remove input fields for alt text and image title since they are currently not used. 

### How to review

Go into Florence, attempt to edit the homepage by clicking on "Add a headline". See that the bottom two inputs on the modal are Image title and Alt text. Pull this branch and see the inputs are gone. 

### Who can review

Anyone but me.
