### PR TITLE
Release 1.43.0 regression issues - Use memo hook to prevent redirection

### DIFF
--- a/src/app/components/layout/Layout.jsx
+++ b/src/app/components/layout/Layout.jsx
@@ -1,4 +1,4 @@
-import React, { Component, useEffect, useState } from "react";
+import React, { Component, useEffect, useMemo, useState } from "react";
 import { hasValidAuthToken } from "../../utilities/hasValidAuthToken";
 import log from "../../utilities/logging/log";
 import notifications from "../../utilities/notifications";
@@ -11,17 +11,7 @@ import NavBar from "../../components/navbar";
 const Layout = props => {
     const [isCheckingAuthentication, setIsCheckingAuthentication] = useState(null);
 
-    useEffect(() => {
-        log.initialise();
-
-        window.setInterval(() => {
-            ping();
-        }, 10000);
-
-        checkAuthentication();
-    }, []);
-
-    const checkAuthentication = () => {
+    useMemo(() => {
         setIsCheckingAuthentication(true);
         hasValidAuthToken().then(isValid => {
             if (isValid) {
@@ -52,11 +42,19 @@ const Layout = props => {
             }
             setIsCheckingAuthentication(false);
         });
+    }, []);
+
+    useEffect(() => {
+        log.initialise();
+
+        window.setInterval(() => {
+            ping();
+        }, 10000);
 
         if (props.location.pathname !== "/florence/login" && props.enableNewSignIn) {
             sessionManagement.startSessionExpiryTimers();
         }
-    };
+    }, []);
 
     if (isCheckingAuthentication)
         return (


### PR DESCRIPTION
### What

After  refactoring the  Layout component to use hooks the auth check is too late and app uses redirect defined in index.js. This happens when users are coming form legacy. 
Previous solution used ComponentWillMount life cycle method for side effects to check if user is logged in. 
To solve this particular issue I decided to use for now useMemo hook which solves both problems. This solution will be replaced when user authentication be refactored as it is temporary patch to not hold release and it resotres the previous code equivalent. 

[BUG - post 1.43.0 release - Florence not able to  ‘preview’ collection once the collection is in the queue.](https://trello.com/c/eoeVeMJB/584-bug-post-1430-release-florence-not-able-to-preview-collection-once-the-collection-is-in-the-queue)
[BUG - post 1.43.0 release - Florence redirect to collections after preview exit](https://trello.com/c/GhO5hDVz/582-bug-post-1430-release-florence-redirect-to-collections-after-preview-exit)



### How to review
steps to reproduce in each ticket with video explanation 

### Who can review
Devs
