### PR TITLE
Feature - Emergency banner,  expand test for 100% coverage

### DIFF
--- a/src/app/components/banner/Banner.test.js
+++ b/src/app/components/banner/Banner.test.js
@@ -124,8 +124,11 @@ describe("Banner", () => {
             expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("Test Title");
         });
 
-        test("allows edit existing banner values when Edit button is clicked", async () => {
-            render(<Banner {...props} />);
+        test("allows edit existing banner values", async () => {
+            const handleBannerSave = jest.fn(() => {
+                /*do nothing*/
+            });
+            render(<Banner {...props} handleBannerSave={handleBannerSave} />);
 
             expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("Test Title");
             expect(screen.getByTestId("banner")).toHaveClass("banner margin-top--1 local_emergency", { exact: true });
@@ -145,6 +148,32 @@ describe("Banner", () => {
             await expect(screen.queryByLabelText("Title")).toHaveValue("Test TitleBoo");
             await expect(screen.queryByLabelText("Type")).toHaveValue("national_emergency");
             await expect(screen.queryByLabelText("Description")).toHaveValue("My emergency descriptionFoo");
+
+            userEvent.click(screen.getByRole("button", { name: "Save emergency banner" }));
+
+            expect(handleBannerSave).toBeCalledWith({
+                description: "My emergency descriptionFoo",
+                linkText: "Read more",
+                title: "Test TitleBoo",
+                type: "national_emergency",
+                uri: "https://www.test.com/",
+            });
+        });
+
+        test("allows delete banner", async () => {
+            const handleBannerSave = jest.fn(() => {
+                /*do nothing*/
+            });
+            render(<Banner {...props} handleBannerSave={handleBannerSave} />);
+
+            expect(screen.queryByRole("button", { name: "Add an Emergency Banner" })).not.toBeInTheDocument();
+            expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("Test Title");
+            expect(screen.getByTestId("banner")).toHaveClass("banner margin-top--1 local_emergency", { exact: true });
+            expect(screen.getByTestId("description")).toHaveTextContent("My emergency description");
+
+            userEvent.click(screen.getByText("Delete"));
+
+            expect(handleBannerSave).toBeCalledWith({});
         });
 
         test("validates values filled in the Banner Form", () => {


### PR DESCRIPTION
### What

This quick and simple  PR is addition to the feature Emergency banner.
I noticed few functionality wasn't tested so I expanded  tests slightly so now newly created component has 100% coverage. 
(I left out the elements which were reused to put on the list of tech debt to fill in when time permitted as those components will be refactored later on.)

<img width="658" alt="Screenshot 2022-01-07 at 09 45 37" src="https://user-images.githubusercontent.com/17829828/148525221-52c81cf4-a0bf-4519-9e37-9cb814c1521c.png">


### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
