### PR TITLE
Workaround for race issue with generating main.min.css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,8 @@ node-modules-react:
 
 .PHONY: node-modules-legacy
 node-modules-legacy:
-	cd src/legacy; npm install --unsafe-perm
+	cd src/legacy; npm install --unsafe-perm ; sleep 2
+    # NB. Sleeping for two seconds as a workaround to allow time for main.min.css to finish writing
 
 .PHONY: watch-src
 watch-src:


### PR DESCRIPTION
### What

The node step of the build was completing before the asset was generated meaning the next step to generate go assets wasn't including it.
Introduced a sleep to allow time for the asset to complete.

### How to review

Ensure it builds OK on develop.

### Who can review

Anyone but me