### PR TITLE
Enable dataset import by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The following environment variables are available when running the Go server.
 | DATASET_API_URL              | http://localhost:22000            | URL that the [dataset API](https://github.com/ONSdigital/dp-dataset-api) can be accessed on                                              |
 | TABLE_RENDERER_URL           | http://localhost:23300            | The URL that dp-table-renderer can be accessed on                                                                                        | |
 | DATASET_CONTROLLER_URL       | http://localhost:24000            | Dataset controller url                                                                                                                   |
-| ENABLE_DATASET_IMPORT        | false                             | Displays the screens to allow filterable datasets to be imported through Florence (note: it requires the whole CMD stack to be running)  |
+| ENABLE_DATASET_IMPORT        | true                              | Displays the screens to allow filterable datasets to be imported through Florence (note: it requires the whole CMD stack to be running)  |
 | GRACEFUL_SHUTDOWN_TIMEOUT    | 10s                               | The graceful shutdown timeout in seconds
 | HEALTHCHECK_INTERVAL         | 30s                               | The period of time between health checks                                                                                                 |
 | HEALTHCHECK_CRITICAL_TIMEOUT | 90s                               | The period of time after which failing checks will result in critical global check status                                                |

--- a/config/config.go
+++ b/config/config.go
@@ -44,7 +44,7 @@ func Get() (*Config, error) {
 		DatasetControllerURL:       "http://localhost:24000",
 		TableRendererURL:           "http://localhost:23300",
 		TopicsURL:                  "http://localhost:25300",
-		SharedConfig:               SharedConfig{EnableDatasetImport: false, EnableHomepagePublishing: false, EnableNewSignIn: false},
+		SharedConfig:               SharedConfig{EnableDatasetImport: true, EnableHomepagePublishing: false, EnableNewSignIn: false},
 		GracefulShutdownTimeout:    10 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,7 +22,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			DatasetControllerURL:       "http://localhost:24000",
 			TableRendererURL:           "http://localhost:23300",
 			TopicsURL:                  "http://localhost:25300",
-			SharedConfig:               SharedConfig{EnableDatasetImport: false, EnableHomepagePublishing: false, EnableNewSignIn: false},
+			SharedConfig:               SharedConfig{EnableDatasetImport: true, EnableHomepagePublishing: false, EnableNewSignIn: false},
 			GracefulShutdownTimeout:    10 * time.Second,
 			HealthCheckInterval:        30 * time.Second,
 			HealthCheckCriticalTimeout: 90 * time.Second,


### PR DESCRIPTION
### What
The `ENABLE_DATASET_IMPORT` feature flag is ON in production and development, and it has been like that for years. However locally we still rely on setting an environment variable, which sometimes causes confusion: different behaviour on environments than locally.
There is even [documentation](https://github.com/ONSdigital/dp/blob/main/guides/INSTALLING.md#running-the-apps) to set this variable when running it locally (this will be updated)
Ideally we'll need to tidy up this flag but just setting it to true for now so that devs don't need to do anything special for Florence to behave like prod. 

### How to review

Check changes make sense.

### Who can review

Anyone