### PR TITLE
Bug: Password change state reference error

### DIFF
--- a/src/app/views/users/change-password/ChangeUserPasswordController.jsx
+++ b/src/app/views/users/change-password/ChangeUserPasswordController.jsx
@@ -220,7 +220,7 @@ ChangeUserPasswordController.propTypes = propTypes;
 export function mapStateToProps(state) {
     return {
         rootPath: state.state.rootPath,
-        loggedInUser: state.state.user,
+        loggedInUser: state.user,
     };
 }
 

--- a/src/app/views/users/change-password/ChangeUserPasswordController.test.js
+++ b/src/app/views/users/change-password/ChangeUserPasswordController.test.js
@@ -527,10 +527,9 @@ describe("On input change component state updates", () => {
 describe("Mapping state to props", () => {
     it("logged in user details from state are mapped to 'loggedInUser' prop", () => {
         const state = {
-            state: {
-                user: {
-                    isAdmin: true,
-                },
+            state: {rootPath: "/florence"},
+            user: {
+                isAdmin: true,
             },
         };
         const mappedProps = mapStateToProps(state);


### PR DESCRIPTION
### What

Ticket:  [[BUG] User can't change password in Florence](https://trello.com/c/SlGAppNd/594-bug-user-cant-change-password-in-florence)

When user resets a password in Florence is getting a blank screen instead of Change password modal.
<img width="1724" alt="Screenshot 2021-11-04 at 10 21 02" src="https://user-images.githubusercontent.com/17829828/140298185-7048cb95-9a6b-4a41-a447-c6c13b025493.png">

### How to review

Log in to Florence
Go to Users and access
Click Change password button and you should be able to see the Modal Change password
![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/17829828/140298345-6d281b7e-59bb-4f70-97a9-c8046598d3b8.gif)


### Who can review

all
