### PR TITLE
feature: add preview button to collections

### DIFF
--- a/src/app/views/collections/details/CollectionDetails.jsx
+++ b/src/app/views/collections/details/CollectionDetails.jsx
@@ -371,6 +371,9 @@ export class CollectionDetails extends Component {
                             >
                                 Restore page
                             </button>
+                            <Link id="preview" to={`${location.pathname}/preview`} className="margin-left--1 btn btn--primary">
+                                Preview
+                            </Link>
                         </div>
                     </div>
                 </div>

--- a/src/app/views/teams/team-edit/TeamEditController.jsx
+++ b/src/app/views/teams/team-edit/TeamEditController.jsx
@@ -2,13 +2,11 @@ import React, { Component } from "react";
 import { connect } from "react-redux";
 import { push } from "react-router-redux";
 import PropTypes from "prop-types";
-
 import { updateActiveTeamMembers, addAllUsers } from "../../../config/actions";
 import user from "../../../utilities/api-clients/user";
 import teams from "../../../utilities/api-clients/teams";
 import notifications from "../../../utilities/notifications";
 import log from "../../../utilities/logging/log";
-
 import TeamEdit from "./TeamEdit";
 
 const propTypes = {
@@ -334,7 +332,7 @@ function mapStateToProps(state) {
         name: state.state.teams.active.name,
         members: state.state.teams.active.members,
         rootPath: state.state.rootPath,
-        users: state.users.all,
+        users: state.state.users.all,
     };
 }
 


### PR DESCRIPTION
### What

Tickets:
https://trello.com/c/Gg9AsQ9l/583-bug-post-1430-release-redirect-to-home-page-after-editing-url-in-the-browser-bar
https://trello.com/c/qb1uj9F4/561-preview-a-collection

The user has to copy and paste the preview URL and add '/preview' to the end. This makes it a more time consuming and arduous task that it needs to be and a 'preview' button on the collection summary page would fill the user need. This functionality broke after react update.
 Also, noticed regression on users object 
![Uploading ezgif.com-gif-maker.gif…]()

### How to review

![preview](https://user-images.githubusercontent.com/17829828/138910285-ccfd35ee-6d81-4951-a330-3a955bb83a7a.jpg)

### Who can review
all
