### PR TITLE
Collection Name Validation

### DIFF
--- a/src/app/constants/Errors.js
+++ b/src/app/constants/Errors.js
@@ -1,0 +1,1 @@
+export const UNIQ_NAME_ERROR = "Collections must be given a name.";

--- a/src/app/views/collections/create/CollectionCreate.jsx
+++ b/src/app/views/collections/create/CollectionCreate.jsx
@@ -140,7 +140,6 @@ class CollectionCreate extends Component {
                         type="text"
                         error={this.props.newCollectionDetails.name.errorMsg}
                         value={this.props.newCollectionDetails.name.value}
-                        onBlur={this.props.handleCollectionNameValidation}
                         onChange={this.props.handleCollectionNameChange}
                     />
 

--- a/src/app/views/collections/create/CollectionCreateController.jsx
+++ b/src/app/views/collections/create/CollectionCreateController.jsx
@@ -8,6 +8,7 @@ import log from "../../../utilities/logging/log";
 import CollectionCreate from "./CollectionCreate";
 import { updateAllTeamIDsAndNames, updateAllTeams } from "../../../config/actions";
 import collectionValidation from "../validation/collectionValidation";
+import { UNIQ_NAME_ERROR } from "../../../constants/Errors";
 
 const propTypes = {
     user: PropTypes.shape({
@@ -21,6 +22,7 @@ const propTypes = {
         })
     ),
     dispatch: PropTypes.func.isRequired,
+    collections: PropTypes.array,
 };
 
 export class CollectionCreateController extends Component {
@@ -130,27 +132,6 @@ export class CollectionCreateController extends Component {
                 console.error("Error fetching all teams:\n", error);
             });
     }
-
-    handleCollectionNameValidation = event => {
-        if (!this.props.collections) return;
-
-        const name = event.target.value.trim();
-        const nameTaken = this.props.collections.some(c => c.name === name);
-
-        if (nameTaken) {
-            this.setState(prevState => ({
-                ...prevState,
-                newCollectionDetails: {
-                    ...prevState.newCollectionDetails,
-                    name: {
-                        ...prevState.newCollectionDetails.name,
-                        value: "",
-                        errorMsg: "A collection with this name already exists",
-                    },
-                },
-            }));
-        }
-    };
 
     handleCollectionNameChange = event => {
         const collectionName = {
@@ -342,7 +323,7 @@ export class CollectionCreateController extends Component {
 
         let hasError = false;
         let newCollectionDetails = this.state.newCollectionDetails;
-        const validatedName = collectionValidation.name(this.state.newCollectionDetails.name.value);
+        const validatedName = collectionValidation.name(this.state.newCollectionDetails.name.value, this.props.collections);
 
         if (!validatedName.isValid) {
             const collectionName = {
@@ -467,7 +448,7 @@ export class CollectionCreateController extends Component {
     };
 
     handle409SubmitStatus(error) {
-        if (error.body.message.includes("A collection with this name already exists")) {
+        if (error.body.message.includes(UNIQ_NAME_ERROR)) {
             log.event(
                 `error creating collection: collection name already exists`,
                 log.error(error),
@@ -477,7 +458,7 @@ export class CollectionCreateController extends Component {
             );
             const collectionName = {
                 value: this.state.newCollectionDetails.name.value,
-                errorMsg: "A collection with this name already exists",
+                errorMsg: UNIQ_NAME_ERROR,
             };
             const newCollectionDetails = {
                 ...this.state.newCollectionDetails,
@@ -522,7 +503,6 @@ export class CollectionCreateController extends Component {
                 <CollectionCreate
                     newCollectionDetails={this.state.newCollectionDetails}
                     handleCollectionNameChange={this.handleCollectionNameChange}
-                    handleCollectionNameValidation={this.handleCollectionNameValidation}
                     handleTeamSelection={this.handleTeamSelection}
                     handleRemoveTeam={this.handleRemoveTeam}
                     handleCollectionTypeChange={this.handleCollectionTypeChange}

--- a/src/app/views/collections/create/CollectionCreateController.test.js
+++ b/src/app/views/collections/create/CollectionCreateController.test.js
@@ -3,6 +3,7 @@ import { CollectionCreateController } from "./CollectionCreateController";
 import { mount, shallow } from "enzyme";
 import renderer from "react-test-renderer";
 import websocket from "../../../utilities/websocket";
+import { UNIQ_NAME_ERROR } from "../../../constants/Errors";
 
 jest.mock("../../../utilities/notifications", () => {
     return {
@@ -186,7 +187,27 @@ test("Handle publish time change updates state correctly", () => {
 test("Handle submit validates that a collection has a name", () => {
     const component = shallow(<CollectionCreateController {...defaultProps} />);
     component.instance().handleSubmit({ preventDefault: () => {} });
-    expect(component.update().state().newCollectionDetails.name.errorMsg).toBe("Collections must be given a name");
+    expect(component.update().state().newCollectionDetails.name.errorMsg).toBe("Collections must be given a name.");
+});
+
+test("Handle submit validates that a collection has a uniq name", () => {
+    const props = {
+        ...defaultProps,
+        collections: [{ ...newCollectionDetails, name: "Foo" }],
+    };
+    const component = shallow(<CollectionCreateController {...props} />);
+    component.setState({
+        newCollectionDetails: {
+            name: {
+                value: "Foo",
+                errorMsg: "Bar",
+            },
+            type: "Boo",
+        },
+    });
+    component.instance().handleSubmit({ preventDefault: () => {} });
+    expect(component.update().state().newCollectionDetails.name.errorMsg).not.toBe("Bar");
+    expect(component.update().state().newCollectionDetails.name.errorMsg).toBe(UNIQ_NAME_ERROR);
 });
 
 test("Handle submit validates that a scheduled collection has a date", () => {
@@ -195,7 +216,7 @@ test("Handle submit validates that a scheduled collection has a date", () => {
     const newCollection = { ...newCollectionDetails, name: name };
     component.setState({ newCollectionDetails: newCollection });
     component.instance().handleSubmit({ preventDefault: () => {} });
-    expect(component.update().state().newCollectionDetails.publishDate.errorMsg).toBe("Scheduled collections must be given a publish date");
+    expect(component.update().state().newCollectionDetails.publishDate.errorMsg).toBe("Scheduled collections must be given a publish date.");
 });
 
 test("Handle submit validates that a scheduled collection has a time", () => {
@@ -206,7 +227,7 @@ test("Handle submit validates that a scheduled collection has a time", () => {
     const newCollection = { ...newCollectionDetails, name: name, publishDate: date, publishTime: time };
     component.setState({ newCollectionDetails: newCollection });
     component.instance().handleSubmit({ preventDefault: () => {} });
-    expect(component.update().state().newCollectionDetails.publishTime.errorMsg).toBe("Scheduled collections must be given a publish time");
+    expect(component.update().state().newCollectionDetails.publishTime.errorMsg).toBe("Scheduled collections must be given a publish time.");
 });
 
 test("Make publish date returns correct date value", () => {

--- a/src/app/views/collections/create/__snapshots__/CollectionCreateController.test.js.snap
+++ b/src/app/views/collections/create/__snapshots__/CollectionCreateController.test.js.snap
@@ -22,7 +22,6 @@ exports[`Create collection form matches stored snapshot 1`] = `
         disabled={false}
         id="collection-name"
         name="collection-name"
-        onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
         type="text"

--- a/src/app/views/collections/edit/CollectionEdit.jsx
+++ b/src/app/views/collections/edit/CollectionEdit.jsx
@@ -132,7 +132,6 @@ class CollectionEdit extends Component {
                                 value={this.props.name}
                                 error={this.props.nameErrorMsg}
                                 onChange={this.handleNameChange}
-                                onBlur={this.props.handleCollectionNameValidation}
                             />
                             <Select
                                 id="collection-edit-teams"

--- a/src/app/views/collections/edit/CollectionEditController.jsx
+++ b/src/app/views/collections/edit/CollectionEditController.jsx
@@ -19,6 +19,7 @@ import collectionValidation from "../validation/collectionValidation";
 import collections from "../../../utilities/api-clients/collections";
 import date from "../../../utilities/date";
 import collectionMapper from "../mapper/collectionMapper";
+import { UNIQ_NAME_ERROR } from "../../../constants/Errors";
 
 const propTypes = {
     name: PropTypes.string.isRequired,
@@ -126,33 +127,14 @@ export class CollectionEditController extends Component {
             });
     }
 
-    handleCollectionNameValidation = event => {
-        if (!this.props.collections) return;
-
-        const name = event.target.value.trim();
-        if (name === this.props.name.trim()) return;
-
-        const nameTaken = this.props.collections.some(c => c.name === name);
-
-        if (nameTaken) {
-            this.setState(prevState => ({
-                ...prevState,
-                name: {
-                    ...prevState.name,
-                    value: "",
-                    errorMsg: "A collection with this name already exists.",
-                },
-            }));
-        }
-    };
-
     handleNameChange = name => {
-        this.setState({
+        this.setState(prevState => ({
+            ...prevState.name,
             name: {
                 value: name,
                 errorMsg: "",
             },
-        });
+        }));
     };
 
     handleAddTeam = teamID => {
@@ -270,12 +252,14 @@ export class CollectionEditController extends Component {
 
     handleSave = () => {
         let hasError = false;
+        if (this.state.name.value === this.props.name) return;
 
-        const validatedName = collectionValidation.name(this.state.name.value);
+        const validatedName = collectionValidation.name(this.state.name.value, this.props.collections);
+
         if (!validatedName.isValid) {
-            this.setState(state => ({
+            this.setState(prevState => ({
                 name: {
-                    ...state.name,
+                    ...prevState.name,
                     errorMsg: validatedName.errorMsg,
                 },
             }));
@@ -391,7 +375,7 @@ export class CollectionEditController extends Component {
                         this.setState(state => ({
                             name: {
                                 value: state.name.value,
-                                errorMsg: "A collection with this name already exists",
+                                errorMsg: UNIQ_NAME_ERROR,
                             },
                         }));
                         break;
@@ -399,7 +383,7 @@ export class CollectionEditController extends Component {
                     default: {
                         const notification = {
                             type: "warning",
-                            message: `An unexpected error occured whilst saving the edits to collection '${this.props.name}'`,
+                            message: `An unexpected error occurred whilst saving the edits to collection '${this.props.name}'`,
                             isDismissable: true,
                             autoDismiss: 4000,
                         };
@@ -479,7 +463,6 @@ export class CollectionEditController extends Component {
                 onPublishTimeChange={this.handlePublishTimeChange}
                 originalName={this.props.name}
                 name={this.state.name.value}
-                handleCollectionNameValidation={this.handleCollectionNameValidation}
                 nameErrorMsg={this.state.name.errorMsg}
                 originalPublishType={this.props.publishType}
                 publishType={this.state.publishType}

--- a/src/app/views/collections/validation/collectionValidation.js
+++ b/src/app/views/collections/validation/collectionValidation.js
@@ -4,8 +4,10 @@
  * @returns {object{isValid: boolean, errorMsg: string}} - Returns object with isValid boolean and an optional error message of why it's not valid
  */
 
+import { UNIQ_NAME_ERROR } from "../../../constants/Errors";
 export default class collectionValidation {
-    static name(name) {
+
+    static name(name, collections) {
         let response = {
             isValid: true,
             errorMsg: "",
@@ -21,7 +23,14 @@ export default class collectionValidation {
         if (!name || name.match(/^\s*$/)) {
             response = {
                 isValid: false,
-                errorMsg: "Collections must be given a name",
+                errorMsg: "Collections must be given a name.",
+            };
+        }
+
+        if (collections && collections.some(c => c.name === name.trim())) {
+            response = {
+                isValid: false,
+                errorMsg: UNIQ_NAME_ERROR,
             };
         }
 
@@ -32,7 +41,7 @@ export default class collectionValidation {
         if (!date) {
             return {
                 isValid: false,
-                errorMsg: "Scheduled collections must be given a publish date",
+                errorMsg: "Scheduled collections must be given a publish date.",
             };
         }
 
@@ -46,7 +55,7 @@ export default class collectionValidation {
         if (!time) {
             return {
                 isValid: false,
-                errorMsg: "Scheduled collections must be given a publish time",
+                errorMsg: "Scheduled collections must be given a publish time.",
             };
         }
 
@@ -60,7 +69,7 @@ export default class collectionValidation {
         if (!release.uri) {
             return {
                 isValid: false,
-                errorMsg: "Must select a release",
+                errorMsg: "Must select a release.",
             };
         }
 
@@ -74,14 +83,14 @@ export default class collectionValidation {
         if (!publishType) {
             return {
                 isValid: false,
-                errorMsg: "Collections must have a publish type",
+                errorMsg: "Collections must have a publish type.",
             };
         }
 
         if (publishType !== "manual" && publishType !== "scheduled") {
             return {
                 isValid: false,
-                errorMsg: "Collections must have a publish type",
+                errorMsg: "Collections must have a publish type.",
             };
         }
 

--- a/src/app/views/collections/validation/collectionValidation.test.js
+++ b/src/app/views/collections/validation/collectionValidation.test.js
@@ -1,6 +1,9 @@
 import collectionValidation from "./collectionValidation";
+import { UNIQ_NAME_ERROR } from "../../../constants/Errors";
 
 describe("Validating the collection name", () => {
+    const collections = [{ name: "Foo" }, { name: "Boo" }];
+
     it("returns 'false' if the collection name is missing", () => {
         expect(collectionValidation.name("").isValid).toBe(false);
     });
@@ -25,9 +28,20 @@ describe("Validating the collection name", () => {
         expect(collectionValidation.name("My collection").isValid).toBe(true);
     });
 
-    // TODO these should probably be written in a string sanitise function, which is not done yet
-    // it("trims whitespace from the beginning and end of the name")
-    // it("replaces double whitespace with single whitespace from the within the name")
+    it("returns false isValid and an error message if the collection name is already taken", () => {
+        expect(collectionValidation.name("Foo", collections).errorMsg).toBe(UNIQ_NAME_ERROR);
+        expect(collectionValidation.name("Foo", collections).isValid).toBe(false);
+    });
+
+    it("returns true and no error message if the collection name isn't in collections array", () => {
+        expect(collectionValidation.name("Bar", collections).errorMsg).toBeFalsy();
+        expect(collectionValidation.name("Bar", collections).isValid).toBe(true);
+    });
+
+    it("returns false and error message if the collection name difference with wite space only", () => {
+        expect(collectionValidation.name("Foo ", collections).errorMsg).toBe(UNIQ_NAME_ERROR);
+        expect(collectionValidation.name("Foo ", collections).isValid).toBe(false);
+    });
 });
 
 describe("Validating the collection publish date", () => {


### PR DESCRIPTION
### What

After testing the changes made to name validation it was brought to my attention users expect the validation to happen on submit more then on blur. I also decided to refactor now the feature to fit the user customs. 

I added name validation to existing validation class and added test for this addition. 

![name](https://user-images.githubusercontent.com/17829828/142849691-841b89db-fcb2-403c-a7ca-5a4f3db48866.jpg)


### How to review

please verify the code and tests

### Who can review

Describe who worked on the changes, so that other people can review.
