### PR TITLE
Feature/add edit ability to homepage around ons

### DIFF
--- a/src/app/views/homepage/edit/EditHomepage.jsx
+++ b/src/app/views/homepage/edit/EditHomepage.jsx
@@ -28,6 +28,7 @@ class EditHomepage extends Component {
                     maximumNumberOfEntries={this.props.maximumNumberOfEntries}
                     disableActions={this.props.disableForm}
                 />
+                <h2 className="margin-top--1">Around ONS</h2>
                 <SimpleEditableList
                     addText={"Add around ONS feature"}
                     fields={this.props.homepageData.aroundONS}

--- a/src/app/views/homepage/edit/EditHomepage.jsx
+++ b/src/app/views/homepage/edit/EditHomepage.jsx
@@ -28,6 +28,16 @@ class EditHomepage extends Component {
                     maximumNumberOfEntries={this.props.maximumNumberOfEntries}
                     disableActions={this.props.disableForm}
                 />
+                <SimpleEditableList
+                    addText={"Add around ONS feature"}
+                    fields={this.props.homepageData.aroundONS}
+                    editingStateFieldName="aroundONS"
+                    handleAddClick={this.props.handleSimpleEditableListAdd}
+                    handleEditClick={this.props.handleSimpleEditableListEdit}
+                    handleDeleteClick={this.props.handleSimpleEditableListDelete}
+                    maximumNumberOfEntries={this.props.maximumNumberOfEntries}
+                    disableActions={this.props.disableForm}
+                />
                 <h2 className="margin-top--1">Service Message</h2>
                 <Input
                     id="serviceMessage"
@@ -65,6 +75,7 @@ class EditHomepage extends Component {
 const propTypes = {
     homepageData: PropTypes.shape({
         featuredContent: PropTypes.array,
+        aroundONS: PropTypes.array,
         serviceMessage: PropTypes.string
     }),
     handleBackButton: PropTypes.func.isRequired,

--- a/src/app/views/homepage/edit/EditHomepageController.jsx
+++ b/src/app/views/homepage/edit/EditHomepageController.jsx
@@ -34,6 +34,7 @@ export class EditHomepageController extends Component {
             isInAnotherCollection: true,
             homepageData: {
                 featuredContent: [],
+                aroundONS: [],
                 serviceMessage: ""
             },
             collectionState: "",
@@ -116,11 +117,12 @@ export class EditHomepageController extends Component {
         return homepage
             .get(this.props.params.collectionID)
             .then(homepageData => {
-                const mappedfeaturedContent = this.mapfeaturedContentToState(homepageData.featuredContent);
+                const mappedFeaturedContent = this.mapFeaturedContentToState(homepageData.featuredContent);
+                const mappedAroundONS = this.mapFeaturedContentToState(homepageData.aroundONS);
                 this.setState({
                     initialHomepageData: homepageData,
                     homepageFetched: true,
-                    homepageData: { featuredContent: mappedfeaturedContent, serviceMessage: homepageData.serviceMessage }
+                    homepageData: { featuredContent: mappedFeaturedContent, aroundONS: mappedAroundONS, serviceMessage: homepageData.serviceMessage }
                 });
                 return;
             })
@@ -134,7 +136,7 @@ export class EditHomepageController extends Component {
             });
     };
 
-    mapfeaturedContentToState = featuredContent => {
+    mapFeaturedContentToState = featuredContent => {
         try {
             return featuredContent.map((item, index) => {
                 return {
@@ -232,7 +234,7 @@ export class EditHomepageController extends Component {
         const newFieldState = [...this.state.homepageData[stateFieldName]];
         newField.id = newFieldState.length;
         newFieldState.push(newField);
-        const mappedNewFieldState = this.mapfeaturedContentToState(newFieldState);
+        const mappedNewFieldState = this.mapFeaturedContentToState(newFieldState);
         return {
             ...this.state.homepageData,
             [stateFieldName]: mappedNewFieldState
@@ -246,7 +248,7 @@ export class EditHomepageController extends Component {
             }
             return field;
         });
-        const mappedNewFieldState = this.mapfeaturedContentToState(newFieldState, stateFieldName);
+        const mappedNewFieldState = this.mapFeaturedContentToState(newFieldState, stateFieldName);
         return {
             ...this.state.homepageData,
             [stateFieldName]: mappedNewFieldState
@@ -254,7 +256,7 @@ export class EditHomepageController extends Component {
     };
 
     checkForHomepageDataChanges = fieldName => {
-        if (fieldName === "featuredContent" || "serviceMessage") {
+        if (fieldName === "featuredContent" || "aroundONS" || "serviceMessage") {
             return true;
         }
         return this.state.hasChangesMade;
@@ -289,6 +291,7 @@ export class EditHomepageController extends Component {
 
     handleSave = async actions => {
         let featuredContent = [];
+        let aroundONS = [];
         let serviceMessage = "";
         let initialHomepageData = this.state.initialHomepageData;
         let formattedHomepageData = {};
@@ -302,9 +305,15 @@ export class EditHomepageController extends Component {
                 uri: entry.uri,
                 image: entry.image
             }));
+            aroundONS = this.state.homepageData.aroundONS.map(entry => ({
+                title: entry.title,
+                description: entry.description,
+                uri: entry.uri,
+                image: entry.image
+            }));
             serviceMessage = this.state.homepageData.serviceMessage;
             initialHomepageData = this.state.initialHomepageData;
-            formattedHomepageData = { ...initialHomepageData, featuredContent, serviceMessage };
+            formattedHomepageData = { ...initialHomepageData, featuredContent, aroundONS, serviceMessage };
             saveHomepageChangesError = await this.saveHomepageChanges(this.props.params.collectionID, formattedHomepageData);
         }
 
@@ -381,14 +390,13 @@ export class EditHomepageController extends Component {
     };
 
     renderModal = () => {
-        const modal = React.Children.map(this.props.children, child => {
+        return React.Children.map(this.props.children, child => {
             return React.cloneElement(child, {
                 data: this.state.homepageData[this.props.params.homepageDataField][this.props.params.homepageDataFieldID],
                 handleSuccessClick: this.handleSimpleEditableListEditSuccess,
                 handleCancelClick: this.handleSimpleEditableListEditCancel
             });
         });
-        return modal;
     };
 
     render() {

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -25,6 +25,20 @@ const mockAPIResponse = {
             image: null
         }
     ],
+    aroundONS: [
+        {
+            title: "Local statistics",
+            description: "Where to find statistics covering specific areas.",
+            uri: "/",
+            image: null
+        },
+        {
+            title: "Secure Research Service",
+            description: "Find out how ONS secure data could help your research project.",
+            uri: "/",
+            image: null
+        }
+    ],
     serviceMessage: "This is a default service message for mock testing"
 };
 
@@ -104,12 +118,18 @@ describe("On mount of the edit homepage controller", () => {
 describe("mapping data fetched from API to component state", () => {
     it("maps the mock response to the state", () => {
         expect(wrapper.state("homepageData").featuredContent.length).toBe(3);
+        expect(wrapper.state("homepageData").aroundONS.length).toBe(2);
     });
     it("maps the additional fields to the state", () => {
         const firstEntryOffeaturedContent = wrapper.state("homepageData").featuredContent[0];
         expect(firstEntryOffeaturedContent.simpleListHeading).toBe("Weekly deaths");
         expect(firstEntryOffeaturedContent.simpleListDescription).toBe(
             "The most up-to-date provisional figures for deaths involving the coronavirus (COVID-19) in England and Wales."
+        );
+        const firstEntryOfaroundONS = wrapper.state("homepageData").aroundONS[0];
+        expect(firstEntryOfaroundONS.simpleListHeading).toBe("Local statistics");
+        expect(firstEntryOfaroundONS.simpleListDescription).toBe(
+            "Where to find statistics covering specific areas."
         );
     });
 });
@@ -127,14 +147,21 @@ describe("managing data loading states", () => {
 });
 
 describe("editable list handlers", () => {
-    it("calls dispatch with the correct route when handleSimpleEditableListAdd is called", () => {
+    it("calls dispatch with the correct route when featuredContent handleSimpleEditableListAdd is called", () => {
         wrapper.instance().handleSimpleEditableListAdd("featuredContent");
         expect(dispatchedActions[0].type).toBe("@@router/CALL_HISTORY_METHOD");
         expect(dispatchedActions[0].payload.method).toBe("push");
         expect(dispatchedActions[0].payload.args[0]).toBe("florence/collections/12345/homepage/edit/featuredContent/3");
     });
 
-    it("calls dispatch with the correct route when handleSimpleEditableListEdit is called", () => {
+    it("calls dispatch with the correct route when aroundONS handleSimpleEditableListAdd is called", () => {
+        wrapper.instance().handleSimpleEditableListAdd("aroundONS");
+        expect(dispatchedActions[0].type).toBe("@@router/CALL_HISTORY_METHOD");
+        expect(dispatchedActions[0].payload.method).toBe("push");
+        expect(dispatchedActions[0].payload.args[0]).toBe("florence/collections/12345/homepage/edit/aroundONS/2");
+    });
+
+    it("calls dispatch with the correct route when featuredContent handleSimpleEditableListEdit is called", () => {
         const editedField = {
             id: 1,
             title: "Title",
@@ -145,6 +172,19 @@ describe("editable list handlers", () => {
         expect(dispatchedActions[0].type).toBe("@@router/CALL_HISTORY_METHOD");
         expect(dispatchedActions[0].payload.method).toBe("push");
         expect(dispatchedActions[0].payload.args[0]).toBe("florence/collections/12345/homepage/edit/featuredContent/1");
+    });
+
+    it("calls dispatch with the correct route when aroundONS handleSimpleEditableListEdit is called", () => {
+        const editedField = {
+            id: 1,
+            title: "Title",
+            description: "Description",
+            uri: "/"
+        };
+        wrapper.instance().handleSimpleEditableListEdit(editedField, "aroundONS");
+        expect(dispatchedActions[0].type).toBe("@@router/CALL_HISTORY_METHOD");
+        expect(dispatchedActions[0].payload.method).toBe("push");
+        expect(dispatchedActions[0].payload.args[0]).toBe("florence/collections/12345/homepage/edit/aroundONS/1");
     });
 
     it("calls dispatch with the correct route when handleSimpleEditableListCancel is called", () => {
@@ -162,6 +202,14 @@ describe("editable list handlers", () => {
         expect(wrapper.state("homepageData").featuredContent.length).toBe(2);
     });
 
+    it("removes aroundONS element with ID of 0 when handleSimpleEditableListDelete is called", () => {
+        const deletedField = {
+            id: 0
+        };
+        wrapper.instance().handleSimpleEditableListDelete(deletedField, "aroundONS");
+        expect(wrapper.state("homepageData").aroundONS.length).toBe(1);
+    });
+
     it("adds a new element into featuredContent when handleSimpleEditableListEditSuccess is called without an ID present", async () => {
         const newField = {
             title: "Title 2",
@@ -172,26 +220,49 @@ describe("editable list handlers", () => {
         expect(wrapper.state("homepageData").featuredContent.length).toBe(3);
     });
 
+    it("adds a new element into aroundONS when handleSimpleEditableListEditSuccess is called without an ID present", async () => {
+        const newField = {
+            title: "Title 2",
+            description: "Description 5",
+            uri: "/"
+        };
+        await wrapper.instance().handleSimpleEditableListEditSuccess(newField, "aroundONS");
+        expect(wrapper.state("homepageData").aroundONS.length).toBe(2);
+    });
+
     it("updates the element in featuredContent when handleSimpleEditableListEditSuccess is called with an ID present", async () => {
         const updatedfield = {
             id: 0,
-            title: "New Title",
-            description: "New Description",
+            title: "New featuredContent Title",
+            description: "New featuredContent Description",
             uri: "/new-uri"
         };
         await wrapper.instance().handleSimpleEditableListEditSuccess(updatedfield, "featuredContent");
-        expect(wrapper.state("homepageData").featuredContent[0].title).toBe("New Title");
-        expect(wrapper.state("homepageData").featuredContent[0].description).toBe("New Description");
+        expect(wrapper.state("homepageData").featuredContent[0].title).toBe("New featuredContent Title");
+        expect(wrapper.state("homepageData").featuredContent[0].description).toBe("New featuredContent Description");
         expect(wrapper.state("homepageData").featuredContent[0].uri).toBe("/new-uri");
+    });
+
+    it("updates the element in aroundONS when handleSimpleEditableListEditSuccess is called with an ID present", async () => {
+        const updatedfield = {
+            id: 0,
+            title: "New aroundONS Title",
+            description: "New aroundONS Description",
+            uri: "/new-uri"
+        };
+        await wrapper.instance().handleSimpleEditableListEditSuccess(updatedfield, "aroundONS");
+        expect(wrapper.state("homepageData").aroundONS[0].title).toBe("New aroundONS Title");
+        expect(wrapper.state("homepageData").aroundONS[0].description).toBe("New aroundONS Description");
+        expect(wrapper.state("homepageData").aroundONS[0].uri).toBe("/new-uri");
     });
 });
 
 describe("submit handlers", () => {
-    it("calls the savePageContent method when changes have been made", async () => {
+    it("calls the savePageContent method when featuredContent changes have been made", async () => {
         const updatedfield = {
             id: 0,
-            title: "New Title",
-            description: "New Description",
+            title: "New featuredContent Title",
+            description: "New featuredContent Description",
             uri: "/new-uri"
         };
         await wrapper.instance().handleSimpleEditableListEditSuccess(updatedfield, "featuredContent");
@@ -199,6 +270,19 @@ describe("submit handlers", () => {
         expect(wrapper.state("isSaving")).toBe(true);
         expect(wrapper.state("hasChangesMade")).toBe(true);
         expect(collections.savePageContent.mock.calls.length).toBe(1);
+    });
+    it("calls the savePageContent method when aroundONS changes have been made", async () => {
+        const updatedfield = {
+            id: 0,
+            title: "New aroundONS Title",
+            description: "New aroundONS Description",
+            uri: "/new-uri"
+        };
+        await wrapper.instance().handleSimpleEditableListEditSuccess(updatedfield, "aroundONS");
+        await wrapper.instance().handleSaveAndPreview();
+        expect(wrapper.state("isSaving")).toBe(true);
+        expect(wrapper.state("hasChangesMade")).toBe(true);
+        expect(collections.savePageContent.mock.calls.length).toBe(2);
     });
     it("calls the setContentStatusToComplete method", async () => {
         await wrapper.instance().handleSubmitForReview();

--- a/src/app/views/homepage/edit/EditHomepageController.test.js
+++ b/src/app/views/homepage/edit/EditHomepageController.test.js
@@ -128,9 +128,7 @@ describe("mapping data fetched from API to component state", () => {
         );
         const firstEntryOfaroundONS = wrapper.state("homepageData").aroundONS[0];
         expect(firstEntryOfaroundONS.simpleListHeading).toBe("Local statistics");
-        expect(firstEntryOfaroundONS.simpleListDescription).toBe(
-            "Where to find statistics covering specific areas."
-        );
+        expect(firstEntryOfaroundONS.simpleListDescription).toBe("Where to find statistics covering specific areas.");
     });
 });
 

--- a/src/app/views/homepage/edit/EditHomepageItem.jsx
+++ b/src/app/views/homepage/edit/EditHomepageItem.jsx
@@ -341,7 +341,8 @@ export default class EditHomepageItem extends Component {
 
     renderModalBody = isDisabled => {
         switch (this.props.params.homepageDataField) {
-            case "featuredContent": {
+            case "featuredContent":
+            case "aroundONS": {
                 return (
                     <div>
                         <Input


### PR DESCRIPTION
### What

Add Around ONS section to homepage edit

### How to review

Get latest zebedee develop branch
Clone the feature/add-edit-ability-to-homepage-around-ons branch in the following repos:
- florence
- dp-frontend-homepage-controller
- dp-frontend-renderer

Run publishing stack locally
Create a new collection in florence CMS and attempt to edit the homepage content.
Should see a new editable list section titled 'Around ONS'
Once some content is added to the section select save and preview
In the preview window the newly added/edited Around ONS content should be displayed in the correct section

### Who can review

Anyone