### PR TITLE
Better workaround for race issue with generating main.min.css

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,13 @@ debug: generate-go-debug
 	go build $(LDFLAGS) -tags 'debug' -o $(BINPATH)/florence
 	HUMAN_LOG=1 BIND_ADDR=${BIND_ADDR} $(BINPATH)/florence
 
+.PHONY: ensure-main-min-css
+ensure-main-min-css:
+    # Sleeping for a bit if necessary as a workaround to allow time for main.min.css to finish writing
+	bash -c 'for i in {1..10} ; do if [ -e dist/legacy-assets/css/main.min.css ] ; then break ; fi ; echo "Waiting for main.min.css" ; sleep 2 ; done'
+
 .PHONY: generate-go-prod
-generate-go-prod:
+generate-go-prod: ensure-main-min-css
 	# Generate the production assets version
 	cd assets; find ../dist/ -type f ; go run github.com/jteeuwen/go-bindata/go-bindata -o data.go -pkg assets ../dist/...
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ debug: generate-go-debug
 .PHONY: generate-go-prod
 generate-go-prod:
 	# Generate the production assets version
-	cd assets; go run github.com/jteeuwen/go-bindata/go-bindata -o data.go -pkg assets ../dist/...
+	cd assets; find ../dist/ -type f ; go run github.com/jteeuwen/go-bindata/go-bindata -o data.go -pkg assets ../dist/...
 
 .PHONY: generate-go-debug
 generate-go-debug:
@@ -65,8 +65,7 @@ node-modules-react:
 
 .PHONY: node-modules-legacy
 node-modules-legacy:
-	cd src/legacy; npm install --unsafe-perm ; sleep 2
-    # NB. Sleeping for two seconds as a workaround to allow time for main.min.css to finish writing
+	cd src/legacy; npm install --unsafe-perm
 
 .PHONY: watch-src
 watch-src:

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -7,12 +7,12 @@ pushd $cwd/florence
 
   # Sleeping for a bit if necessary as a workaround to allow time for main.min.css to finish writing
   for i in {1..10}
-    do if [ -e ../dist/legacy-assets/css/main.min.css ]
+    do if [ -e dist/legacy-assets/css/main.min.css ]
       then break
     fi
     echo "Waiting for main.min.css $i/10"
     sleep 2
   done
 
-  make build && cp Dockerfile.concourse build/florence $cwd/build
+  make generate-go-prod && cp Dockerfile.concourse build/florence $cwd/build
 popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -3,16 +3,5 @@
 cwd=$(pwd)
 
 pushd $cwd/florence
-  make node-modules
-
-  # Sleeping for a bit if necessary as a workaround to allow time for main.min.css to finish writing
-  for i in {1..10}
-    do if [ -e dist/legacy-assets/css/main.min.css ]
-      then break
-    fi
-    echo "Waiting for main.min.css $i/10"
-    sleep 2
-  done
-
-  make generate-go-prod && cp Dockerfile.concourse build/florence $cwd/build
+  make build && cp Dockerfile.concourse build/florence $cwd/build
 popd

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -3,5 +3,16 @@
 cwd=$(pwd)
 
 pushd $cwd/florence
-  make node-modules build && cp Dockerfile.concourse build/florence $cwd/build
+  make node-modules
+
+  # Sleeping for a bit if necessary as a workaround to allow time for main.min.css to finish writing
+  for i in {1..10}
+    do if [ -e ../dist/legacy-assets/css/main.min.css ]
+      then break
+    fi
+    echo "Waiting for main.min.css $i/10"
+    sleep 2
+  done
+
+  make build && cp Dockerfile.concourse build/florence $cwd/build
 popd


### PR DESCRIPTION
### What

Changed the workaround from #548 to wait for `main.min.css` to have been written.
Also lists files in `/dist/` that will be included in go assets before generating to make debugging the CI job easier.

### How to review

Check it builds and runs in CI.

### Who can review

Anyone but me.