### PR TITLE
Feature/update post body for Cantabular types

### DIFF
--- a/src/app/views/datasets-new/create/CreateCantabularDatasetController.jsx
+++ b/src/app/views/datasets-new/create/CreateCantabularDatasetController.jsx
@@ -3,6 +3,7 @@ import { push } from "react-router-redux";
 import PropTypes from "prop-types";
 
 import datasets from "../../../utilities/api-clients/datasets";
+import recipes from "../../../utilities/api-clients/recipes";
 import notifications from "../../../utilities/notifications";
 import url from "../../../utilities/url";
 import log from "../../../utilities/logging/log";
@@ -11,7 +12,7 @@ const propTypes = {
     dispatch: PropTypes.func.isRequired,
     params: PropTypes.shape({
         datasetID: PropTypes.string.isRequired,
-        format: PropTypes.string.isRequired,
+        recipeID: PropTypes.string.isRequired,
     }),
     location: PropTypes.shape({
         pathname: PropTypes.string.isRequired,
@@ -24,24 +25,57 @@ export class CreateCantabularDatasetController extends Component {
 
         this.state = {
             isPosting: false,
+            isGettingRecipe: false,
             datasetID: "",
             format: "",
+            isBasedOn: "",
         };
     }
 
     UNSAFE_componentWillMount = () => {
         this.setStateFromParameters();
+        this.getRecipe();
     };
 
     setStateFromParameters = () => {
         this.setState({
             datasetID: this.props.params.datasetID,
-            format: this.props.params.format,
         });
+    };
+
+    handleGETSuccess = recipe => {
+        this.setState({
+            format: recipe.format,
+            isBasedOn: recipe.cantabular_blob,
+        });
+    };
+
+    getRecipe = () => {
+        const recipeId = this.props.params.recipeID;
+        this.setState({ isGettingRecipe: true });
+        return recipes
+            .get(recipeId)
+            .then(recipe => {
+                this.setState({ isGettingRecipe: false });
+                this.handleGETSuccess(recipe);
+            })
+            .catch(error => {
+                log.event("get recipe: error GETting recipe", log.data({ recipeId }), log.error());
+                notifications.add({
+                    type: "warning",
+                    message: "An error occurred when getting recipe information. Please try again",
+                    isDismissable: true,
+                });
+                console.error("get metadata: error GETting metadata from controller", error);
+            });
     };
 
     makeCreateDatasetPostBody = () => {
         return {
+            is_based_on: {
+                id: this.state.isBasedOn,
+                type: this.state.format,
+            },
             type: this.state.format,
         };
     };
@@ -114,11 +148,22 @@ export class CreateCantabularDatasetController extends Component {
                     </div>
                     <h1 className="margin-top--1 margin-bottom--1">Create dataset</h1>
                     <p className="font-size--18  margin-bottom--1">
-                        <span className="font-weight--600">for&nbsp;</span>
-                        {this.state.datasetID}
+                        {this.state.isGettingRecipe ? (
+                            <div className="loader loader--dark"></div>
+                        ) : (
+                            <div>
+                                <span className="font-weight--600">for&nbsp;</span>
+                                {this.state.datasetID}
+                            </div>
+                        )}
                     </p>
                     <div className="grid__col-2">
-                        <button type="button" className="btn btn--positive" disabled={this.state.isPosting} onClick={this.handleCreateClick}>
+                        <button
+                            type="button"
+                            className="btn btn--positive"
+                            disabled={this.state.isPosting || this.state.isGettingRecipe}
+                            onClick={this.handleCreateClick}
+                        >
                             {this.state.isPosting ? <div className="form__loader loader loader--dark margin-left--1"></div> : "Create"}
                         </button>
                     </div>

--- a/src/app/views/datasets-new/create/CreateCantabularDatasetController.test.js
+++ b/src/app/views/datasets-new/create/CreateCantabularDatasetController.test.js
@@ -2,6 +2,7 @@ import React from "react";
 import { CreateCantabularDatasetController } from "./CreateCantabularDatasetController";
 import { shallow } from "enzyme";
 import datasets from "../../../utilities/api-clients/datasets";
+import recipes from "../../../utilities/api-clients/recipes";
 
 console.error = () => {};
 
@@ -22,6 +23,14 @@ jest.mock("../../../utilities/api-clients/datasets", () => {
     };
 });
 
+jest.mock("../../../utilities/api-clients/recipes", () => {
+    return {
+        get: jest.fn(() => {
+            return Promise.resolve(mockedRecipeCall);
+        }),
+    };
+});
+
 let mockNotifications = [];
 let dispatchedActions = [];
 
@@ -34,11 +43,39 @@ const defaultProps = {
     },
     params: {
         datasetID: "test-id",
-        format: "test_format",
+        recipeID: "2943f3c5-c3f1-4a9a-aa6e-14d21c33524c",
     },
 };
 
 const component = shallow(<CreateCantabularDatasetController {...defaultProps} />);
+
+const mockedRecipeCall = {
+    id: "2943f3c5-c3f1-4a9a-aa6e-14d21c33524c",
+    alias: "TEST5",
+    format: "cantabular_flexible_table",
+    files: [],
+    cantabular_blob: "test_blob",
+    output_instances: [
+        {
+            dataset_id: "test-dataset-5",
+            editions: ["time-series"],
+            title: "Test dataset 5",
+            code_lists: [
+                {
+                    id: "mmm-yy",
+                    href: "http://localhost:22400/code-lists/mmm-yy",
+                    name: "time",
+                    is_hierarchy: false,
+                },
+            ],
+        },
+    ],
+};
+
+const mockedState = {
+    format: mockedRecipeCall.format,
+    isBasedOn: mockedRecipeCall.cantabular_blob,
+};
 
 beforeEach(() => {
     mockNotifications = [];
@@ -46,10 +83,35 @@ beforeEach(() => {
 });
 
 test("makeCreateDatasetPostBody returns correct model", () => {
-    component.setState({ format: "test_format" });
+    component.setState({
+        format: mockedState.format,
+        isBasedOn: mockedState.isBasedOn,
+    });
     const postBody = component.instance().makeCreateDatasetPostBody();
     expect(postBody).toMatchObject({
-        type: "test_format",
+        type: mockedState.format,
+        is_based_on: {
+            id: mockedState.isBasedOn,
+            type: mockedState.format,
+        },
+    });
+});
+
+describe("calling getRecipe", () => {
+    it("returns recipe on success", async () => {
+        expect(component.state("isGettingRecipe")).toBe(false);
+        await component.instance().getRecipe();
+        expect(component.state("format")).toMatch(mockedState.format);
+        expect(component.state("isBasedOn")).toMatch(mockedState.isBasedOn);
+        expect(component.state("isGettingRecipe")).toBe(false);
+    });
+
+    it("shows notification on fail", async () => {
+        recipes.get.mockImplementationOnce(() => Promise.reject({ status: 500 }));
+        await component.instance().getRecipe();
+        expect(mockNotifications.length).toBe(1);
+        // create button is still disabled
+        expect(component.state("isGettingRecipe")).toBe(true);
     });
 });
 

--- a/src/app/views/datasets-new/create/CreateDatasetController.jsx
+++ b/src/app/views/datasets-new/create/CreateDatasetController.jsx
@@ -90,12 +90,11 @@ export class CreateDatasetController extends Component {
         recipes.items.forEach(recipe => {
             if (recipe.output_instances.length > 1) {
                 recipe.output_instances.forEach(output => {
-                    allOutputs.push({ ...output, format: recipe.format });
+                    allOutputs.push({ ...output, format: recipe.format, recipeID: recipe.id });
                 });
                 return;
             }
-
-            allOutputs.push({ ...recipe.output_instances[0], format: recipe.format });
+            allOutputs.push({ ...recipe.output_instances[0], format: recipe.format, recipeID: recipe.id });
         });
         return allOutputs;
     };
@@ -113,7 +112,7 @@ export class CreateDatasetController extends Component {
         return outputs.map(output => {
             let outputUrl = `${this.props.location.pathname}/${output.dataset_id}`;
             if (output.format.includes("cantabular")) {
-                outputUrl += `/${output.format}`;
+                outputUrl += `/${output.recipeID}`;
             }
 
             return {

--- a/src/app/views/datasets-new/create/CreateDatasetController.test.js
+++ b/src/app/views/datasets-new/create/CreateDatasetController.test.js
@@ -291,7 +291,7 @@ describe("Calling getAllUncreatedDatasetFromRecipeOutputs", () => {
             expect(component.state("outputs")[2]).toMatchObject({
                 title: "Test dataset 5",
                 id: "test-dataset-5",
-                url: "florence/collections/12345/datasets/create/test-dataset-5/cantabular_table",
+                url: "florence/collections/12345/datasets/create/test-dataset-5/2943f3c5-c3f1-4a9a-aa6e-14d21c33524c",
             });
         });
         it("updates isFetchingRecipesAndDatasets state to show it has created dataset", async () => {

--- a/src/app/views/uploads/dataset/upload-details/DatasetUploadMetadata.jsx
+++ b/src/app/views/uploads/dataset/upload-details/DatasetUploadMetadata.jsx
@@ -120,7 +120,7 @@ class DatasetUploadMetadata extends Component {
             return recipe.id === this.props.job.recipe;
         });
         let isRecipeCantabular = false;
-        if (recipe.format === "cantabular_table" || recipe.format === "cantabular_blob") {
+        if (recipe.format.includes("cantabular")) {
             isRecipeCantabular = true;
         }
 

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ const Index = () => {
                                 <IndexRoute component={userIsAuthenticated(SelectADataset)} />
                                 <Route path="create">
                                     <IndexRoute component={userIsAuthenticated(CreateDatasetController)} />
-                                    <Route path=":datasetID/:format" component={userIsAuthenticated(CreateCantabularDatasetController)} />
+                                    <Route path=":datasetID/:recipeID" component={userIsAuthenticated(CreateCantabularDatasetController)} />
                                     <Route path=":datasetID" component={userIsAuthenticated(CreateDatasetTaxonomyController)} />
                                 </Route>
                                 <Route path=":datasetID">


### PR DESCRIPTION
### What

- Updated POST /datasets body to
```
is_based_on: {
    id: this.state.isBasedOn,
    type: this.state.format,
},
type: this.state.format,
```
- Changed conditionals to look for 'includes' `cantabular` rather than being specific types
- Refactored `CreateCantabularDatasetController` to perform a GET instead of relying on query string parameters 
- Updated unit tests

### How to review

- Sense check
- Tests pass

### Who can review

Anyone but me
