### PR TITLE
Forgotten Password request submitted screen

### DIFF
--- a/src/app/components/panel/Panel.jsx
+++ b/src/app/components/panel/Panel.jsx
@@ -3,7 +3,11 @@ import PropTypes from "prop-types";
 
 const propTypes = {
     type: PropTypes.string.isRequired,
-    body: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
+    body: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+        PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.elementType]))
+    ]),
     heading: PropTypes.string,
     bannerHeading: PropTypes.bool,
     icon: PropTypes.oneOf(["exclamation", "tick", "arrow"]),

--- a/src/app/utilities/errorCodes.js
+++ b/src/app/utilities/errorCodes.js
@@ -3,5 +3,6 @@ export const errCodes = {
     RESPONSE_ERR: "Florence is experiencing difficulties",
     UNEXPECTED_ERR: "Something has gone seriously wrong. Please restart Florence",
     LOGIN_UNEXPECTED_ERR: "An unexpected error has occurred, please try again",
-    RESET_PASSWORD_REQUEST_UNEXPECTED_ERR: "An unexpected error has occurred, please try again"
+    RESET_PASSWORD_REQUEST_UNEXPECTED_ERR: "An unexpected error has occurred, please try again",
+    RESET_PASSWORD_REQUEST_RATE_LIMIT: "There is a problem, the number of requests made has exceeded the limit, please try again later"
 };

--- a/src/app/views/change-password/changePasswordConfirmed.jsx
+++ b/src/app/views/change-password/changePasswordConfirmed.jsx
@@ -2,11 +2,11 @@ import React from "react";
 import Panel from "../../components/panel/Panel";
 
 const ChangePasswordConfirmed = props => {
-    const changePasswordPanelBody = (
-        <p>
+    const changePasswordPanelBody = [
+        <p key="info-technical">
             If you have technical problems with your account, please email&nbsp;<a href="mailto:publishing@ons.gov.uk">publishing@ons.gov.uk</a>
         </p>
-    );
+    ];
 
     return (
         <div className="grid grid--justify-center">

--- a/src/app/views/forgotten-password/forgottenPasswordController.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordController.jsx
@@ -1,6 +1,4 @@
 import React, { Component } from "react";
-import { connect } from "react-redux";
-import { push } from "react-router-redux";
 import PropTypes from "prop-types";
 import ForgottenPasswordRequest from "./forgottenPasswordRequest";
 import ForgottenPasswordEmailSent from "./forgottenPasswordEmailSent";
@@ -9,10 +7,7 @@ import { errCodes } from "../../utilities/errorCodes";
 import notifications from "../../utilities/notifications";
 
 const propTypes = {
-    dispatch: PropTypes.func.isRequired,
-    isAuthenticated: PropTypes.bool.isRequired,
-    rootPath: PropTypes.string.isRequired,
-    location: PropTypes.object
+    dispatch: PropTypes.func.isRequired
 };
 
 export class ForgottenPasswordController extends Component {
@@ -20,10 +15,6 @@ export class ForgottenPasswordController extends Component {
         super(props);
         this.handleInputChange = this.handleInputChange.bind(this);
         this.handleSubmit = this.handleSubmit.bind(this);
-        this.requestEmailChange = this.requestEmailChange.bind(this);
-        this.postResetPassword = this.postResetPassword.bind(this);
-        this.handleResetPasswordError = this.handleResetPasswordError.bind(this);
-        this.showValidationError = this.showValidationError.bind(this);
         this.state = {
             validationErrors: {},
             email: {
@@ -48,6 +39,16 @@ export class ForgottenPasswordController extends Component {
                     </p>
                 );
                 errorContents.emailMessage = "Enter a valid email address";
+                break;
+            case "LimitExceeded":
+                let notification = {
+                    type: "warning",
+                    isDismissable: true,
+                    autoDismiss: 15000,
+                    message: errCodes.RESET_PASSWORD_REQUEST_RATE_LIMIT
+                };
+                console.error(errCodes.RESET_PASSWORD_REQUEST_RATE_LIMIT);
+                notifications.add(notification);
                 break;
             default:
                 this.notifyUnexpectedError();
@@ -104,7 +105,7 @@ export class ForgottenPasswordController extends Component {
     requestEmailChange(email) {
         const body = { email: email };
         this.postResetPassword(body)
-            .then(response => {
+            .then(() => {
                 this.setState({ isSubmitting: false, hasSubmitted: true });
             })
             .catch(error => {
@@ -132,7 +133,6 @@ export class ForgottenPasswordController extends Component {
     handleSubmit(event) {
         event.preventDefault();
         const email = this.state.email.value;
-
         this.setState(
             {
                 hasSubmitted: false,
@@ -153,23 +153,23 @@ export class ForgottenPasswordController extends Component {
             onChange: this.handleInputChange,
             error: this.state.email.errorMsg
         };
-        const screenToShow = this.state.hasSubmitted ? (
-            <ForgottenPasswordEmailSent />
-        ) : (
-            <ForgottenPasswordRequest emailInput={emailInput} validationErrors={this.state.validationErrors} onSubmit={this.handleSubmit} />
-            // <ForgottenPasswordRequest validationErrors={this.state.validationErrors} />
+        return (
+            <div>
+                {this.state.hasSubmitted ? (
+                    <ForgottenPasswordEmailSent email={this.state.email.value} />
+                ) : (
+                    <ForgottenPasswordRequest
+                        emailInput={emailInput}
+                        validationErrors={this.state.validationErrors}
+                        onSubmit={this.handleSubmit}
+                        waitingResponse={this.state.isSubmitting}
+                    />
+                )}
+            </div>
         );
-        return <div>{screenToShow}</div>;
     }
 }
 
 ForgottenPasswordController.propTypes = propTypes;
 
-function mapStateToProps(state) {
-    return {
-        isAuthenticated: state.state.user.isAuthenticated,
-        rootPath: state.state.rootPath
-    };
-}
-
-export default connect(mapStateToProps)(ForgottenPasswordController);
+export default ForgottenPasswordController;

--- a/src/app/views/forgotten-password/forgottenPasswordController.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordController.jsx
@@ -42,7 +42,7 @@ export class ForgottenPasswordController extends Component {
                 break;
             }
             case "LimitExceeded": {
-                let notification = {
+                const notification = {
                     type: "warning",
                     isDismissable: true,
                     autoDismiss: 15000,
@@ -60,7 +60,7 @@ export class ForgottenPasswordController extends Component {
     }
 
     notifyUnexpectedError() {
-        let notification = {
+        const notification = {
             type: "warning",
             isDismissable: true,
             autoDismiss: 15000,

--- a/src/app/views/forgotten-password/forgottenPasswordController.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordController.jsx
@@ -32,8 +32,8 @@ export class ForgottenPasswordController extends Component {
             case "JSONMarshalError":
             case "InvalidEmail": {
                 errorContents.errorsForBody.push(
-                    <p key={"email-error"}>
-                        <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
+                    <p key="email-error">
+                        <a href="javascript:document.getElementById('email').focus()" className="colour--night-shadz">
                             Enter a valid email address
                         </a>
                     </p>

--- a/src/app/views/forgotten-password/forgottenPasswordController.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordController.jsx
@@ -32,7 +32,7 @@ export class ForgottenPasswordController extends Component {
             case "JSONMarshalError":
             case "InvalidEmail": {
                 errorContents.errorsForBody.push(
-                    <p>
+                    <p key={"email-error"}>
                         <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
                             Enter a valid email address
                         </a>
@@ -79,13 +79,15 @@ export class ForgottenPasswordController extends Component {
                 if (error.body != null && error.body.errors != null) {
                     error.body.errors.forEach(anError => {
                         errorContents = this.showValidationError(anError, errorContents);
-                        validationErrors.heading = "Fix the following: ";
                     });
                 } else {
                     this.notifyUnexpectedError();
                 }
 
-                validationErrors.body = errorContents.errorsForBody;
+                if (errorContents.errorsForBody.length >= 1) {
+                    validationErrors.heading = "Fix the following: ";
+                    validationErrors.body = errorContents.errorsForBody;
+                }
                 stateToSet = {
                     ...this.state,
                     validationErrors

--- a/src/app/views/forgotten-password/forgottenPasswordController.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordController.jsx
@@ -30,7 +30,7 @@ export class ForgottenPasswordController extends Component {
         // Switch so that it is easily expandable if we introduce new error types
         switch (anError.code) {
             case "JSONMarshalError":
-            case "InvalidEmail":
+            case "InvalidEmail": {
                 errorContents.errorsForBody.push(
                     <p>
                         <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
@@ -40,7 +40,8 @@ export class ForgottenPasswordController extends Component {
                 );
                 errorContents.emailMessage = "Enter a valid email address";
                 break;
-            case "LimitExceeded":
+            }
+            case "LimitExceeded": {
                 let notification = {
                     type: "warning",
                     isDismissable: true,
@@ -50,8 +51,10 @@ export class ForgottenPasswordController extends Component {
                 console.error(errCodes.RESET_PASSWORD_REQUEST_RATE_LIMIT);
                 notifications.add(notification);
                 break;
-            default:
+            }
+            default: {
                 this.notifyUnexpectedError();
+            }
         }
         return errorContents;
     }

--- a/src/app/views/forgotten-password/forgottenPasswordController.test.js
+++ b/src/app/views/forgotten-password/forgottenPasswordController.test.js
@@ -1,0 +1,13 @@
+import { mount } from "enzyme";
+import { forgottenPasswordController } from "../forgotten-password/forgottenPasswordController";
+import React from "react";
+
+test("", () => {
+    const props = {
+        dispatch: function() {},
+        rootPath: "/florence",
+        isAuthenticated: false
+    };
+    const component = mount(<LoginController {...props} />);
+    expect(component.find("h1").text()).toBe("Sign in to your Florence account");
+});

--- a/src/app/views/forgotten-password/forgottenPasswordController.test.js
+++ b/src/app/views/forgotten-password/forgottenPasswordController.test.js
@@ -1,13 +1,100 @@
 import { mount } from "enzyme";
-import { forgottenPasswordController } from "../forgotten-password/forgottenPasswordController";
+import { ForgottenPasswordController } from "./forgottenPasswordController";
+
 import React from "react";
 
-test("", () => {
+describe("When the user first lands on the forgotten-password url", () => {
     const props = {
-        dispatch: function() {},
-        rootPath: "/florence",
-        isAuthenticated: false
+        dispatch: function() {}
     };
-    const component = mount(<LoginController {...props} />);
-    expect(component.find("h1").text()).toBe("Sign in to your Florence account");
+    const component = mount(<ForgottenPasswordController {...props} />);
+    it("Load the correct child component forgottenPasswordRequest", () => {
+        expect(component.find("h1").text()).toBe("Forgotten password");
+    });
+    it("Hide all validation error components as there are no errors yet", () => {
+        expect(component.find(".panel__error").length).toBe(0);
+        expect(component.find(".error-msg").length).toBe(0);
+    });
+    it("Hide the spinning loading icon as nothing has been submitted yet", () => {
+        expect(component.find(".form__loader").length).toBe(0);
+    });
+});
+
+describe("When the user submits their email for a password request whilst waiting a response", () => {
+    const props = {
+        dispatch: function() {}
+    };
+    const component = mount(<ForgottenPasswordController {...props} />);
+    component.setState({
+        validationErrors: {},
+        email: {
+            value: "",
+            errorMsg: ""
+        },
+        hasSubmitted: false,
+        isSubmitting: true
+    });
+    it("Continue to show the forgottenPasswordRequest component", () => {
+        expect(component.find("h1").text()).toBe("Forgotten password");
+    });
+    it("Show the spinning loading icon", () => {
+        expect(component.find(".form__loader").length).toBe(1);
+    });
+});
+
+describe("When the user submits their email for a password request but the server returns a validation error", () => {
+    const props = {
+        dispatch: function() {}
+    };
+    const component = mount(<ForgottenPasswordController {...props} />);
+    component.setState({
+        validationErrors: {
+            heading: "Fix the following",
+            body: (
+                <p>
+                    <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
+                        Enter a valid email address
+                    </a>
+                </p>
+            )
+        },
+        email: {
+            value: "foo@bar.com",
+            errorMsg: "Enter a valid email address"
+        },
+        hasSubmitted: false,
+        isSubmitting: false
+    });
+    it("Continue to show the forgottenPasswordRequest component", () => {
+        expect(component.find("h1").text()).toBe("Forgotten password");
+    });
+    it("Stop showing the loading icon", () => {
+        expect(component.find(".form__loader").length).toBe(0);
+    });
+    it("Show the error", () => {
+        expect(component.find(".panel__error").length).toBe(1);
+        expect(component.find(".error-msg").length).toBe(1);
+    });
+});
+
+describe("When the user submits their email for a password request and the process is a success", () => {
+    const props = {
+        dispatch: function() {}
+    };
+    const component = mount(<ForgottenPasswordController {...props} />);
+    component.setState({
+        validationErrors: {},
+        email: {
+            value: "foo@bar.com",
+            errorMsg: ""
+        },
+        hasSubmitted: true,
+        isSubmitting: false
+    });
+    it("Show the forgottenPasswordEmailSent component", () => {
+        expect(component.find("h1").text()).toBe("We sent you an email");
+    });
+    it("Show the users email", () => {
+        expect(component.find("b").text()).toBe("foo@bar.com");
+    });
 });

--- a/src/app/views/forgotten-password/forgottenPasswordController.test.js
+++ b/src/app/views/forgotten-password/forgottenPasswordController.test.js
@@ -51,8 +51,8 @@ describe("When the user submits their email for a password request but the serve
         validationErrors: {
             heading: "Fix the following: ",
             body: [
-                <p key={"error"}>
-                    <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
+                <p key="error">
+                    <a href="javascript:document.getElementById('email').focus()" className="colour--night-shadz">
                         Enter a valid email address
                     </a>
                 </p>
@@ -95,6 +95,11 @@ describe("When the user submits their email for a password request and the proce
         expect(component.find("h1").text()).toBe("We sent you an email");
     });
     it("Show the users email", () => {
-        expect(component.find("b").text()).toBe("foo@bar.com");
+        expect(
+            component
+                .find("strong")
+                .at(0)
+                .text()
+        ).toBe("foo@bar.com");
     });
 });

--- a/src/app/views/forgotten-password/forgottenPasswordController.test.js
+++ b/src/app/views/forgotten-password/forgottenPasswordController.test.js
@@ -49,14 +49,14 @@ describe("When the user submits their email for a password request but the serve
     const component = mount(<ForgottenPasswordController {...props} />);
     component.setState({
         validationErrors: {
-            heading: "Fix the following",
-            body: (
-                <p>
+            heading: "Fix the following: ",
+            body: [
+                <p key={"error"}>
                     <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
                         Enter a valid email address
                     </a>
                 </p>
-            )
+            ]
         },
         email: {
             value: "foo@bar.com",

--- a/src/app/views/forgotten-password/forgottenPasswordEmailSent.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordEmailSent.jsx
@@ -4,7 +4,7 @@ import Panel from "../../components/panel/Panel";
 
 const propTypes = {
     validationErrors: PropTypes.shape({
-        hading: PropTypes.string,
+        heading: PropTypes.string,
         body: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     }),
     onSubmit: PropTypes.func,
@@ -13,9 +13,12 @@ const propTypes = {
 
 const ForgottenPasswordEmailSent = props => {
     const noEmailBody = (
-        <div>
+        <div className={"margin-top--1"}>
             <p>
-                If you did not get the email you can <a href={"/florence/forgotten-password"}>reset your password again.</a>
+                If you did not get the email you can
+                <a href={"/florence/forgotten-password"} className={"colour--primary-link"}>
+                    reset your password again.
+                </a>
             </p>
             <p>
                 Alternatively, to get help and support with your Florence account, please email&nbsp;

--- a/src/app/views/forgotten-password/forgottenPasswordEmailSent.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordEmailSent.jsx
@@ -1,6 +1,6 @@
 import React from "react";
-import Input from "../../components/Input";
 import PropTypes from "prop-types";
+import Panel from "../../components/panel/Panel";
 
 const propTypes = {
     validationErrors: PropTypes.shape({
@@ -8,21 +8,31 @@ const propTypes = {
         body: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     }),
     onSubmit: PropTypes.func,
-    emailInput: PropTypes.shape({
-        id: PropTypes.string,
-        label: PropTypes.string,
-        type: PropTypes.string,
-        onChange: PropTypes.func,
-        error: PropTypes.string
-    })
+    email: PropTypes.string
 };
 
 const ForgottenPasswordEmailSent = props => {
-    // TODO this page is to be done in an upcoming task
+    const noEmailBody = (
+        <div>
+            <p>
+                If you did not get the email you can <a href={"/florence/forgotten-password"}>reset your password again.</a>
+            </p>
+            <p>
+                Alternatively, to get help and support with your Florence account, please email&nbsp;
+                <a href="mailto:publishing@ons.gov.uk">publishing@ons.gov.uk</a>
+            </p>
+        </div>
+    );
     return (
         <div className="grid grid--justify-center">
-            <div className="grid__col-3">
+            <div className="grid__col-4">
                 <h1>We sent you an email</h1>
+                <p className={"font-size--18 margin-bottom--1"}>
+                    If you have a Florence account, we’ve sent an email to <b>{props.email}</b>.
+                </p>
+                <p>You need to follow the link in the email to reset your password.</p>
+                <p className={"margin-bottom--1"}>If you do not reset your password straight away, you may need to reset it again.</p>
+                <Panel type={"information"} heading={"If you did not get the email"} body={noEmailBody} />
             </div>
         </div>
     );

--- a/src/app/views/forgotten-password/forgottenPasswordEmailSent.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordEmailSent.jsx
@@ -13,10 +13,10 @@ const propTypes = {
 
 const ForgottenPasswordEmailSent = props => {
     const noEmailBody = (
-        <div className={"margin-top--1"}>
+        <div className="margin-top--1">
             <p>
                 If you did not get the email you can
-                <a href={"/florence/forgotten-password"} className={"colour--primary-link"}>
+                <a href={"/florence/forgotten-password"} className="colour--primary-link">
                     reset your password again.
                 </a>
             </p>
@@ -30,12 +30,12 @@ const ForgottenPasswordEmailSent = props => {
         <div className="grid grid--justify-center">
             <div className="grid__col-4">
                 <h1>We sent you an email</h1>
-                <p className={"font-size--18 margin-bottom--1"}>
-                    If you have a Florence account, we’ve sent an email to <b>{props.email}</b>.
+                <p className="font-size--18 margin-bottom--1">
+                    If you have a Florence account, we’ve sent an email to <strong>{props.email}</strong>.
                 </p>
                 <p>You need to follow the link in the email to reset your password.</p>
-                <p className={"margin-bottom--1"}>If you do not reset your password straight away, you may need to reset it again.</p>
-                <Panel type={"information"} heading={"If you did not get the email"} body={noEmailBody} />
+                <p className="margin-bottom--1">If you do not reset your password straight away, you may need to reset it again.</p>
+                <Panel type="information" heading="If you did not get the email" body={noEmailBody} />
             </div>
         </div>
     );

--- a/src/app/views/forgotten-password/forgottenPasswordRequest.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordRequest.jsx
@@ -31,8 +31,8 @@ const ForgottenPasswordRequest = props => {
                 <h1>Forgotten password</h1>
                 <p className={"font-size--18 margin-bottom--2"}>We'll email you a link to reset your password.</p>
                 {validationErrorsToDisplay && (
-                    <div className={"margin-bottom--1"}>
-                        <Panel className={""} type={"error"} heading={props.validationErrors.heading} body={props.validationErrors.body} />
+                    <div className="margin-bottom--1">
+                        <Panel type={"error"} heading={props.validationErrors.heading} body={props.validationErrors.body} />
                     </div>
                 )}
                 <form className="form" onSubmit={props.onSubmit}>
@@ -40,7 +40,7 @@ const ForgottenPasswordRequest = props => {
                     <button type="submit" className="btn btn--primary margin-top--1">
                         Send the link
                     </button>
-                    {props.waitingResponse ? <div className="form__loader loader loader--dark margin-left--1" /> : ""}
+                    {props.waitingResponse && <div className="form__loader loader loader--dark margin-left--1" />}
                 </form>
             </div>
         </div>

--- a/src/app/views/forgotten-password/forgottenPasswordRequest.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordRequest.jsx
@@ -9,6 +9,7 @@ const propTypes = {
         body: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
     }),
     onSubmit: PropTypes.func,
+    waitingResponse: PropTypes.bool,
     emailInput: PropTypes.shape({
         id: PropTypes.string,
         label: PropTypes.string,
@@ -21,7 +22,7 @@ const propTypes = {
 const ForgottenPasswordRequest = props => {
     return (
         <div className="grid grid--justify-center">
-            <div className="grid__col-3">
+            <div className="grid__col-4">
                 <h1>Forgotten password</h1>
                 <p className={"font-size--18 margin-bottom--2"}>We'll email you a link to reset your password.</p>
                 {props.validationErrors.body && (
@@ -34,6 +35,7 @@ const ForgottenPasswordRequest = props => {
                     <button type="submit" className="btn btn--primary margin-top--1">
                         Send the link
                     </button>
+                    {props.waitingResponse ? <div className="form__loader loader loader--dark margin-left--1" /> : ""}
                 </form>
             </div>
         </div>

--- a/src/app/views/forgotten-password/forgottenPasswordRequest.jsx
+++ b/src/app/views/forgotten-password/forgottenPasswordRequest.jsx
@@ -5,8 +5,12 @@ import Panel from "../../components/panel/Panel";
 
 const propTypes = {
     validationErrors: PropTypes.shape({
-        hading: PropTypes.string,
-        body: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+        heading: PropTypes.string,
+        body: PropTypes.oneOfType([
+            PropTypes.string,
+            PropTypes.element,
+            PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.string, PropTypes.element, PropTypes.elementType]))
+        ])
     }),
     onSubmit: PropTypes.func,
     waitingResponse: PropTypes.bool,
@@ -20,12 +24,13 @@ const propTypes = {
 };
 
 const ForgottenPasswordRequest = props => {
+    const validationErrorsToDisplay = props.validationErrors.body && props.validationErrors.body.length > 0;
     return (
         <div className="grid grid--justify-center">
             <div className="grid__col-4">
                 <h1>Forgotten password</h1>
                 <p className={"font-size--18 margin-bottom--2"}>We'll email you a link to reset your password.</p>
-                {props.validationErrors.body && (
+                {validationErrorsToDisplay && (
                     <div className={"margin-bottom--1"}>
                         <Panel className={""} type={"error"} heading={props.validationErrors.heading} body={props.validationErrors.body} />
                     </div>

--- a/src/app/views/login/SignInController.jsx
+++ b/src/app/views/login/SignInController.jsx
@@ -123,8 +123,8 @@ export class LoginController extends Component {
         switch (anError.code) {
             case "InvalidEmail":
                 errorContents.errorsForBody.push(
-                    <p key={"error-invalid-email"}>
-                        <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
+                    <p key="error-invalid-email">
+                        <a href="javascript:document.getElementById('email').focus()" className="colour--night-shadz">
                             Enter a valid email address
                         </a>
                     </p>
@@ -133,8 +133,8 @@ export class LoginController extends Component {
                 break;
             case "InvalidPassword":
                 errorContents.errorsForBody.push(
-                    <p key={"error-invalid-password"}>
-                        <a href="javascript:document.getElementById('password').focus()" className={"colour--night-shadz"}>
+                    <p key="error-invalid-password">
+                        <a href="javascript:document.getElementById('password').focus()" className="colour--night-shadz">
                             Enter a password
                         </a>
                     </p>
@@ -142,11 +142,11 @@ export class LoginController extends Component {
                 errorContents.passwordMessage = "Enter a password";
                 break;
             case "NotAuthorised":
-                errorContents.errorsForBody.push(<p key={"error-not-authorised"}>Email address or password are incorrect</p>);
+                errorContents.errorsForBody.push(<p key="error-not-authorised">Email address or password are incorrect</p>);
                 break;
             case "TooManyFailedAttempts":
                 errorContents.errorsForBody.push(
-                    <p key={"error-too-many-attempts"}>You've tried to sign in to your account too many times. Please try again later.</p>
+                    <p key="error-too-many-attempts">You've tried to sign in to your account too many times. Please try again later.</p>
                 );
                 break;
             default:

--- a/src/app/views/login/SignInController.jsx
+++ b/src/app/views/login/SignInController.jsx
@@ -123,7 +123,7 @@ export class LoginController extends Component {
         switch (anError.code) {
             case "InvalidEmail":
                 errorContents.errorsForBody.push(
-                    <p>
+                    <p key={"error-invalid-email"}>
                         <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
                             Enter a valid email address
                         </a>
@@ -133,7 +133,7 @@ export class LoginController extends Component {
                 break;
             case "InvalidPassword":
                 errorContents.errorsForBody.push(
-                    <p>
+                    <p key={"error-invalid-password"}>
                         <a href="javascript:document.getElementById('password').focus()" className={"colour--night-shadz"}>
                             Enter a password
                         </a>
@@ -142,10 +142,12 @@ export class LoginController extends Component {
                 errorContents.passwordMessage = "Enter a password";
                 break;
             case "NotAuthorised":
-                errorContents.errorsForBody.push(<p>Email address or password are incorrect</p>);
+                errorContents.errorsForBody.push(<p key={"error-not-authorised"}>Email address or password are incorrect</p>);
                 break;
             case "TooManyFailedAttempts":
-                errorContents.errorsForBody.push(<p>You've tried to sign in to your account too many times. Please try again later.</p>);
+                errorContents.errorsForBody.push(
+                    <p key={"error-too-many-attempts"}>You've tried to sign in to your account too many times. Please try again later.</p>
+                );
                 break;
             default:
                 // Code undefined or different to expected range of errors

--- a/src/app/views/login/SignInController.test.js
+++ b/src/app/views/login/SignInController.test.js
@@ -54,7 +54,10 @@ test("Does password change form appear on state change", () => {
     };
     const component = mount(<LoginController {...props} />);
     expect(component.find(".modal__overlay").length).toBe(0);
-    component.setState({ requestPasswordChange: true });
+    component.setState({
+        requestPasswordChange: true,
+        validationErrors: {}
+    });
     expect(component.find(".modal__overlay").length).toBe(1);
 });
 
@@ -67,13 +70,13 @@ test("Given a missing password validation error do the warnings appear", () => {
     const state = {
         validationErrors: {
             heading: "Fix the following: ",
-            body: (
-                <p>
+            body: [
+                <p key={"error"}>
                     <a href="javascript:document.getElementById('password').focus()" className={"colour--night-shadz"}>
                         Enter a password
                     </a>
                 </p>
-            )
+            ]
         },
         email: {
             value: "foo@bar.com",
@@ -104,13 +107,13 @@ test("Given a bad email validation error do the warnings appear", () => {
     const state = {
         validationErrors: {
             heading: "Fix the following: ",
-            body: (
-                <p>
+            body: [
+                <p key={"email-error"}>
                     <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
                         Enter a valid email address
                     </a>
                 </p>
-            )
+            ]
         },
         email: {
             value: "foobar!baz",
@@ -142,12 +145,12 @@ test("Given a bad email and no password validation error do the warnings appear"
         validationErrors: {
             heading: "Fix the following: ",
             body: [
-                <p>
+                <p key={"email-error"}>
                     <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
                         Enter a valid email address
                     </a>
                 </p>,
-                <p>
+                <p key={"email-error-2"}>
                     <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
                         Enter a valid email address
                     </a>
@@ -183,7 +186,7 @@ test("Given a bad email and password combination validation error do the warning
     const state = {
         validationErrors: {
             heading: "Fix the following: ",
-            body: [<p>Email address or password are incorrect</p>]
+            body: [<p key={"error"}>Email address or password are incorrect</p>]
         },
         email: {
             value: "foobar!baz",
@@ -214,7 +217,7 @@ test("Given too many attempts to sign in does validation error appear", () => {
     const state = {
         validationErrors: {
             heading: "Fix the following: ",
-            body: [<p>You've tried to sign in to your account too many times. Please try again later.</p>]
+            body: [<p key={"error"}>You've tried to sign in to your account too many times. Please try again later.</p>]
         },
         email: {
             value: "foobar!baz",

--- a/src/app/views/login/SignInController.test.js
+++ b/src/app/views/login/SignInController.test.js
@@ -71,8 +71,8 @@ test("Given a missing password validation error do the warnings appear", () => {
         validationErrors: {
             heading: "Fix the following: ",
             body: [
-                <p key={"error"}>
-                    <a href="javascript:document.getElementById('password').focus()" className={"colour--night-shadz"}>
+                <p key="error">
+                    <a href="javascript:document.getElementById('password').focus()" className="colour--night-shadz">
                         Enter a password
                     </a>
                 </p>
@@ -108,8 +108,8 @@ test("Given a bad email validation error do the warnings appear", () => {
         validationErrors: {
             heading: "Fix the following: ",
             body: [
-                <p key={"email-error"}>
-                    <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
+                <p key="email-error">
+                    <a href="javascript:document.getElementById('email').focus()" className="colour--night-shadz">
                         Enter a valid email address
                     </a>
                 </p>
@@ -145,13 +145,13 @@ test("Given a bad email and no password validation error do the warnings appear"
         validationErrors: {
             heading: "Fix the following: ",
             body: [
-                <p key={"email-error"}>
-                    <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
+                <p key="email-error">
+                    <a href="javascript:document.getElementById('email').focus()" className="colour--night-shadz">
                         Enter a valid email address
                     </a>
                 </p>,
-                <p key={"email-error-2"}>
-                    <a href="javascript:document.getElementById('email').focus()" className={"colour--night-shadz"}>
+                <p key="email-error-2">
+                    <a href="javascript:document.getElementById('email').focus()" className="colour--night-shadz">
                         Enter a valid email address
                     </a>
                 </p>
@@ -186,7 +186,7 @@ test("Given a bad email and password combination validation error do the warning
     const state = {
         validationErrors: {
             heading: "Fix the following: ",
-            body: [<p key={"error"}>Email address or password are incorrect</p>]
+            body: [<p key="error">Email address or password are incorrect</p>]
         },
         email: {
             value: "foobar!baz",
@@ -217,7 +217,7 @@ test("Given too many attempts to sign in does validation error appear", () => {
     const state = {
         validationErrors: {
             heading: "Fix the following: ",
-            body: [<p key={"error"}>You've tried to sign in to your account too many times. Please try again later.</p>]
+            body: [<p key="error">You've tried to sign in to your account too many times. Please try again later.</p>]
         },
         email: {
             value: "foobar!baz",

--- a/src/app/views/login/SignInForm.jsx
+++ b/src/app/views/login/SignInForm.jsx
@@ -6,8 +6,8 @@ import PropTypes from "prop-types";
 
 const propTypes = {
     validationErrors: PropTypes.shape({
-        hading: PropTypes.string,
-        body: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+        heading: PropTypes.string,
+        body: PropTypes.arrayOf(PropTypes.elementType)
     }),
     onSubmit: PropTypes.func,
     isSubmitting: PropTypes.bool,
@@ -23,11 +23,12 @@ const propTypes = {
 };
 
 const LoginForm = props => {
+    const showValidationErrorPanel = props.validationErrors.body && props.validationErrors.body.length > 0;
     return (
         <div className="grid grid--justify-center">
             <div className="grid__col-3">
                 <h1>Sign in to your Florence account</h1>
-                {props.validationErrors.body && (
+                {showValidationErrorPanel && (
                     <div className={"margin-bottom--1"}>
                         <Panel className={""} type={"error"} heading={props.validationErrors.heading} body={props.validationErrors.body} />
                     </div>

--- a/src/app/views/login/SignInForm.jsx
+++ b/src/app/views/login/SignInForm.jsx
@@ -29,8 +29,8 @@ const LoginForm = props => {
             <div className="grid__col-3">
                 <h1>Sign in to your Florence account</h1>
                 {showValidationErrorPanel && (
-                    <div className={"margin-bottom--1"}>
-                        <Panel className={""} type={"error"} heading={props.validationErrors.heading} body={props.validationErrors.body} />
+                    <div className="margin-bottom--1">
+                        <Panel type={"error"} heading={props.validationErrors.heading} body={props.validationErrors.body} />
                     </div>
                 )}
                 <form className="form" onSubmit={props.onSubmit}>

--- a/src/scss/base/_variables.scss
+++ b/src/scss/base/_variables.scss
@@ -122,7 +122,9 @@ $colours: (
     wild-sand: $wild-sand,
     tawny-port: $tawny-port,
     silver-sand: $silver-sand,
-    focu: $focus
+    focu: $focus,
+    primary-link: $primary-link
+
 );
 
 /* Panel heights - TODO probably update with new grid */


### PR DESCRIPTION
### What

When a user submits a password reset and is successful, they will be directed to this new screen

Panel component in some cases was being misused and propTypes not matching. These have now been resolved
prop 'heading' was being misspelt, this has now been corrected.

### How to review

Make sure you are running the `dp-identity-api` - note you don't need any user accounts to test this PR

Run Florence with the feature flag `ENABLE_NEW_SIGN_IN=true` If pulling this PR for the first time you will need to run `make node-modules` before running the `make debug` command (`make node-modules` will rebuild the JS/React side of Florence).

Navigate to http://localhost:8081/florence/forgotten-password and have a play around with the screen. 

It is important to note that we do not provide detail as to which emails are valid and which are not on this screen, this is for security reasons. The new screen can be seen once you submit a valid formatted email address - validity is decided by the backend, specifically `dp-identity-api`

### Who can review

Anyone except me
