### PR TITLE
bug: Florence Collections Details - Last edited page data was wrong

### DIFF
--- a/src/app/components/dynamic-list/DynamicListItem.jsx
+++ b/src/app/components/dynamic-list/DynamicListItem.jsx
@@ -35,7 +35,10 @@ const DynamicListItem = props => {
             <span className="dynamic-list-item__title">{props.title}</span>
             {props.desc && (
                 <>
-                    <span className="dynamic-list-item__separator" aria-hidden="true"> • </span>
+                    <span className="dynamic-list-item__separator" aria-hidden="true">
+                        {" "}
+                        •{" "}
+                    </span>
                     <span className="dynamic-list-item__desc">{props.desc}</span>
                 </>
             )}

--- a/src/app/views/collections/CollectionsController.jsx
+++ b/src/app/views/collections/CollectionsController.jsx
@@ -74,12 +74,8 @@ export class CollectionsController extends Component {
             .then(collections => {
                 const allCollectionsVisible = this.isViewer
                     ? collections
-                    : collections.filter(collection => {
-                          return collection.approvalStatus !== "COMPLETE";
-                      });
-                const allCollections = allCollectionsVisible.map(collection => {
-                    return collectionMapper.collectionResponseToState(collection);
-                });
+                    : collections.filter(collection => collection.approvalStatus !== "COMPLETE");
+                const allCollections = allCollectionsVisible.map(collection => collectionMapper.collectionResponseToState(collection));
                 this.props.dispatch(addAllCollections(allCollections));
                 this.setState({ isFetchingCollections: false });
             })

--- a/src/app/views/collections/create/CollectionCreateController.jsx
+++ b/src/app/views/collections/create/CollectionCreateController.jsx
@@ -132,6 +132,7 @@ export class CollectionCreateController extends Component {
     }
 
     handleCollectionNameValidation = event => {
+        if (!collections) return;
         const name = event.target.value.trim();
         const nameTaken = this.props.collections.some(c => c.name === name);
 

--- a/src/app/views/collections/mapper/collectionMapper.js
+++ b/src/app/views/collections/mapper/collectionMapper.js
@@ -66,12 +66,13 @@ export default class collectionMapper {
                     return null;
                 }
                 return pagesArray.map(page => {
+                    const lastEditedEvent = page.events && page.events.filter(e => e.type === "EDITED").pop(); //events coming sorted
                     let updatedPage = {};
                     try {
                         updatedPage = {
                             lastEdit: {
-                                email: page.events && page.events.length > 0 ? page.events[0].email : "",
-                                date: page.events && page.events.length > 0 ? page.events[0].date : "",
+                                email: lastEditedEvent && lastEditedEvent.email || "",
+                                date: lastEditedEvent && lastEditedEvent.date || ""
                             },
                             title: page.description.title,
                             edition: page.description.edition || "",

--- a/src/app/views/collections/mapper/collectionMapper.test.js
+++ b/src/app/views/collections/mapper/collectionMapper.test.js
@@ -44,7 +44,7 @@ const exampleUnmappedPages = [
         description: {
             title: "Environmental accounts",
         },
-        events: [{ email: "test@test.com", date: "2018-05-29T13:41:40.536Z" }],
+        events: [{ email: "test@test.com", date: "2018-05-29T13:41:40.536Z", type: "EDITED"}],
         type: "taxonomy_landing_page",
     },
     {
@@ -54,7 +54,7 @@ const exampleUnmappedPages = [
         description: {
             title: "Economy",
         },
-        events: [{ email: "test@test.com", date: "2018-05-28T10:23:13.569Z" }],
+        events: [{ email: "test@test.com", date: "2018-05-28T10:23:13.569Z", type: "EDITED" }],
         type: "taxonomy_landing_page",
     },
 ];
@@ -489,7 +489,7 @@ describe("Mapping a collections pages to state", () => {
                         title: "Second estimate of GDP",
                         edition: "October to December 2017",
                     },
-                    events: [{ email: "test@test.com", date: "2018-05-29T13:42:23.909Z" }],
+                    events: [{ email: "test@test.com", date: "2018-05-29T13:42:23.909Z", type: 'EDITED'}],
                     type: "bulletin",
                 },
             ],


### PR DESCRIPTION
### What
[Ticket](https://trello.com/c/PxfpfRHw/562-show-correct-lasteditdate-on-collection-screen)

Made changes to the code to show properly  **last edited** in the page of collections:  email of the person who edited and the date stamp. The events array comes already sorted so I used `pop()` which is the quickest way to get the last element form the array. 

Current code was **always** showing the first event, when the change in collection page has been created not edited and not the latest. 
  
<img width="1792" alt="Screenshot 2021-11-17 at 16 27 16" src="https://user-images.githubusercontent.com/17829828/142240665-88f0ca48-f800-4552-b35c-97bb409ab7ce.png">
### How to review
check code and reach out if you need demo 

### Who can review

front end devs
