### PR TITLE
Feature/oldworld session timeout toasts

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { Router, Route, IndexRoute, IndexRedirect, Redirect } from "react-router
 import { routerActions } from "react-router-redux";
 import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
 import { store, history } from "./app/config/store";
-import { setConfig } from "./app/config/actions";
+import {setConfig} from "./app/config/actions";
 import auth from "./app/utilities/auth";
 import Layout from "./app/components/layout";
 import LoginController from "./app/views/login/LoginController";
@@ -45,7 +45,9 @@ import WorkflowPreview from "./app/views/workflow-preview/WorkflowPreview";
 import CreateContent from "./app/views/content/CreateContent";
 import NotFound from "./app/components/not-found";
 import "./scss/main.scss";
-
+import {errCodes} from "./app/utilities/errorCodes";
+import notifications from "./app/utilities/notifications";
+console.log('testing loading')
 const config = window.getEnv();
 store.dispatch(setConfig(config));
 
@@ -69,6 +71,20 @@ const userIsAdminOrEditor = connectedReduxRedirect({
     redirectPath: `${rootPath}/collections`,
     allowRedirectBack: false
 });
+
+const hasRedirect = () => {
+    const redirect = new URLSearchParams(window.location.search).get('redirect');
+    if (redirect) {
+        const notification = {
+            type: "neutral",
+            message: errCodes.SESSION_EXPIRED,
+            isDismissable: true,
+            autoDismiss: 20000,
+        };
+        notifications.add(notification);
+    }
+    return config.enableNewSignIn ? SignInController : LoginController;
+};
 
 const Index = () => {
     return (
@@ -175,7 +191,7 @@ const Index = () => {
                     )}
                     <Route path={`${rootPath}/selectable-list`} component={SelectableTest} />
                     <Route path={`${rootPath}/logs`} component={Logs} />
-                    <Route path={`${rootPath}/login`} component={config.enableNewSignIn ? SignInController : LoginController} />
+                    <Route path={`${rootPath}/login`} component={hasRedirect()} />
                     <Route path={`${rootPath}/forgotten-password`} component={config.enableNewSignIn ? ForgottenPasswordController : null} />
                     <Route path={`${rootPath}/password-reset`} component={config.enableNewSignIn ? SetForgottenPasswordController : null} />
                     <Route path="*" component={NotFound} />

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ import { Router, Route, IndexRoute, IndexRedirect, Redirect } from "react-router
 import { routerActions } from "react-router-redux";
 import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
 import { store, history } from "./app/config/store";
-import {setConfig} from "./app/config/actions";
+import { setConfig } from "./app/config/actions";
 import auth from "./app/utilities/auth";
 import Layout from "./app/components/layout";
 import LoginController from "./app/views/login/LoginController";
@@ -45,9 +45,8 @@ import WorkflowPreview from "./app/views/workflow-preview/WorkflowPreview";
 import CreateContent from "./app/views/content/CreateContent";
 import NotFound from "./app/components/not-found";
 import "./scss/main.scss";
-import {errCodes} from "./app/utilities/errorCodes";
+import { errCodes } from "./app/utilities/errorCodes";
 import notifications from "./app/utilities/notifications";
-console.log('testing loading')
 const config = window.getEnv();
 store.dispatch(setConfig(config));
 

--- a/src/legacy/js/functions/_handleApiError.js
+++ b/src/legacy/js/functions/_handleApiError.js
@@ -10,7 +10,8 @@ function handleApiError(response) {
 
     if (response.status === 403 || response.status === 401) {
         //sweetAlert('You are not logged in', 'Please refresh Florence and log back in.');
-        logout();
+        // passing pathname through so the user can be brought back to the page once they log back in
+        logout(window.location.pathname);
     } else if (response.status === 504) {
         sweetAlert('This task is taking longer than expected', "It will continue to run in the background.", "info");
     } else {

--- a/src/legacy/js/functions/_logout.js
+++ b/src/legacy/js/functions/_logout.js
@@ -1,7 +1,7 @@
 /**
  * Logout the current user and return to the login screen.
  */
-async function logout() {
+async function logout(currentPath) {
     if (Florence.globalVars.config.enableNewSignIn) {
         const response = await fetch('/tokens/self', {
             method: 'DELETE',
@@ -23,8 +23,12 @@ async function logout() {
     localStorage.setItem("loggedInAs", "");
     localStorage.setItem("userType", "");
 
-    // Redirect to refactored login page
-    window.location.pathname = "/florence/login";
+    // Redirect to login page adding an address to return to on login if one provided.
+    if (currentPath) {
+        window.location.href = "/florence/login?redirect=" + currentPath;
+    } else {
+        window.location.pathname = "/florence/login";
+    }
 }
 
 function delete_cookie(name) {


### PR DESCRIPTION
### What

Added redirect paths to url when returning to login screen from legacy Florence on session timeout.
Added check on login endpoint to add session expired notification if a redirect is in the url to give users context.

### How to review

Log in to Florence.
Remove your session cookie.
Navigate to a legacy Florence page.
You should be taken to the login screen, the url of the page you tried to view should be in the url as a redirect query param, a toast notification should appear saying that your session has expired.


### Who can review

Anyone but me
