### PR TITLE
fix: add missed description and correct link

### DIFF
--- a/src/app/components/banner/Banner.jsx
+++ b/src/app/components/banner/Banner.jsx
@@ -24,7 +24,11 @@ const Banner = ({ data, handleBannerSave }) => {
                 <div className={clsx("banner", "margin-top--1", data.type)}>
                     <h3 className="banner-title">{data.title}</h3>
                     <p className="banner-description">{data.description}</p>
-                    <p className="banner-link">{`[${data.uri}] ${data.linkText}`}</p>
+                    <p className="banner-link">
+                        <a href={data.uri} title={data.uri} target="_blank">
+                            {data.linkText}
+                        </a>
+                    </p>
                 </div>
                 <div className="text-right">
                     <button type="button" className="btn btn--link" onClick={toggleForm}>

--- a/src/app/components/banner/Form.jsx
+++ b/src/app/components/banner/Form.jsx
@@ -7,7 +7,7 @@ import Select from "../Select";
 const Form = ({ data, handleFormSave, handleCancel }) => {
     const [type, setType] = useState(data ? data.type : "");
     const [title, setTitle] = useInput(data ? data.title : "");
-    const [description, setDescription] = useInput(data ? description : "");
+    const [description, setDescription] = useInput(data ? data.description : "");
     const [uri, setUri] = useInput(data ? data.uri : "");
     const [linkText, setLinkText] = useInput(data ? data.linkText : "");
 
@@ -24,14 +24,7 @@ const Form = ({ data, handleFormSave, handleCancel }) => {
     return (
         <div className="margin-top--1">
             <Input id="title" label="Title" type="text" {...title} />
-            <Select
-                id="type"
-                label="Type"
-                contents={options}
-                selectedOption={type}
-                showDefaultOption={false}
-                onChange={e => setType(e.target.value)}
-            />
+            <Select id="type" label="Type" contents={options} selectedOption={type} onChange={e => setType(e.target.value)} />
             <Input id="description" label="Description" type="textarea" {...description} />
             <div className="grid">
                 <div className="margin-right--2">

--- a/src/scss/components/_banner.scss
+++ b/src/scss/components/_banner.scss
@@ -1,6 +1,10 @@
 .banner {
   padding: 1rem;
   color: white;
+  > a, a:link, a:hover, a:visited {
+    color: white;
+  }
+
   &-link{
     padding-top: 0.5rem;
     text-decoration: underline;


### PR DESCRIPTION
### What

Corrections after testing:
- add description value on edit
- make uri part of link not separate 
-add default value
<img width="924" alt="Screenshot 2021-12-22 at 18 02 28" src="https://user-images.githubusercontent.com/17829828/147135932-6225c463-d708-4b83-b8e5-4133b1db7f52.png">

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
