### PR TITLE
bug: add back contact name in datasets edit view

### DIFF
--- a/src/app/views/datasets-new/edit-metadata/DatasetMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata/DatasetMetadata.jsx
@@ -226,7 +226,7 @@ const DatasetMetadata = ({
                 label="Contact name"
                 onChange={handleStringInputChange}
                 value={metadata.contactName}
-                disabled={props.disableForm}
+                disabled={disableForm}
                 />
             <Input
                 id="contact-email"

--- a/src/app/views/datasets-new/edit-metadata/DatasetMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata/DatasetMetadata.jsx
@@ -219,28 +219,15 @@ const DatasetMetadata = ({
                 legend={"National Statistic"}
                 disabled={disableForm}
             />
-
-            <RadioGroup
-                groupName="national-statistic"
-                radioData={[
-                    {
-                        id: "national-statistic-yes",
-                        value: "true",
-                        label: "Yes",
-                    },
-                    {
-                        id: "national-statistic-no",
-                        value: "false",
-                        label: "No",
-                    },
-                ]}
-                selectedValue={metadata.nationalStatistic ? metadata.nationalStatistic.toString() : "false"}
-                onChange={handleNationalStatisticChange}
-                inline={true}
-                legend={"National Statistic"}
-                disabled={disableForm}
-            />
-
+            <h2>Contact details</h2>
+            <Input
+                id="contact-name"
+                name="contactName"
+                label="Contact name"
+                onChange={handleStringInputChange}
+                value={metadata.contactName}
+                disabled={props.disableForm}
+                />
             <Input
                 id="contact-email"
                 name="contactEmail"
@@ -281,10 +268,8 @@ const DatasetMetadata = ({
                 handleDeleteClick={handleSimpleEditableListDelete}
                 disableActions={disableForm}
             />
-
             <h3 className="margin-top--1">Quality and methodology information</h3>
             <Input id="qmi" label="QMI URL" onChange={handleStringInputChange} value={metadata.qmi} disabled={disableForm} />
-
             <h3>Methodologies</h3>
             <SimpleEditableList
                 addText={"Add a methodology"}


### PR DESCRIPTION
### What

This bug was reported to support team. 
[Ticket](https://trello.com/c/THhQiWWY/597-bug-florence-metadata-missing-contact-name)

Details of request:On the metadata page, the option to amend the contact name has disappeared and been replaced by a duplicated National Statistics radio button. It's appearing on every dataset. 
<img width="536" alt="Screenshot 2021-11-11 100257" src="https://user-images.githubusercontent.com/17829828/141288754-9a516dca-6ea1-451e-b09f-045b2eaaee3d.png">

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
