### PR TITLE
Fix for validation errors not reading the body on API response

### DIFF
--- a/src/app/views/login/SignInController.jsx
+++ b/src/app/views/login/SignInController.jsx
@@ -90,8 +90,8 @@ export class LoginController extends Component {
                     heading: "Fix the following: "
                 };
 
-                if (error.errors != null) {
-                    error.errors.forEach(anError => {
+                if (error.body != null && error.body.errors != null) {
+                    error.body.errors.forEach(anError => {
                         errorContents = this.showValidationError(anError, errorContents, notification);
                     });
                 } else {


### PR DESCRIPTION
### What

Note this code isn't actually in use yet.

Errors were not reading the body of the error but instead trying to read 'errors' of the error. This property can be found in the body. This PR should resolve that nesting issue.

### How to review

Backend is not hooked up so not easy to reproduce but if you provide the wrong log int credentials then in src/app/views/login/SignInController.jsx around  line 85 add: 

```JavaScript
error = { status: 400, body: { errors: [{ code: "InvalidEmail" }] } };
```

You then click Sign in, on the Florence login page, you should see validation error.

### Who can review

Anyone except me