### PR TITLE
Call topics api via api router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,7 +14,6 @@ type Config struct {
 	RouterURL                  string        `envconfig:"ROUTER_URL"`
 	DatasetControllerURL       string        `envconfig:"DATASET_CONTROLLER_URL"`
 	TableRendererURL           string        `envconfig:"TABLE_RENDERER_URL"`
-	TopicsURL                  string        `envconfig:"TOPICS_URL"`
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -42,7 +41,6 @@ func Get() (*Config, error) {
 		RouterURL:                  "http://localhost:20000", // Frontend router
 		DatasetControllerURL:       "http://localhost:24000",
 		TableRendererURL:           "http://localhost:23300",
-		TopicsURL:                  "http://localhost:25300",
 		SharedConfig:               SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false},
 		GracefulShutdownTimeout:    10 * time.Second,
 		HealthCheckInterval:        30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,6 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			RouterURL:                  "http://localhost:20000",
 			DatasetControllerURL:       "http://localhost:24000",
 			TableRendererURL:           "http://localhost:23300",
-			TopicsURL:                  "http://localhost:25300",
 			SharedConfig:               SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false},
 			GracefulShutdownTimeout:    10 * time.Second,
 			HealthCheckInterval:        30 * time.Second,

--- a/service/directors.go
+++ b/service/directors.go
@@ -96,7 +96,7 @@ func imageAPIDirector(apiRouterVersion string) func(req *http.Request) {
 func topicAPIDirector(apiRouterVersion string) func(req *http.Request) {
 	return func(req *http.Request) {
 		director(req)
-		req.URL.Path = fmt.Sprintf("/%s%s", apiRouterVersion, strings.TrimPrefix(req.URL.Path, "/topics"))
+		req.URL.Path = fmt.Sprintf("/%s%s", apiRouterVersion, req.URL.Path)
 	}
 }
 

--- a/service/directors.go
+++ b/service/directors.go
@@ -93,6 +93,13 @@ func imageAPIDirector(apiRouterVersion string) func(req *http.Request) {
 	}
 }
 
+func topicAPIDirector(apiRouterVersion string) func(req *http.Request) {
+	return func(req *http.Request) {
+		director(req)
+		req.URL.Path = fmt.Sprintf("/%s%s", apiRouterVersion, strings.TrimPrefix(req.URL.Path, "/topics"))
+	}
+}
+
 func datasetControllerDirector(req *http.Request) {
 	director(req)
 	req.URL.Path = strings.TrimPrefix(req.URL.Path, "/dataset-controller")
@@ -100,9 +107,4 @@ func datasetControllerDirector(req *http.Request) {
 
 func tableDirector(req *http.Request) {
 	req.URL.Path = strings.TrimPrefix(req.URL.Path, "/table")
-}
-
-func topicsDirector(req *http.Request) {
-	director(req)
-	req.URL.Path = strings.TrimPrefix(req.URL.Path, "/topics")
 }

--- a/service/directors_test.go
+++ b/service/directors_test.go
@@ -97,4 +97,11 @@ func TestDirectors(t *testing.T) {
 		So(idHeaderValue, ShouldEqual, idTokenValue)
 		So(refreshHeaderValue, ShouldEqual, refreshTokenValue)
 	})
+
+	Convey("Topic API proxy director function appends the provided router api version to the provided path", t, func() {
+		request, err := http.NewRequest("GET", "/topics/topics", nil)
+		So(err, ShouldBeNil)
+		topicAPIDirector("v22")(request)
+		So(request.URL.String(), ShouldEqual, "/v22/topics")
+	})
 }

--- a/service/directors_test.go
+++ b/service/directors_test.go
@@ -99,7 +99,7 @@ func TestDirectors(t *testing.T) {
 	})
 
 	Convey("Topic API proxy director function appends the provided router api version to the provided path", t, func() {
-		request, err := http.NewRequest("GET", "/topics/topics", nil)
+		request, err := http.NewRequest("GET", "/topics", nil)
 		So(err, ShouldBeNil)
 		topicAPIDirector("v22")(request)
 		So(request.URL.String(), ShouldEqual, "/v22/topics")

--- a/service/service.go
+++ b/service/service.go
@@ -144,6 +144,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	router.Handle("/image/{uri:.*}", imageAPIProxy)
 	router.Handle("/zebedee{uri:/.*}", zebedeeProxy)
 	router.Handle("/table/{uri:.*}", tableProxy)
+	router.Handle("/topics", topicsProxy)
 	router.Handle("/topics/{uri:.*}", topicsProxy)
 	router.HandleFunc("/florence/dist/{uri:.*}", staticFiles)
 	router.HandleFunc("/florence/", redirectToFlorence)

--- a/service/service.go
+++ b/service/service.go
@@ -105,12 +105,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		return nil, err
 	}
 
-	topicsURL, err := url.Parse(cfg.TopicsURL)
-	if err != nil {
-		log.Event(ctx, "error parsing topic URL", log.FATAL, log.Error(err))
-		return nil, err
-	}
-
 	routerProxy := reverseproxy.Create(routerURL, director, nil)
 	zebedeeProxy := reverseproxy.Create(apiRouterURL, zebedeeDirector, nil)
 	recipeAPIProxy := reverseproxy.Create(apiRouterURL, recipeAPIDirector(cfg.APIRouterVersion), nil)
@@ -118,7 +112,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	importAPIProxy := reverseproxy.Create(apiRouterURL, importAPIDirector(cfg.APIRouterVersion), nil)
 	datasetAPIProxy := reverseproxy.Create(apiRouterURL, datasetAPIDirector(cfg.APIRouterVersion), nil)
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, datasetControllerDirector, nil)
-	topicsProxy := reverseproxy.Create(topicsURL, topicsDirector, nil)
+	topicsProxy := reverseproxy.Create(apiRouterURL, topicAPIDirector(cfg.APIRouterVersion), nil)
 	imageAPIProxy := reverseproxy.Create(apiRouterURL, imageAPIDirector(cfg.APIRouterVersion), nil)
 	uploadServiceAPIProxy := reverseproxy.Create(apiRouterURL, uploadServiceAPIDirector(cfg.APIRouterVersion), nil)
 	identityAPIProxy := reverseproxy.Create(apiRouterURL, identityAPIDirector(cfg.APIRouterVersion), modifiers.IdentityResponseModifier)

--- a/src/legacy/js/functions/_tags.js
+++ b/src/legacy/js/functions/_tags.js
@@ -36,7 +36,7 @@
 
 function getTopics(primaryTopic){
     $.ajax({
-        url: "/topics/topics",
+        url: "/topics",
         dataType: 'json',
         crossDomain: true,
         success: function (result) {
@@ -65,7 +65,7 @@ function getSubTopics(primaryTopic = null, secondaryTopics = null){
     }
 
     $.ajax({
-        url: "/topics/topics/" + id + "/subtopics",
+        url: "/topics/" + id + "/subtopics",
         dataType: 'json',
         crossDomain: true,
         success: function (result) {


### PR DESCRIPTION
### What

Make calls to the topics api via the api router.
Also remove duplication of `topics` in the url

### How to review

Having the `api-router` (with `ENABLE_TOPIC_API` flag set to true) and `dp-topic-api` (with data in the relevant collection) running :
Create/edit an article and navigate to the tags widget: the topic and subtopic dropdowns will be populated

### Who can review

Any dev
