### PR TITLE
hide from user view

### DIFF
--- a/src/legacy/templates/chartEditBarlineExtras.handlebars
+++ b/src/legacy/templates/chartEditBarlineExtras.handlebars
@@ -25,9 +25,10 @@
         <option value="ShortDash">ShortDash</option>
         <option value="ShortDot">ShortDot</option>
         <option value="ShortDashDot">ShortDashDot</option>
-        <option value="ShortDashDotDot">ShortDashDotDot</option>
+        {{!-- Hidden from view since they do not display well --}}
+        {{!-- <option value="ShortDashDotDot">ShortDashDotDot</option>
         <option value="LongDashDot">LongDashDot</option>
-        <option value="LongDashDotDot">LongDashDotDot</option>
+        <option value="LongDashDotDot">LongDashDotDot</option> --}}
       {{/select}}
     </select>
   </div>

--- a/src/legacy/templates/chartEditBarlineExtras.handlebars
+++ b/src/legacy/templates/chartEditBarlineExtras.handlebars
@@ -26,9 +26,9 @@
         <option value="ShortDot">ShortDot</option>
         <option value="ShortDashDot">ShortDashDot</option>
         {{!-- Hidden from view since they do not display well --}}
-        {{!-- <option value="ShortDashDotDot">ShortDashDotDot</option>
-        <option value="LongDashDot">LongDashDot</option>
-        <option value="LongDashDotDot">LongDashDotDot</option> --}}
+        {{!-- <option value="ShortDashDotDot">ShortDashDotDot</option> --}}
+        {{!-- <option value="LongDashDot">LongDashDot</option> --}}
+        {{!-- <option value="LongDashDotDot">LongDashDotDot</option> --}}
       {{/select}}
     </select>
   </div>


### PR DESCRIPTION
### What

Commented out lines that users should not be able to select. 

### How to review

Check that the following lines are hidden from user view when selecting lines in Florence:
- `ShortDashDotDot`
- `Longdashdot`
- `Longdashdotdot`

### Who can review

Anyone but me. 
