### PR TITLE
Call validation check after password has been updated

### DIFF
--- a/src/app/components/validate-new-password/NewPasswordInput.jsx
+++ b/src/app/components/validate-new-password/NewPasswordInput.jsx
@@ -63,11 +63,13 @@ export class NewPasswordInput extends Component {
     }
 
     handleInputChange = event => {
-        const passwordValue = event.target.value
-        this.setState(() => ({
-            password: passwordValue
-        }))
-        this.checkPasswordValidation();
+        const passwordValue = event.target.value;
+        this.setState(
+            () => ({
+                password: passwordValue
+            }),
+            this.checkPasswordValidation
+        );
     };
 
     togglePasswordVisibility = event => {

--- a/src/app/views/forgotten-password/setForgottenPasswordController.jsx
+++ b/src/app/views/forgotten-password/setForgottenPasswordController.jsx
@@ -1,15 +1,10 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import SetForgottenPasswordRequest from "./setForgottenPasswordRequest";
 import SetForgottenPasswordConfirmed from "./setForgottenPasswordConfirmed";
 import user from "../../utilities/api-clients/user";
 import { errCodes } from "../../utilities/errorCodes";
 import notifications from "../../utilities/notifications";
 import log from "../../utilities/logging/log";
-
-const propTypes = {
-    dispatch: PropTypes.func.isRequired
-};
 
 const status = {
     WAITING_USER_INPUT: "waiting for user input",
@@ -45,7 +40,7 @@ export class SetForgottenPasswordController extends Component {
         );
     };
 
-    requestPasswordChange() {
+    requestPasswordChange = () => {
         let verificationID = new URLSearchParams(location.search).get("vid");
         let userID = new URLSearchParams(location.search).get("uid");
         // UID is sent in Email field, for speed of first delivery it was decided UID is to be used instead of email.
@@ -69,9 +64,9 @@ export class SetForgottenPasswordController extends Component {
                     status: status.WAITING_USER_INPUT
                 });
             });
-    }
+    };
 
-    handlePasswordResetError(error) {
+    handlePasswordResetError = error => {
         const notification = {
             type: "warning",
             isDismissable: true,
@@ -104,7 +99,7 @@ export class SetForgottenPasswordController extends Component {
             outputGenericError();
         }
         notifications.add(notification);
-    }
+    };
 
     validityCheck = (isValid, password) => {
         // Only show input error if user had previously tried to submit password and it is still invalid
@@ -132,7 +127,5 @@ export class SetForgottenPasswordController extends Component {
         return <SetForgottenPasswordRequest {...setForgottenPasswordRequestProps} />;
     }
 }
-
-SetForgottenPasswordController.propTypes = propTypes;
 
 export default SetForgottenPasswordController;


### PR DESCRIPTION
### What

Validation for the forgotten password is being triggered before the state change. As such it actually validates the password minus the last character entered. This resolved that

- in addition, there is an error in the console about a required prop, but the prop is never used so has been removed.

### How to review

Pull the PR Run Florence with the feature flag `ENABLE_NEW_SIGN_IN=true`
Go to http://localhost:8081/florence/password-reset
Type in the password field, does it respond as expected (Now after a single lowercase character does it show a tick in the 'at least 1 lowercase character required' validation field
(Note submit won't work unless you create an account in Cognito)

### Who can review

Anyone except me
