### PR TITLE
feature: add ability to filter users

### DIFF
--- a/src/app/components/back-button/BackButton.jsx
+++ b/src/app/components/back-button/BackButton.jsx
@@ -8,7 +8,10 @@ function BackButton({ text = "Back", redirectUrl, classNames }) {
     const to = redirectUrl ? redirectUrl : url.resolve("../");
     return (
         <div className={clsx(classNames)}>
-            &#9664;&nbsp;<Link role="link" to={to}>{text}</Link>
+            &#9664;&nbsp;
+            <Link role="link" to={to}>
+                {text}
+            </Link>
         </div>
     );
 }

--- a/src/app/components/selected-items/SelectedItemList.jsx
+++ b/src/app/components/selected-items/SelectedItemList.jsx
@@ -5,7 +5,13 @@ import SelectedItem from "./SelectedItem";
 const SelectedItemList = ({ items, removeClassNames, classNames, handleRemoveItem }) => (
     <div className="selected-item-list">
         {items.map((selectedItem, index) => (
-            <SelectedItem key={index} removeClassNames={removeClassNames} classNames={classNames} {...selectedItem} handleRemoveItem={handleRemoveItem} />
+            <SelectedItem
+                key={index}
+                removeClassNames={removeClassNames}
+                classNames={classNames}
+                {...selectedItem}
+                handleRemoveItem={handleRemoveItem}
+            />
         ))}
     </div>
 );

--- a/src/app/config/selectors.js
+++ b/src/app/config/selectors.js
@@ -48,17 +48,18 @@ export const getUserLoading = state => state.user.isLoading;
 export const getUserAddingToGroups = state => state.isUserAddingToGroups;
 
 export const getUsers = state => state.users.all;
+
+export const getActiveUsers = createSelector(getUsers, users => {
+    if (!users) return [];
+    return users.filter(user => user.active === true);
+});
+
+export const getSuspendedUsers = createSelector(getUsers, users => {
+    if (!users) return [];
+    return users.filter(user => user.active === false);
+});
+
 export const getUsersLoading = state => state.users.isLoading;
 export const getRootPath = state => state.rootPath;
 
 export const getUserGroups = state => state.user.groups;
-
-export const getMappedUsers = createSelector(getUsers, getRootPath, (users, rootPath) => {
-    if (!users) return [];
-    return users.map(user => ({
-        ...user,
-        title: `${user.forename} ${user.lastname}`,
-        details: [user.email],
-        url: `${rootPath}/users/${user.id}`,
-    }));
-});

--- a/src/app/config/thunks.js
+++ b/src/app/config/thunks.js
@@ -208,8 +208,7 @@ export const fetchGroupsRequest = isNewSignIn => dispatch => {
 
 export const createUserRequest = body => dispatch => {
     dispatch(actions.createUserProgress());
-    user
-        .createNewUser(body)
+    user.createNewUser(body)
         .then(response => {
             console.log("response", response); // TODO: leaving this here to check what is actually coming back as couldn't test locally
             dispatch(actions.createUserSuccess());
@@ -233,8 +232,7 @@ export const createUserRequest = body => dispatch => {
 
 export const fetchUserGroupsRequest = id => dispatch => {
     dispatch(actions.loadUserGroupsProgress());
-    user
-        .getUserGroups(id)
+    user.getUserGroups(id)
         .then(response => {
             dispatch(actions.loadUserGroupsSuccess(response.groups));
         })
@@ -265,20 +263,18 @@ export const updateUserRequest = (id, body) => dispatch => {
         });
 };
 
-export const getUsersRequest =
-    (params = { active: true }) =>
-    dispatch => {
-        dispatch(actions.loadUsersProgress());
-        users
-            .getAll(params)
-            .then(response => {
-                dispatch(actions.loadUsersSuccess(response.users));
-            })
-            .catch(error => {
-                dispatch(actions.loadUsersFailure());
-                console.error(error);
-            });
-    };
+export const getUsersRequest = () => dispatch => {
+    dispatch(actions.loadUsersProgress());
+    users
+        .getUsers()
+        .then(response => {
+            dispatch(actions.loadUsersSuccess(response.users));
+        })
+        .catch(error => {
+            dispatch(actions.loadUsersFailure());
+            console.error(error);
+        });
+};
 
 export const createTeam = (body, usersInTeam) => dispatch => {
     teams

--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -85,6 +85,11 @@ export default class user {
     }
 
     // TODO: new auth work
+    static getUsers() {
+        return http.get(`/users`);
+    }
+
+    // TODO: new auth work
     static createNewUser(body) {
         return http.post(`/users`, body);
     }

--- a/src/app/views/users/UsersList.jsx
+++ b/src/app/views/users/UsersList.jsx
@@ -1,27 +1,36 @@
 import React, { useEffect, useState, useCallback } from "react";
-import filter from "lodash/filter";
 import PropTypes from "prop-types";
-import log from "../../utilities/logging/log";
-import auth from "../../utilities/auth";
-import url from "../../utilities/url";
-import SimpleSelectableList from "../../components/simple-selectable-list/SimpleSelectableList";
 import { useInput } from "../../hooks/useInput";
 import { Link } from "react-router";
+import filter from "lodash/filter";
+import SimpleSelectableList from "../../components/simple-selectable-list/SimpleSelectableList";
 import BackButton from "../../components/back-button";
 import Magnifier from "../../icons/Magnifier";
+import clsx from "clsx";
+import Loader from "../../components/loader/Loader";
+
+const mapUsers = (users, rootPath) => {
+    return users.map(user => ({
+        ...user,
+        title: `${user.forename} ${user.lastname}`,
+        details: [user.email],
+        url: `${rootPath}/users/${user.id}`,
+    }));
+};
 
 const UsersList = props => {
-    const { users, loading, rootPath, loadUsers, loggedInUser } = props;
-    const isAdmin = auth.isAdmin(loggedInUser);
+    const { active, suspended, loading, rootPath, loadUsers } = props;
+    const [showActiveUsers, setShowActiveUsers] = useState(true);
     const [search, setSearch] = useInput("");
 
     useEffect(() => {
         loadUsers();
     }, []);
 
+    const users = showActiveUsers ? mapUsers(active, rootPath) : mapUsers(suspended, rootPath);
     const getFilteredUsers = useCallback(() => {
         const str = search.value.toLowerCase();
-        return filter(users, user => ((user.forename + ' ' + user.lastname).toLowerCase().includes(str) || user.email.toLowerCase().includes(str)));
+        return filter(users, user => (user.forename + " " + user.lastname).toLowerCase().includes(str) || user.email.toLowerCase().includes(str));
     }, [search.value]);
 
     return (
@@ -38,16 +47,53 @@ const UsersList = props => {
                         </Link>
                     </div>
                 </div>
-                <div className="grid">
-                    <div className="search__input-group margin-bottom--1">
-                        <Magnifier classes="search__icon-magnifier" viewBox="0 0 28 28" />
-                        <label htmlFor="search" className="visually-hidden">
-                            Search users by name
-                        </label>
-                        <input role="search" name="search" placeholder="Search users by name" {...search} />
+                {loading ? (
+                    <div className="grid grid--justify-center grid--align-center">
+                        <Loader classNames="loader--dark loader--large" />
                     </div>
-                </div>
-                <SimpleSelectableList rows={search.value ? getFilteredUsers() : users} showLoadingState={loading} />
+                ) : (
+                    <>
+                        <div className="grid grid--justify-space-between grid--align-center margin-bottom--1">
+                            <div className="grid__col-md-4">
+                                <div className="search__input-group ">
+                                    <Magnifier classes="search__icon-magnifier" viewBox="0 0 28 28" />
+                                    <label htmlFor="search" className="visually-hidden">
+                                        Search users by name
+                                    </label>
+                                    <input role="search" name="search" placeholder="Search users by name" {...search} />
+                                </div>
+                            </div>
+                            <div className="grid__col-md-4">
+                                <div className="btn-group">
+                                    <div className="form__label inline">Show</div>
+                                    <label htmlFor="active" className="visually-hidden">
+                                        Show active users
+                                    </label>
+                                    <button
+                                        onClick={() => setShowActiveUsers(true)}
+                                        id="active"
+                                        aria-pressed={showActiveUsers}
+                                        className={clsx("btn btn--margin-left", showActiveUsers ? "btn--primary" : "btn--link")}
+                                    >
+                                        Active users
+                                    </button>
+                                    <label htmlFor="suspended" className="visually-hidden">
+                                        Show suspended users
+                                    </label>{" "}
+                                    <button
+                                        onClick={() => setShowActiveUsers(false)}
+                                        aria-pressed={showActiveUsers}
+                                        id="suspended"
+                                        className={clsx("btn btn--margin-left", !showActiveUsers ? "btn--primary" : "btn--link")}
+                                    >
+                                        Suspended
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        {users ? <SimpleSelectableList rows={search.value ? getFilteredUsers() : users} /> : "Nothing to show."}
+                    </>
+                )}
             </div>
         </div>
     );
@@ -59,7 +105,7 @@ UsersList.propTypes = {
         userID: PropTypes.string,
     }).isRequired,
     loggedInUser: PropTypes.object,
-    users: PropTypes.arrayOf(
+    active: PropTypes.arrayOf(
         PropTypes.shape({
             forename: PropTypes.string,
             lastname: PropTypes.string,

--- a/src/app/views/users/UsersList.test.js
+++ b/src/app/views/users/UsersList.test.js
@@ -83,6 +83,6 @@ describe("UserList", () => {
 
         expect(screen.getByLabelText("Show active users", { pressed: false })).toBeInTheDocument();
         expect(screen.getByLabelText("Show suspended users", { pressed: true })).toBeInTheDocument();
-        expect(screen.getByText(/nothing to show/)).toBeInTheDocument();
+        expect(screen.getByText(/nothing to show/i)).toBeInTheDocument();
     });
 });

--- a/src/app/views/users/UsersList.test.js
+++ b/src/app/views/users/UsersList.test.js
@@ -1,39 +1,13 @@
 import React from "react";
 import { render, screen, createMockUser } from "../../utilities/tests/test-utils";
+import userEvent from "@testing-library/user-event";
 import UsersList from "./UsersList";
+import { user } from "../../utilities/tests/mockData";
 
 const admin = createMockUser("admin@test.com", true, true, "ADMIN");
-const mockedAllUsers = [
-    {
-        active: true,
-        details: ["test.user-1498@ons.gov.uk"],
-        email: "test.user-1498@ons.gov.uk",
-        forename: "Test1",
-        groups: [],
-        id: "test.user-1498@ons.gov.uk",
-        lastname: "Surname 1498",
-        status: "CONFIRMED",
-        status_notes: "This user was nice ",
-        title: "Test1 Surname 1498",
-        url: "/florence/users/test.user-1498@ons.gov.uk",
-    },
-    {
-        active: true,
-        details: ["test.user-642@ons.gov.uk"],
-        email: "test.user-642@ons.gov.uk",
-        forename: "Test2",
-        groups: [],
-        id: "test.user-642@ons.gov.uk",
-        lastname: "Surname 642",
-        status: "CONFIRMED",
-        status_notes: "this user was ok ",
-        title: "Test2 Surname 642",
-        url: "/florence/users/test.user-642@ons.gov.uk",
-    },
-];
-
 const props = {
-    users: [],
+    active: [],
+    suspended: [],
     loading: false,
     params: {},
     rootPath: "test",
@@ -56,7 +30,7 @@ describe("UserList", () => {
         expect(props.loadUsers).toBeCalled();
     });
 
-    it("renders loader when fetching users", () => {
+    it("shows loader when fetching users", () => {
         const newProps = {
             ...props,
             loading: true,
@@ -65,18 +39,50 @@ describe("UserList", () => {
         expect(screen.getByTestId("loader")).toBeInTheDocument();
     });
 
-    it("renders list of users", () => {
+    it("lists active users by default", () => {
         const newProps = {
             ...props,
-            users: mockedAllUsers,
+            active: [user],
         };
         render(<UsersList {...newProps} />);
 
         const items = screen.getAllByRole("listitem");
 
         expect(screen.getByPlaceholderText(/Search users by name/i)).toBeInTheDocument();
-        expect(items).toHaveLength(2);
-        expect(items[0]).toHaveTextContent("Test1 Surname 1498test.user-1498@ons.gov.uk");
-        expect(items[1]).toHaveTextContent("Test2 Surname 642test.user-642@ons.gov.uk");
+        expect(items).toHaveLength(1);
+        expect(items[0]).toHaveTextContent("test.user-1498@ons.gov.uk");
+    });
+
+    it("renders list of active users by default", () => {
+        const newProps = {
+            ...props,
+            active: [user],
+        };
+        render(<UsersList {...newProps} />);
+
+        const items = screen.getAllByRole("listitem");
+
+        expect(screen.getByPlaceholderText(/Search users by name/i)).toBeInTheDocument();
+        expect(items).toHaveLength(1);
+        expect(items[0]).toHaveTextContent("test.user-1498@ons.gov.uk");
+
+        screen.getByLabelText("Show active users", { pressed: true });
+    });
+
+    it("renders list of inactive users when show suspended is active", () => {
+        const newProps = {
+            ...props,
+            active: [user],
+        };
+        render(<UsersList {...newProps} />);
+
+        expect(screen.getByLabelText("Show active users", { pressed: true })).toBeInTheDocument();
+        expect(screen.getByLabelText("Show suspended users", { pressed: false })).toBeInTheDocument();
+
+        userEvent.click(screen.getByRole("button", { name: /suspended/i }));
+
+        expect(screen.getByLabelText("Show active users", { pressed: false })).toBeInTheDocument();
+        expect(screen.getByLabelText("Show suspended users", { pressed: true })).toBeInTheDocument();
+        expect(screen.getByText(/nothing to show./)).toBeInTheDocument();
     });
 });

--- a/src/app/views/users/UsersList.test.js
+++ b/src/app/views/users/UsersList.test.js
@@ -83,6 +83,6 @@ describe("UserList", () => {
 
         expect(screen.getByLabelText("Show active users", { pressed: false })).toBeInTheDocument();
         expect(screen.getByLabelText("Show suspended users", { pressed: true })).toBeInTheDocument();
-        expect(screen.getByText(/nothing to show./)).toBeInTheDocument();
+        expect(screen.getByText(/nothing to show/)).toBeInTheDocument();
     });
 });

--- a/src/app/views/users/edit/EditUser.jsx
+++ b/src/app/views/users/edit/EditUser.jsx
@@ -46,13 +46,13 @@ export const EditUser = props => {
     const hasErrors = !isEmpty(errors);
     const hasNewValues = !isEqual(values, user);
 
-    const routerWillLeave = (nextLocation) => {
-        if (hasNewValues) return 'Your work is not saved! Are you sure you want to leave?'
-    }
+    const routerWillLeave = nextLocation => {
+        if (hasNewValues && !isSubmitting) return "Your work is not saved! Are you sure you want to leave?";
+    };
 
     useEffect(() => {
-        props.router.setRouteLeaveHook(props.route, routerWillLeave)
-    })
+        props.router.setRouteLeaveHook(props.route, routerWillLeave);
+    });
 
     useEffect(() => {
         if (user) {

--- a/src/app/views/users/edit/EditUser.test.jsx
+++ b/src/app/views/users/edit/EditUser.test.jsx
@@ -4,7 +4,7 @@ import renderer from "react-test-renderer";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom/extend-expect";
 import EditUser from "./EditUser";
-import { groups, user } from "../../../utilities/tests/mockData"
+import { groups, user } from "../../../utilities/tests/mockData";
 
 const props = {
     loading: false,
@@ -15,24 +15,26 @@ const props = {
     updateUser: jest.fn(),
     loadUser: jest.fn(),
     loadUserGroups: jest.fn(),
-    router: {setRouteLeaveHook: jest.fn()}
+    router: { setRouteLeaveHook: jest.fn() },
 };
-const setRouteLeaveHook =jest.fn();
+const setRouteLeaveHook = jest.fn();
 
 describe("EditUser", () => {
     it("matches the snapshot", () => {
-        const tree = renderer.create(<EditUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        const tree = renderer.create(
+            <EditUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />
+        );
         expect(tree.toJSON()).toMatchSnapshot();
     });
 
     it("fetches user details on load", () => {
-        render(<EditUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        render(<EditUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
         expect(props.loadUser).toBeCalledWith("test.user-1498@ons.gov.uk");
         expect(props.loadUserGroups).toBeCalled();
     });
 
     it("shows the form with user data", () => {
-        render(<EditUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        render(<EditUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
 
         expect(screen.getByRole("link", { name: "Back" })).toBeInTheDocument();
         expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("test user-1498");
@@ -52,7 +54,7 @@ describe("EditUser", () => {
     });
 
     it("allows editing and shows unsaved changes message", () => {
-        render(<EditUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        render(<EditUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
 
         userEvent.clear(screen.getByLabelText(/First name/i));
         userEvent.paste(screen.getByLabelText(/First name/i), "My test First name");
@@ -62,7 +64,7 @@ describe("EditUser", () => {
     });
 
     it("validates form and display errors in panel and within input and disables the submit button", () => {
-        render(<EditUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        render(<EditUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
 
         expect(screen.getByLabelText(/First name/i)).toHaveValue("test");
         expect(screen.getByLabelText(/Last name/i)).toHaveValue("user-1498");
@@ -90,12 +92,12 @@ describe("EditUser", () => {
             ...props,
             loading: true,
         };
-        render(<EditUser.WrappedComponent {...newProps} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        render(<EditUser.WrappedComponent {...newProps} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
         expect(screen.getByTestId("loader")).toBeInTheDocument();
     });
 
     it("updates user data", async () => {
-        render(<EditUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        render(<EditUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
 
         userEvent.paste(screen.getByLabelText(/First name/i), "boo");
 
@@ -121,10 +123,10 @@ describe("EditUser", () => {
             userGroups: groups,
         };
 
-        render(<EditUser.WrappedComponent {...newProps} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />);
+        render(<EditUser.WrappedComponent {...newProps} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
 
-        expect(screen.getByText(/my test group description/i)).toBeInTheDocument()
-        expect(screen.getByText(/my first test group description/i)).toBeInTheDocument()
-        expect(screen.getByText(/admins group description/i)).toBeInTheDocument()
+        expect(screen.getByText(/my test group description/i)).toBeInTheDocument();
+        expect(screen.getByText(/my first test group description/i)).toBeInTheDocument();
+        expect(screen.getByText(/admins group description/i)).toBeInTheDocument();
     });
 });

--- a/src/app/views/users/groups/AddGroupsToUser.jsx
+++ b/src/app/views/users/groups/AddGroupsToUser.jsx
@@ -32,13 +32,13 @@ function AddGroupsToUser(props) {
     const [userGroups, setUserGroups] = useState([]);
 
     const hasNewValues = userGroups.length > 0;
-    const routerWillLeave = (nextLocation) => {
-        if (hasNewValues) return 'Your work is not saved! Are you sure you want to leave?'
-    }
+    const routerWillLeave = nextLocation => {
+        if (hasNewValues) return "Your work is not saved! Are you sure you want to leave?";
+    };
 
     useEffect(() => {
-        props.router.setRouteLeaveHook(props.route, routerWillLeave)
-    })
+        props.router.setRouteLeaveHook(props.route, routerWillLeave);
+    });
 
     const handleRemove = name => {
         setUserGroups(prevState => prevState.filter(group => group !== name));

--- a/src/app/views/users/groups/AddGroupsToUser.test.jsx
+++ b/src/app/views/users/groups/AddGroupsToUser.test.jsx
@@ -4,7 +4,7 @@ import { render, screen, within, getByTestId } from "../../../utilities/tests/te
 import AddGroupsToUser from "./AddGroupsToUser";
 import "@testing-library/jest-dom/extend-expect";
 import userEvent from "@testing-library/user-event";
-import { groups, user } from "../../../utilities/tests/mockData"
+import { groups, user } from "../../../utilities/tests/mockData";
 
 const defaultProps = {
     user: null,
@@ -14,56 +14,44 @@ const defaultProps = {
     addGroupsToUser: jest.fn(),
     loadUser: jest.fn(),
     loadGroups: jest.fn(),
-    router: {setRouteLeaveHook: jest.fn()}
+    router: { setRouteLeaveHook: jest.fn() },
 };
 const props = {
     ...defaultProps,
     user: user,
-    groups: groups
+    groups: groups,
 };
-const setRouteLeaveHook =jest.fn();
+const setRouteLeaveHook = jest.fn();
 
 describe("AddGroupsToUser", () => {
-
     it("matches the snapshot", () => {
-        const wrapper = renderer.create(<AddGroupsToUser.WrappedComponent {...defaultProps} params={{router:
-            setRouteLeaveHook}} />);
+        const wrapper = renderer.create(<AddGroupsToUser.WrappedComponent {...defaultProps} params={{ router: setRouteLeaveHook }} />);
         expect(wrapper.toJSON()).toMatchSnapshot();
     });
 
     it("requests user data on component load", () => {
-        render(
-            <AddGroupsToUser.WrappedComponent {...defaultProps} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-        );
+        render(<AddGroupsToUser.WrappedComponent {...defaultProps} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
         expect(defaultProps.loadUser).toHaveBeenCalledWith("test.user-1498@ons.gov.uk");
     });
 
     it("requests groups on component load", () => {
-        render(
-            <AddGroupsToUser.WrappedComponent {...defaultProps} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-        );
+        render(<AddGroupsToUser.WrappedComponent {...defaultProps} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
         expect(defaultProps.loadGroups).toHaveBeenCalled();
     });
 
     it("shows Back Button", () => {
-        render(
-            <AddGroupsToUser.WrappedComponent {...defaultProps} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-        );
+        render(<AddGroupsToUser.WrappedComponent {...defaultProps} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
         expect(screen.getByText(/Back/i)).toBeInTheDocument();
     });
 
     it("shows Groups heard, search and message if no groups", () => {
-        render(
-            <AddGroupsToUser.WrappedComponent {...defaultProps} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-        );
+        render(<AddGroupsToUser.WrappedComponent {...defaultProps} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
         expect(screen.getByText(/add a team for the user to join/i)).toBeInTheDocument();
         expect(screen.getByPlaceholderText("Search teams by name")).toHaveValue("");
     });
 
     it("shows Footer Section with Buttons", () => {
-        render(
-            <AddGroupsToUser.WrappedComponent {...defaultProps} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-        );
+        render(<AddGroupsToUser.WrappedComponent {...defaultProps} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
         expect(screen.getByTestId("form-footer")).toBeInTheDocument();
         expect(screen.getByText(/Save changes/i)).toBeInTheDocument();
         expect(screen.getByText(/Cancel/i)).toBeInTheDocument();
@@ -72,19 +60,15 @@ describe("AddGroupsToUser", () => {
     describe("when loading data", () => {
         it("shows spinner", () => {
             const props = { ...defaultProps, loading: true };
-            render(
-                <AddGroupsToUser.WrappedComponent {...props} params={{userID: "", router: setRouteLeaveHook}} />
-            );
+            render(<AddGroupsToUser.WrappedComponent {...props} params={{ userID: "", router: setRouteLeaveHook }} />);
 
             expect(screen.getByTestId("loader")).toBeInTheDocument();
         });
-    })
+    });
 
     describe("where user and groups fetched", () => {
         it("shows user details", () => {
-            render(
-                <AddGroupsToUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-            );
+            render(<AddGroupsToUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
             expect(screen.getByText(/Back/i)).toBeInTheDocument();
             expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(/test user-1498/i);
             expect(screen.getByText("test.user-1498@ons.gov.uk")).toBeInTheDocument();
@@ -93,9 +77,7 @@ describe("AddGroupsToUser", () => {
         });
 
         it("shows groups", () => {
-            render(
-                <AddGroupsToUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-            );
+            render(<AddGroupsToUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
             const GroupsSection = screen.getByTestId("groups-table");
 
             expect(screen.getByText(/add a team for the user to join/i)).toBeInTheDocument();
@@ -106,12 +88,10 @@ describe("AddGroupsToUser", () => {
         });
 
         it("adds user to groups", () => {
-            render(
-                <AddGroupsToUser.WrappedComponent {...props} params={{userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook}} />
-            );
+            render(<AddGroupsToUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
             const GroupsSection = screen.getByTestId("groups-table");
 
-            expect(screen.getByRole("heading", {level: 2, name: "Add a team for the user to join"})).toBeInTheDocument();
+            expect(screen.getByRole("heading", { level: 2, name: "Add a team for the user to join" })).toBeInTheDocument();
             expect(screen.getByPlaceholderText("Search teams by name")).toHaveValue("");
             expect(screen.getByText(/admins/i)).toBeInTheDocument();
             expect(screen.getByText(/my first group/i)).toBeInTheDocument();
@@ -126,5 +106,5 @@ describe("AddGroupsToUser", () => {
             userEvent.click(screen.getByText(/save changes/i));
             expect(props.addGroupsToUser).toHaveBeenCalledWith("test.user-1498@ons.gov.uk", ["my test group"]);
         });
-    })
+    });
 });

--- a/src/app/views/users/index.jsx
+++ b/src/app/views/users/index.jsx
@@ -1,11 +1,12 @@
 import { connect } from "react-redux";
 import { getUsersRequest } from "../../config/thunks";
-import { getMappedUsers, getUsersLoading } from "../../config/selectors";
+import { getSuspendedUsers, getActiveUsers, getUsersLoading } from "../../config/selectors";
 import UsersList from "./UsersList";
 
 export const mapStateToProps = state => ({
     rootPath: state.state.rootPath,
-    users: getMappedUsers(state.state),
+    active: getActiveUsers(state.state),
+    suspended: getSuspendedUsers(state.state),
     loggedInUser: state.user,
     loading: getUsersLoading(state.state),
 });


### PR DESCRIPTION
### What

Ticket [#883: Add filters to user list screen to allow viewing of deactivated users](https://trello.com/c/1VgBC5H2/883-883-add-filters-to-user-list-screen-to-allow-viewing-of-deactivated-users)

![ezgif com-gif-maker (12)](https://user-images.githubusercontent.com/17829828/156008509-b0f29286-fc0a-44c9-8bb9-e5e81df41908.gif)

Plus missed commits for last PR:
- apply  lint correction for last PR
- don't show user notification about changes when submitting form 

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
