### PR TITLE
Add format to dataset POST for Cantabular types 

### DIFF
--- a/src/app/views/datasets-new/create/CreateCantabularDatasetController.jsx
+++ b/src/app/views/datasets-new/create/CreateCantabularDatasetController.jsx
@@ -1,0 +1,136 @@
+import React, { Component } from "react";
+import { push } from "react-router-redux";
+import PropTypes from "prop-types";
+
+import datasets from "../../../utilities/api-clients/datasets";
+import notifications from "../../../utilities/notifications";
+import url from "../../../utilities/url";
+import log from "../../../utilities/logging/log";
+
+const propTypes = {
+    dispatch: PropTypes.func.isRequired,
+    params: PropTypes.shape({
+        datasetID: PropTypes.string.isRequired,
+        format: PropTypes.string.isRequired
+    }),
+    location: PropTypes.shape({
+        pathname: PropTypes.string.isRequired
+    })
+};
+
+export class CreateCantabularDatasetController extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isPosting: false,
+            datasetID: "",
+            format: ""
+        };
+    }
+
+    componentWillMount = () => {
+        this.setStateFromParameters();
+    };
+
+    setStateFromParameters = () => {
+        this.setState({
+            datasetID: this.props.params.datasetID,
+            format: this.props.params.format
+        });
+    };
+
+    makeCreateDatasetPostBody = format => {
+        return {
+            type: format
+        };
+    };
+
+    handleCreateClick = event => {
+        event.preventDefault();
+        const datasetID = this.state.datasetID;
+        const format = this.state.format;
+        const postBody = this.makeCreateDatasetPostBody(format);
+        this.setState({ isPosting: true });
+        return datasets
+            .create(datasetID, postBody)
+            .then(() => {
+                notifications.add({
+                    type: "positive",
+                    message: "Dataset created.",
+                    isDismissable: true,
+                    autoDismiss: 5000
+                });
+                this.setState({ isPosting: false });
+                const datasetsOverviewPageURL = url.resolve("../../");
+                this.props.dispatch(push(datasetsOverviewPageURL));
+            })
+            .catch(error => {
+                let notificationMessage;
+                switch (error.status) {
+                    case 400: {
+                        notificationMessage =
+                            "Unable to create dataset due to invalid values being submitted. Please check your updates for any issues and try again";
+                        break;
+                    }
+                    case 403: {
+                        notificationMessage = "Unable to create dataset. It may already exist.";
+                        break;
+                    }
+                    case "FETCH_ERR": {
+                        notificationMessage = "Unable to create dataset due to a network issue. Please check your internet connection and try again";
+                        break;
+                    }
+                    default: {
+                        notificationMessage = "Unable to create dataset due to an unexpected error";
+                        break;
+                    }
+                }
+                notifications.add({
+                    type: "warning",
+                    message: notificationMessage,
+                    isDismissable: true,
+                    autoDismiss: 10000
+                });
+                this.setState({ isPosting: false });
+                log.event("Error creating dataset", log.error(error));
+                console.error("Error creating dataset\n", error);
+            });
+    };
+
+    handleBackButton = () => {
+        const previousUrl = url.resolve("../../");
+        this.props.dispatch(push(previousUrl));
+    };
+
+    render() {
+        console.log(this.state);
+        return (
+            <div className="grid grid--justify-center margin-bottom--2">
+                <div className="grid__col-9">
+                    <div className="margin-top--2">
+                        &#9664;{" "}
+                        <button type="button" className="btn btn--link" onClick={this.handleBackButton}>
+                            Back
+                        </button>
+                    </div>
+                    <h1 className="margin-top--1 margin-bottom--1">Create dataset</h1>
+                    <p className="font-size--18  margin-bottom--1">
+                        <span className="font-weight--600">for&nbsp;</span>
+                        {this.props.params.datasetID}
+                    </p>
+                    <div className="grid__col-2">
+                        <button type="button" className="btn btn--positive" disabled={this.state.isPosting} onClick={this.handleCreateClick}>
+                            Create dataset
+                        </button>
+                        {this.state.isPosting ? <div className="form__loader loader loader--dark margin-left--1"></div> : ""}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+CreateCantabularDatasetController.propTypes = propTypes;
+
+export default CreateCantabularDatasetController;

--- a/src/app/views/datasets-new/create/CreateCantabularDatasetController.jsx
+++ b/src/app/views/datasets-new/create/CreateCantabularDatasetController.jsx
@@ -40,17 +40,16 @@ export class CreateCantabularDatasetController extends Component {
         });
     };
 
-    makeCreateDatasetPostBody = format => {
+    makeCreateDatasetPostBody = () => {
         return {
-            type: format
+            type: this.state.format
         };
     };
 
     handleCreateClick = event => {
         event.preventDefault();
         const datasetID = this.state.datasetID;
-        const format = this.state.format;
-        const postBody = this.makeCreateDatasetPostBody(format);
+        const postBody = this.makeCreateDatasetPostBody();
         this.setState({ isPosting: true });
         return datasets
             .create(datasetID, postBody)
@@ -62,7 +61,7 @@ export class CreateCantabularDatasetController extends Component {
                     autoDismiss: 5000
                 });
                 this.setState({ isPosting: false });
-                const datasetsOverviewPageURL = url.resolve("../../");
+                const datasetsOverviewPageURL = url.resolve("../../../");
                 this.props.dispatch(push(datasetsOverviewPageURL));
             })
             .catch(error => {
@@ -104,7 +103,6 @@ export class CreateCantabularDatasetController extends Component {
     };
 
     render() {
-        console.log(this.state);
         return (
             <div className="grid grid--justify-center margin-bottom--2">
                 <div className="grid__col-9">
@@ -117,13 +115,12 @@ export class CreateCantabularDatasetController extends Component {
                     <h1 className="margin-top--1 margin-bottom--1">Create dataset</h1>
                     <p className="font-size--18  margin-bottom--1">
                         <span className="font-weight--600">for&nbsp;</span>
-                        {this.props.params.datasetID}
+                        {this.state.datasetID}
                     </p>
                     <div className="grid__col-2">
                         <button type="button" className="btn btn--positive" disabled={this.state.isPosting} onClick={this.handleCreateClick}>
-                            Create dataset
+                            {this.state.isPosting ? <div className="form__loader loader loader--dark margin-left--1"></div> : "Create"}
                         </button>
-                        {this.state.isPosting ? <div className="form__loader loader loader--dark margin-left--1"></div> : ""}
                     </div>
                 </div>
             </div>

--- a/src/app/views/datasets-new/create/CreateCantabularDatasetController.test.js
+++ b/src/app/views/datasets-new/create/CreateCantabularDatasetController.test.js
@@ -1,0 +1,92 @@
+import React from "react";
+import { CreateCantabularDatasetController } from "./CreateCantabularDatasetController";
+import { shallow, mount } from "enzyme";
+import datasets from "../../../utilities/api-clients/datasets";
+
+console.error = () => {};
+
+jest.mock("../../../utilities/notifications", () => {
+    return {
+        add: jest.fn(notification => {
+            mockNotifications.push(notification);
+        }),
+        remove: () => {}
+    };
+});
+
+jest.mock("../../../utilities/api-clients/datasets", () => {
+    return {
+        create: jest.fn(() => {
+            return Promise.resolve();
+        })
+    };
+});
+
+let mockNotifications = [];
+let dispatchedActions = [];
+
+const defaultProps = {
+    dispatch: event => {
+        dispatchedActions.push(event);
+    },
+    location: {
+        pathname: "florence/collections/12345/datasets/create"
+    },
+    params: {
+        datasetID: "test-id",
+        format: "test_format"
+    }
+};
+
+const component = shallow(<CreateCantabularDatasetController {...defaultProps} />);
+
+beforeEach(() => {
+    mockNotifications = [];
+    dispatchedActions = [];
+});
+
+test("makeCreateDatasetPostBody returns correct model", () => {
+    component.setState({ format: "test_format" });
+    const postBody = component.instance().makeCreateDatasetPostBody();
+    expect(postBody).toMatchObject({
+        type: "test_format"
+    });
+});
+
+describe("Calling handleCreateClick", () => {
+    const mockEvent = { preventDefault: () => {} };
+
+    it("updates isPosting state to show post of new dataset", () => {
+        expect(component.state("isPosting")).toBe(false);
+
+        // Tests that state is set correctly before asynchronous requests have finished
+        component.instance().handleCreateClick(mockEvent);
+        expect(component.state("isPosting")).toBe(true);
+    });
+
+    describe("on success", () => {
+        it("displays notification", async () => {
+            await component.instance().handleCreateClick(mockEvent);
+            expect(mockNotifications.length).toBe(1);
+        });
+
+        it("routes back to list of datasets page", async () => {
+            await component.instance().handleCreateClick(mockEvent);
+            expect(dispatchedActions[0].type).toBe("@@router/CALL_HISTORY_METHOD");
+        });
+
+        it("updates isPosting state to show it has created dataset", async () => {
+            // Tests that state is set correctly after asynchronous requests were successful
+            await component.instance().handleCreateClick(mockEvent);
+            expect(component.state("isPosting")).toBe(false);
+        });
+    });
+    describe("on failure", () => {
+        it("shows notification", async () => {
+            datasets.create.mockImplementationOnce(() => Promise.reject({ status: 404 }));
+            await component.instance().handleCreateClick(mockEvent);
+            expect(mockNotifications.length).toBe(1);
+            expect(component.state("isPosting")).toBe(false);
+        });
+    });
+});

--- a/src/app/views/datasets-new/create/CreateDatasetController.jsx
+++ b/src/app/views/datasets-new/create/CreateDatasetController.jsx
@@ -90,12 +90,12 @@ export class CreateDatasetController extends Component {
         recipes.items.forEach(recipe => {
             if (recipe.output_instances.length > 1) {
                 recipe.output_instances.forEach(output => {
-                    allOutputs.push(Object.assign({ format: recipe.format }, output));
+                    allOutputs.push({ ...output, format: recipe.format });
                 });
                 return;
             }
 
-            allOutputs.push(Object.assign({ format: recipe.format }, recipe.output_instances[0]));
+            allOutputs.push({ ...recipe.output_instances[0], format: recipe.format });
         });
         return allOutputs;
     };

--- a/src/app/views/datasets-new/create/CreateDatasetController.jsx
+++ b/src/app/views/datasets-new/create/CreateDatasetController.jsx
@@ -87,19 +87,15 @@ export class CreateDatasetController extends Component {
     // all possible outputs that can be created from a single recipe
     getAllOutputsFromRecipes = recipes => {
         const allOutputs = [];
-        const data = {};
         recipes.items.forEach(recipe => {
             if (recipe.output_instances.length > 1) {
                 recipe.output_instances.forEach(output => {
-                    data["outputInstance"] = output;
-                    data["format"] = recipe.format;
-                    allOutputs.push(data);
+                    allOutputs.push(Object.assign({ format: recipe.format }, output));
                 });
                 return;
             }
-            data["outputInstance"] = recipe.output_instances[0];
-            data["format"] = recipe.format;
-            allOutputs.push(data);
+
+            allOutputs.push(Object.assign({ format: recipe.format }, recipe.output_instances[0]));
         });
         return allOutputs;
     };
@@ -115,14 +111,14 @@ export class CreateDatasetController extends Component {
 
     mapOutputsToState = outputs => {
         return outputs.map(output => {
-            let outputUrl = this.props.location.pathname + "/" + output.outputInstance.dataset_id;
+            let outputUrl = `${this.props.location.pathname}/${output.dataset_id}`;
             if (output.format.includes("cantabular")) {
                 outputUrl += `/${output.format}`;
             }
 
             return {
-                title: output.outputInstance.title,
-                id: output.outputInstance.dataset_id,
+                title: output.title,
+                id: output.dataset_id,
                 url: outputUrl
             };
         });

--- a/src/app/views/datasets-new/create/CreateDatasetController.jsx
+++ b/src/app/views/datasets-new/create/CreateDatasetController.jsx
@@ -87,14 +87,19 @@ export class CreateDatasetController extends Component {
     // all possible outputs that can be created from a single recipe
     getAllOutputsFromRecipes = recipes => {
         const allOutputs = [];
+        const data = {};
         recipes.items.forEach(recipe => {
             if (recipe.output_instances.length > 1) {
                 recipe.output_instances.forEach(output => {
-                    allOutputs.push(output);
+                    data["outputInstance"] = output;
+                    data["format"] = recipe.format;
+                    allOutputs.push(data);
                 });
                 return;
             }
-            allOutputs.push(recipe.output_instances[0]);
+            data["outputInstance"] = recipe.output_instances[0];
+            data["format"] = recipe.format;
+            allOutputs.push(data);
         });
         return allOutputs;
     };
@@ -110,10 +115,15 @@ export class CreateDatasetController extends Component {
 
     mapOutputsToState = outputs => {
         return outputs.map(output => {
+            let outputUrl = this.props.location.pathname + "/" + output.outputInstance.dataset_id;
+            if (output.format.includes("cantabular")) {
+                outputUrl += `/${output.format}`;
+            }
+
             return {
-                title: output.title,
-                id: output.dataset_id,
-                url: this.props.location.pathname + "/" + output.dataset_id
+                title: output.outputInstance.title,
+                id: output.outputInstance.dataset_id,
+                url: outputUrl
             };
         });
     };

--- a/src/app/views/datasets-new/create/CreateDatasetController.test.js
+++ b/src/app/views/datasets-new/create/CreateDatasetController.test.js
@@ -255,7 +255,8 @@ describe("Calling getAllUncreatedDatasetFromRecipeOutputs", () => {
             expect(component.state("outputs")[0]).toMatchObject({
                 title: "Test dataset 3",
                 id: "test-dataset-3",
-                url: "florence/collections/12345/datasets/create/test-dataset-3"
+                url: "florence/collections/12345/datasets/create/test-dataset-3",
+                format: "v4"
             });
         });
         it("updates isFetchingRecipesAndDatasets state to show it has created dataset", async () => {

--- a/src/app/views/datasets-new/create/CreateDatasetController.test.js
+++ b/src/app/views/datasets-new/create/CreateDatasetController.test.js
@@ -144,28 +144,59 @@ const mockedAllRecipesCall = {
                     ]
                 }
             ]
+        },
+        {
+            id: "2943f3c5-c3f1-4a9a-aa6e-14d21c33524c",
+            alias: "TEST5",
+            format: "cantabular_table",
+            files: [],
+            output_instances: [
+                {
+                    dataset_id: "test-dataset-5",
+                    editions: ["time-series"],
+                    title: "Test dataset 5",
+                    code_lists: [
+                        {
+                            id: "mmm-yy",
+                            href: "http://localhost:22400/code-lists/mmm-yy",
+                            name: "time",
+                            is_hierarchy: false
+                        }
+                    ]
+                }
+            ]
         }
     ]
 };
 
 const mockedAllOutputs = [
     {
+        format: mockedAllRecipesCall.items[0].format,
         dataset_id: mockedAllRecipesCall.items[0].output_instances[0].dataset_id,
         editions: mockedAllRecipesCall.items[0].output_instances[0].editions,
         title: mockedAllRecipesCall.items[0].output_instances[0].title,
         code_lists: mockedAllRecipesCall.items[0].output_instances[0].code_lists
     },
     {
+        format: mockedAllRecipesCall.items[0].format,
         dataset_id: mockedAllRecipesCall.items[0].output_instances[1].dataset_id,
         editions: mockedAllRecipesCall.items[0].output_instances[1].editions,
         title: mockedAllRecipesCall.items[0].output_instances[1].title,
         code_lists: mockedAllRecipesCall.items[0].output_instances[1].code_lists
     },
     {
+        format: mockedAllRecipesCall.items[1].format,
         dataset_id: mockedAllRecipesCall.items[1].output_instances[0].dataset_id,
         editions: mockedAllRecipesCall.items[1].output_instances[0].editions,
         title: mockedAllRecipesCall.items[1].output_instances[0].title,
         code_lists: mockedAllRecipesCall.items[1].output_instances[0].code_lists
+    },
+    {
+        format: mockedAllRecipesCall.items[3].format,
+        dataset_id: mockedAllRecipesCall.items[3].output_instances[0].dataset_id,
+        editions: mockedAllRecipesCall.items[3].output_instances[0].editions,
+        title: mockedAllRecipesCall.items[3].output_instances[0].title,
+        code_lists: mockedAllRecipesCall.items[3].output_instances[0].code_lists
     }
 ];
 
@@ -251,12 +282,16 @@ describe("Calling getAllUncreatedDatasetFromRecipeOutputs", () => {
     describe("on success", () => {
         it("adds outputs to state", async () => {
             component.instance().getAllUncreatedDatasetFromRecipeOutputs();
-            expect(component.state("outputs")).toHaveLength(2);
+            expect(component.state("outputs")).toHaveLength(3);
             expect(component.state("outputs")[0]).toMatchObject({
                 title: "Test dataset 3",
                 id: "test-dataset-3",
-                url: "florence/collections/12345/datasets/create/test-dataset-3",
-                format: "v4"
+                url: "florence/collections/12345/datasets/create/test-dataset-3"
+            });
+            expect(component.state("outputs")[2]).toMatchObject({
+                title: "Test dataset 5",
+                id: "test-dataset-5",
+                url: "florence/collections/12345/datasets/create/test-dataset-5/cantabular_table"
             });
         });
         it("updates isFetchingRecipesAndDatasets state to show it has created dataset", async () => {
@@ -283,9 +318,11 @@ describe("Calling getAllUncreatedDatasetFromRecipeOutputs", () => {
 
 test("getAllOutputsFromRecipes returns correct values", () => {
     const outputs = component.instance().getAllOutputsFromRecipes(mockedAllRecipesCall);
+    expect(outputs).toHaveLength(5);
     expect(outputs[0]).toMatchObject(mockedAllOutputs[0]);
     expect(outputs[1]).toMatchObject(mockedAllOutputs[1]);
     expect(outputs[2]).toMatchObject(mockedAllOutputs[2]);
+    expect(outputs[4]).toMatchObject(mockedAllOutputs[3]);
 });
 
 test("getOutputsWithoutExistingDataset returns correct values", () => {

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ import DatasetVersionsController from "./app/views/datasets-new/versions/Dataset
 import DatasetMetadataController from "./app/views/datasets-new/edit-metadata/DatasetMetadataController";
 import CreateDatasetController from "./app/views/datasets-new/create/CreateDatasetController";
 import CreateDatasetTaxonomyController from "./app/views/datasets-new/create/CreateDatasetTaxonomyController";
+import CreateCantabularDatasetController from "./app/views/datasets-new/create/CreateCantabularDatasetController";
 import CreateVersionController from "./app/views/datasets-new/create/CreateVersionController";
 import CreateEditionController from "./app/views/datasets-new/create/CreateEditionController";
 import UsersController from "./app/views/users/UsersController";
@@ -121,6 +122,7 @@ class Index extends Component {
                                         <IndexRoute component={userIsAuthenticated(SelectADataset)} />
                                         <Route path="create">
                                             <IndexRoute component={userIsAuthenticated(CreateDatasetController)} />
+                                            <Route path=":datasetID/:format" component={userIsAuthenticated(CreateCantabularDatasetController)} />
                                             <Route path=":datasetID" component={userIsAuthenticated(CreateDatasetTaxonomyController)} />
                                         </Route>
                                         <Route path=":datasetID">

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2380,9 +2380,9 @@
           }
         },
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+          "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
         },
         "ssri": {
           "version": "8.0.1",
@@ -3507,9 +3507,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+          "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
           "dev": true
         }
       }
@@ -6619,9 +6619,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+          "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
         }
       }
     },


### PR DESCRIPTION
### What

- Amended route for Cantabular datasets
- Created new controller to handler Cantabular types with different POST body to non-Cantabular types
- Amended/added unit tests
- Updated `node-fetch` version

### How to review

#### Easy way
- Check unit tests pass
- Sanity check

#### End to end (the hard way)
Run these services:
- dp-frontend-dataset-controller `make debug ENABLE_CENSUS_PAGES=true`
- florence - use this branch 
- sixteens
- dp-frontend-router
- dp-publishing-dataset-controller
- dp-api-router
- dp-compose/cantabular-import
  - **N.B.** There are a number of services that are run via this subfolder of dp-compose

Step:
1. POST a cantabular recipe using Postman 
You'll need to update the headers to include your `X-Florence-Token` and send this example recipe (feel free to change to experiment)
```json
{
    "alias": "Some Cantabular",
    "cantabular_blob": "Example",
    "format": "cantabular_table",
    "id": "d773db66-b101-43ac-991d-cb2c99f6d5d1",
    "output_instances": [
        {
            
                "code_lists": [
                    {
                        "href": "http://localhost:22400/code-lists/city-regions",
                        "id": "city",
                        "is_hierarchy": false,
                        "name": "City"
                    },
                    {
                        "href": "http://localhost:22400/code-lists/siblings_3",
                        "id": "siblings_3",
                        "is_hierarchy": false,
                        "name": "Number Of Siblings (3 mappings)"
                    },
                    {
                        "href": "http://localhost:22400/code-lists/sex",
                        "id": "sex",
                        "is_hierarchy": false,
                        "name": "Sex"
                    }
            ],
            "dataset_id": "cantabular-1",
            "editions": [
                "2021"
            ],
            "title": "Another cantabular"
        }
    ]
}
```
2. Upload the dataset in Florence (follow on screen instructions)
3. Go back to your Collection and click `Create/edit content`
4. Click `Filterable dataset`
5. Create new dataset
6. Choose your dataset
7. Create the dataset
8. Click on your new dataset (if you used the above recipe, it will be `cantabular-1`)
9. Choose the latest edition (if you used the above recipe, it will be `2021`)
10. Click on Version: 1
11. Complete some metadata fields 
i. Title
ii. Release date
iii. Summary
iv. Contact (name, email and telephone)
v. Add a methodology
vi. Click `Save` and then `Preview` and the new census dataset landing page should be displayed
or `Save and submit for review` and go through the normal publishing steps (you'll need `The train`)

If you followed the above recipe and steps (even if you didn't publish; the joys of working locally 😄 ) the page will be available at:
[http://localhost:8081/datasets/cantabular-1](http://localhost:8081/datasets/cantabular-1) 😌 

### Who can review

Frontend dev, or anyone who knows and loves JS
