### PR TITLE
Hook up Sign Out

### DIFF
--- a/service/directors.go
+++ b/service/directors.go
@@ -31,6 +31,13 @@ func recipeAPIDirector(apiRouterVersion string) func(req *http.Request) {
 	}
 }
 
+func identityAPIDirector(apiRouterVersion string) func(req *http.Request) {
+	return func(req *http.Request) {
+		director(req)
+		req.URL.Path = fmt.Sprintf("/%s%s", apiRouterVersion, req.URL.Path)
+	}
+}
+
 func uploadServiceAPIDirector(apiRouterVersion string) func(req *http.Request) {
 	return func(req *http.Request) {
 		director(req)

--- a/service/directors_test.go
+++ b/service/directors_test.go
@@ -74,4 +74,11 @@ func TestDirectors(t *testing.T) {
 		uploadServiceAPIDirector("v123")(request)
 		So(request.URL.String(), ShouldEqual, "/v123/foo")
 	})
+
+	Convey("Identity API proxy director function appends the provided router api version to the provided path' from the request URL", t, func() {
+		request, err := http.NewRequest("GET", "/foo", nil)
+		So(err, ShouldBeNil)
+		identityAPIDirector("v123")(request)
+		So(request.URL.String(), ShouldEqual, "/v123/foo")
+	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -112,6 +112,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, datasetControllerDirector)
 	imageAPIProxy := reverseproxy.Create(apiRouterURL, imageAPIDirector(cfg.APIRouterVersion))
 	uploadServiceAPIProxy := reverseproxy.Create(apiRouterURL, uploadServiceAPIDirector(cfg.APIRouterVersion))
+	identityAPIProxy := reverseproxy.Create(apiRouterURL, identityAPIDirector(cfg.APIRouterVersion))
 
 	router = pat.New()
 
@@ -128,6 +129,10 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		router.Handle("/dataset/{uri:.*}", datasetAPIProxy)
 		router.Handle("/instances/{uri:.*}", datasetAPIProxy)
 		router.Handle("/dataset-controller/{uri:.*}", datasetControllerProxy)
+		if cfg.SharedConfig.EnableNewSignIn {
+			router.Handle("/tokens/{uri:.*}", identityAPIProxy)
+			router.Handle("/users/{uri:.*}", identityAPIProxy)
+		}
 	}
 	router.Handle("/image/{uri:.*}", imageAPIProxy)
 	router.Handle("/zebedee{uri:/.*}", zebedeeProxy)

--- a/src/app/config/reducer.js
+++ b/src/app/config/reducer.js
@@ -37,6 +37,7 @@ export default function reducer(state = initialState, action) {
         case RESET: {
             return {
                 ...initialState,
+                notifications: state.notifications,
                 config: state.config
             };
         }

--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -1,7 +1,9 @@
 import http from "../http";
 import { store } from "../../config/store";
-import { userLoggedIn, userLoggedOut, reset } from "../../config/actions";
+import { reset, userLoggedIn, userLoggedOut } from "../../config/actions";
 import cookies from "../cookies";
+import notifications from "../notifications";
+import log from "../logging/log";
 
 export default class user {
     static get(email) {
@@ -30,6 +32,10 @@ export default class user {
 
     static getPermissions(email) {
         return http.get(`/zebedee/permission?email=${email}`, true, true);
+    }
+
+    static expireSession(headers) {
+        return http.delete("/tokens/self", true, true, headers);
     }
 
     static getOldUserType(user) {
@@ -72,18 +78,56 @@ export default class user {
     }
 
     static logOut() {
-        const accessTokenCookieRemoved = cookies.remove("access_token");
-        if (!accessTokenCookieRemoved) {
-            console.warn(`Error trying to remove 'access_token' cookie`);
-            return;
+        function clearCookies() {
+            const accessTokenCookieRemoved = cookies.remove("access_token");
+            if (!accessTokenCookieRemoved) {
+                console.warn(`Error trying to remove 'access_token' cookie`);
+            }
+            if (cookies.get("collection")) {
+                cookies.remove("collection");
+            }
+            localStorage.removeItem("loggedInAs");
+            localStorage.removeItem("userType");
+            store.dispatch(userLoggedOut());
+            store.dispatch(reset());
         }
-        if (cookies.get("collection")) {
-            cookies.remove("collection");
+
+        const config = window.getEnv();
+        if (config.enableNewSignIn) {
+            const headers = {
+                Authorization: cookies.get("access_token")
+            };
+            user.expireSession(headers)
+                .then(response => {
+                    clearCookies();
+                })
+                .catch(error => {
+                    if (error.status === 400) {
+                        const notification = {
+                            type: "warning",
+                            message: "An error occurred during sign out 'InvalidToken', please contact a system administrator",
+                            isDismissable: true,
+                            autoDismiss: 20000
+                        };
+                        notifications.add(notification);
+                        console.error("Error occurred sending DELETE to /tokens/self - InvalidToken");
+                        log.event("error on sign out sending delete to /tokens/self failed with an invalid token", log.error(error));
+                    } else {
+                        const notification = {
+                            type: "warning",
+                            message: "Unexpected error occurred during sign out",
+                            isDismissable: true,
+                            autoDismiss: 20000
+                        };
+                        notifications.add(notification);
+                        console.error("Error occurred sending DELETE to /tokens/self");
+                        log.event("error on sign out sending delete to /tokens/self failed with an unexpected error", log.error(error));
+                    }
+                    clearCookies();
+                });
+        } else {
+            clearCookies();
         }
-        localStorage.removeItem("loggedInAs");
-        localStorage.removeItem("userType");
-        store.dispatch(userLoggedOut());
-        store.dispatch(reset());
     }
 
     static updatePassword(body) {

--- a/src/app/utilities/http-methods/request.js
+++ b/src/app/utilities/http-methods/request.js
@@ -16,17 +16,17 @@ import notifications from "../notifications";
  * @returns {Promise} which returns the response body in JSON format
  */
 
-export default function request(method, URI, willRetry = true, onRetry = () => {}, body, callerHandles401) {
+export default function request(method, URI, willRetry = true, onRetry = () => {}, body, callerHandles401, headers) {
     const baseInterval = 50;
     let interval = baseInterval;
     const maxRetries = 5;
     let retryCount = 0;
 
     return new Promise(function(resolve, reject) {
-        tryFetch(resolve, reject, URI, willRetry, body);
+        tryFetch(resolve, reject, URI, willRetry, body, headers);
     });
 
-    function tryFetch(resolve, reject, URI, willRetry, body) {
+    function tryFetch(resolve, reject, URI, willRetry, body, headers) {
         const UID = uuid();
         const URL = window.location.origin + URI;
 
@@ -34,6 +34,7 @@ export default function request(method, URI, willRetry = true, onRetry = () => {
             method,
             credentials: "include",
             headers: {
+                ...headers,
                 "Content-Type": "application/json",
                 "Request-ID": UID,
                 "internal-token": "FD0108EA-825D-411C-9B1D-41EF7727F465"
@@ -195,7 +196,7 @@ export default function request(method, URI, willRetry = true, onRetry = () => {
                     // retry post
                     if (retryCount < maxRetries) {
                         setTimeout(function() {
-                            tryFetch(resolve, reject, URI, willRetry, body);
+                            tryFetch(resolve, reject, URI, willRetry, body, headers);
                         }, interval);
                         retryCount++;
                         interval = interval * 2;

--- a/src/app/utilities/http.js
+++ b/src/app/utilities/http.js
@@ -10,22 +10,24 @@ export default class http {
      * @param {string} uri - URI that the request is being sent to
      * @param {boolean} willRetry - boolean flag whether to retry request on failure
      * @param {boolean} callerHandles401 - Flag to decide whether caller or global handler is to handle 401 responses
+     * @param {object} headers - request headers
      *
      * @returns {Promise} which returns the response body in JSON format
      */
-    static delete(uri, willRetry, callerHandles401) {
-        return request("DELETE", uri, willRetry, undefined, undefined, callerHandles401);
+    static delete(uri, willRetry, callerHandles401, headers) {
+        return request("DELETE", uri, willRetry, undefined, undefined, callerHandles401, headers);
     }
 
     /**
      * @param {string} uri - URI that the request is being sent to
      * @param {boolean} willRetry - boolean flag whether to retry request on failure
      * @param {boolean} callerHandles401 - Flag to decide whether caller or global handler is to handle 401 responses
+     * @param {object} headers - request headers
      *
      * @returns {Promise} which returns the response body in JSON format
      */
-    static get(uri, willRetry, callerHandles401) {
-        return request("GET", uri, willRetry, undefined, undefined, callerHandles401);
+    static get(uri, willRetry, callerHandles401, headers) {
+        return request("GET", uri, willRetry, undefined, undefined, callerHandles401, headers);
     }
 
     /**
@@ -33,11 +35,12 @@ export default class http {
      * @param body - body contents of request
      * @param willRetry - boolean flag whether to retry request on failure
      * @param {boolean} callerHandles401 - Flag to decide whether caller or global handler is to handle 401 responses
+     * @param {object} headers - request headers
      *
      * @returns {Promise} which returns the response body in JSON format
      */
-    static post(uri, body, willRetry, callerHandles401) {
-        return request("POST", uri, willRetry, undefined, body, callerHandles401);
+    static post(uri, body, willRetry, callerHandles401, headers) {
+        return request("POST", uri, willRetry, undefined, body, callerHandles401, headers);
     }
 
     /**
@@ -45,11 +48,12 @@ export default class http {
      * @param body - body contents of request
      * @param willRetry - boolean flag whether to retry request on failure
      * @param {boolean} callerHandles401 - Flag to decide whether caller or global handler is to handle 401 responses
+     * @param {object} headers - request headers
      *
      * @returns {Promise} which returns the response body in JSON format
      */
-    static put(uri, body, willRetry, callerHandles401) {
-        return request("PUT", uri, willRetry, undefined, body, callerHandles401);
+    static put(uri, body, willRetry, callerHandles401, headers) {
+        return request("PUT", uri, willRetry, undefined, body, callerHandles401, headers);
     }
 
     /**


### PR DESCRIPTION
### What

Although the dp-api-router needs to be updated for this to work
- Fix bug where on cookie delete on sign out - if two requests 
- Fix bug that notifications would be deleted if user was signed out as it would set the state to initial state, which means notification array was set to empty immediately after adding a sign out notification error
- Http-requester now allows headers to be set

Bug still present but not part of this PR but now visible due to fixing other bugs (note not a functional issue just visual annoyance) if Florence sends two API requests at once and the users auth token has been removed then these requests will both return errored (401) however they both will sign the user out so you get double notifications saying this has happened - raising a card in the backlog around this.

### How to review

Run Florence without the `ENABLE_NEW_SIGN_IN` feature flag. Ensure that you are able to sign out of Florence like normal.

Run Florence with the feature flag above enabled. Note that Sign out will error but you will be signed out. Let me explain.
Florence used to sign you out by just deleting the session cookie client side, so it's like losing your keys to a lock.
Now Florence will actually tell the owner of the lock 'hey, I no longer need my keys, I am going to dispose of them'. The lock owner is not very trusting of Florence says 'ok' but then changes the lock too so that the keys Florence has will no longer work. Then Florence goes 'cool now time to loose my keys' and does so. 

But note there could be a server error when telling the lock owner Florence doesn't need the keys anymore when this happens an error will trigger BUT Florence will continue to 'lose its keys'. The user at this point will be directed back to the sign in screen and a toast will notify them an error occurred during sign out please contact a system administrator - at this point we should investigate why this error happened.

Right now this error will always happen as requests will go to the dp-api-router but the router isn't configured yet proxy requests to the dp-identity-api (there is a task in the backlog to hook that up - but depends on another task, versioning the endpoints).

### Who can review

Anyone except me