### PR TITLE
741 show list of groups styled as per its role

### DIFF
--- a/src/app/components/chip/Chip.jsx
+++ b/src/app/components/chip/Chip.jsx
@@ -11,15 +11,18 @@ const propTypes = {
     removeFunc: PropTypes.func,
     style: PropTypes.oneOf(["standard", "green", "blue", "red"]),
     text: PropTypes.string.isRequired,
+    testId: PropTypes.string,
 };
 
 const Chip = props => {
     let icon;
     let iconColor;
     let chipClasses = props.link ? "chip chip--clickable" : "chip";
+
     if (props.style != null && props.style !== "standard") {
         chipClasses += ` chip--${props.style}`;
     }
+
     switch (props.style) {
         case "standard":
             iconColor = "#707071"; // Grey2
@@ -34,6 +37,7 @@ const Chip = props => {
             iconColor = "#6D272B"; // tawny-port
             break;
     }
+
     switch (props.icon) {
         case "shield-person":
             icon = <PersonInShield classes="chip__icon" viewBox={"0 0 15 15"} fillColor={iconColor} ariaLabel={"Person inside shield icon"} />;
@@ -54,13 +58,22 @@ const Chip = props => {
         ) : (
             <span className="chip__text">{props.text}</span>
         );
+
+    const handleOnClick = () => {
+        if (props.id) {
+            props.removeFunc(props.id);
+        } else {
+            props.removeFunc();
+        }
+    };
+
     return (
-        <span className={chipClasses}>
+        <span data-testid={props.testId} className={chipClasses}>
             {props.icon && icon}
             {text}
             {props.removeFunc && (
                 <span className="chip__remove-container">
-                    <button aria-label="remove" className="chip__remove" onClick={props.removeFunc} />
+                    <button aria-label="remove" className="chip__remove" onClick={handleOnClick} />
                 </span>
             )}
         </span>

--- a/src/app/components/table/Row.jsx
+++ b/src/app/components/table/Row.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 
-function Row(props) {
+function Row({ item, handleClick }) {
+    const handleOnClick = () => {
+        handleClick(item);
+    };
     return (
         <tr className="simple-table__row grid grid--align-center">
-            <td className="grid__col-10">{props.group_name}</td>
+            <td className="grid__col-10">{item.description}</td>
             <td className="grid__col-2">
-                <button className="btn btn--info" onClick={() => props.handleClick(props.group_name)}>
+                <button className="btn btn--info" onClick={handleOnClick}>
                     Add
                 </button>
             </td>

--- a/src/app/components/table/Table.jsx
+++ b/src/app/components/table/Table.jsx
@@ -9,7 +9,7 @@ function Table({ items, testid, handleClick }) {
         <table role="table" className="simple-table simple-table__scroll" data-testid={testid}>
             <tbody>
                 {items.map((item, key) => (
-                    <Row key={key} {...item} handleClick={handleClick} />
+                    <Row key={key} item={item} handleClick={handleClick} />
                 ))}
             </tbody>
         </table>

--- a/src/app/views/users/edit/EditUser.jsx
+++ b/src/app/views/users/edit/EditUser.jsx
@@ -15,6 +15,7 @@ import SelectedItemList from "../../../components/selected-items/SelectedItemLis
 import Loader from "../../../components/loader/index";
 import RadioGroup from "../../../components/radio-buttons/RadioGroup";
 import TextArea from "../../../components/text-area/TextArea";
+import UserGroupsList from "../groups/UserGroupsList";
 
 const USER_ACCESS_OPTIONS = [
     {
@@ -119,12 +120,10 @@ export const EditUser = props => {
                                         onChange={handleChange}
                                     />
                                     <h2 className="margin-top--1">Team Member</h2>
-                                    {userGroups?.length == 0 && <p>User is not a member of a team. Please add them to a team.</p>}
-                                    {userGroups && (
-                                        <SelectedItemList
-                                            classNames="selected-item-list__item--info"
-                                            items={userGroups.map(group => ({ id: group.id || group.group_name, name: group.description }))}
-                                        />
+                                    {userGroups && userGroups.length > 0 ? (
+                                        <UserGroupsList groups={userGroups} />
+                                    ) : (
+                                        <p>User is not a member of a team. Please add them to a team.</p>
                                     )}
                                 </div>
                             </div>

--- a/src/app/views/users/edit/__snapshots__/EditUser.test.jsx.snap
+++ b/src/app/views/users/edit/__snapshots__/EditUser.test.jsx.snap
@@ -94,9 +94,6 @@ exports[`EditUser matches the snapshot 1`] = `
               <p>
                 User is not a member of a team. Please add them to a team.
               </p>
-              <div
-                className="selected-item-list"
-              />
             </div>
           </div>
         </div>

--- a/src/app/views/users/groups/AddGroupsToUser.jsx
+++ b/src/app/views/users/groups/AddGroupsToUser.jsx
@@ -42,9 +42,7 @@ function AddGroupsToUser(props) {
         props.router.setRouteLeaveHook(props.route, routerWillLeave);
     });
 
-    const handleRemove = id => {
-        setUserGroups(prevState => prevState.filter(group => group.group_name !== id));
-    };
+    const handleRemove = id => setUserGroups(prevState => prevState.filter(group => group.group_name !== id));
 
     const handleAdd = group => {
         if (userGroups.includes(group)) {

--- a/src/app/views/users/groups/AddGroupsToUser.test.jsx
+++ b/src/app/views/users/groups/AddGroupsToUser.test.jsx
@@ -87,24 +87,35 @@ describe("AddGroupsToUser", () => {
             expect(screen.getAllByRole("button", { name: "Add" })).toHaveLength(3);
         });
 
-        it("adds user to groups", () => {
+        it("adds user to groups and removes", () => {
+            const userGroups = groups[2];
             render(<AddGroupsToUser.WrappedComponent {...props} params={{ userID: "test.user-1498@ons.gov.uk", router: setRouteLeaveHook }} />);
-            const GroupsSection = screen.getByTestId("groups-table");
 
             expect(screen.getByRole("heading", { level: 2, name: "Add a team for the user to join" })).toBeInTheDocument();
-            expect(screen.getByPlaceholderText("Search teams by name")).toHaveValue("");
+            expect(screen.getByPlaceholderText(/search teams by name/i)).toHaveValue("");
             expect(screen.getByText(/admins/i)).toBeInTheDocument();
-            expect(screen.getByText(/my first group/i)).toBeInTheDocument();
-            const add_buttons = screen.getAllByRole("button", { name: "Add" });
+            expect(screen.getByText(/user is not a member of a team. Please add them to a team/i)).toBeInTheDocument();
 
-            userEvent.click(add_buttons[0]);
+            const addButtons = screen.getAllByRole("button", { name: "Add" });
+            expect(addButtons).toHaveLength(3);
 
-            expect(screen.getByTestId("form-footer")).toBeInTheDocument();
-            expect(within(screen.getByTestId("user")).getByText("my test group")).toBeInTheDocument();
-            expect(within(screen.getByTestId("form-footer")).getByText("You have unsaved changes")).toBeInTheDocument();
+            userEvent.click(addButtons[1]);
 
-            userEvent.click(screen.getByText(/save changes/i));
-            expect(props.addGroupsToUser).toHaveBeenCalledWith("test.user-1498@ons.gov.uk", ["my test group"]);
+            const userGroupsList = screen.getByTestId("UserGroupsList");
+
+            expect(within(userGroupsList).getByLabelText(/person icon/i)).toBeInTheDocument();
+            expect(within(userGroupsList).getByText(/my first test group description/i)).toBeInTheDocument();
+            expect(screen.queryByText(/user is not a member of a team. Please add them to a team/i)).not.toBeInTheDocument();
+
+            userEvent.click(addButtons[2]);
+
+            expect(within(userGroupsList).getByLabelText(/tick inside shield icon/i)).toBeInTheDocument();
+            expect(within(userGroupsList).getByText(/admins group description/i)).toBeInTheDocument();
+            expect(within(screen.getByTestId("form-footer")).getByText(/you have unsaved changes/i)).toBeInTheDocument();
+
+            userEvent.click(within(userGroupsList).getAllByLabelText("remove")[0]);
+
+            expect(within(userGroupsList).queryByText(/my first test group description/i)).not.toBeInTheDocument();
         });
     });
 });

--- a/src/app/views/users/groups/User.jsx
+++ b/src/app/views/users/groups/User.jsx
@@ -1,23 +1,17 @@
 import React from "react";
-import SelectedItemList from "../../../components/selected-items/SelectedItemList";
+import UserGroupsList from "../groups/UserGroupsList";
 
-function User({ id, forename, lastname, testid, userGroups, handleRemove }) {
-    return (
-        <div data-testid={testid}>
-            <h1 className="margin-top--1 margin-bottom--1">{`${forename} ${lastname}`}</h1>
-            <p>{id}</p>
-            <h2 className="margin-top--1">Team Member</h2>
-            {userGroups.length === 0 && <p>Nothing to show.</p>}
-            {userGroups && (
-                <SelectedItemList
-                    classNames="selected-item-list__item--info"
-                    removeClassNames="selected-item-list__remove--info"
-                    items={userGroups.map(gr => ({ id: gr, name: gr }))}
-                    handleRemoveItem={handleRemove}
-                />
-            )}
-        </div>
-    );
-}
+const User = ({ id, forename, lastname, userGroups, handleRemove }) => (
+    <div data-testid="user">
+        <h1 className="margin-top--1 margin-bottom--1">{`${forename} ${lastname}`}</h1>
+        <p>{id}</p>
+        <h2 className="margin-top--1">Team Member</h2>
+        {userGroups && userGroups.length > 0 ? (
+            <UserGroupsList groups={userGroups} handleRemove={handleRemove} />
+        ) : (
+            <p>User is not a member of a team. Please add them to a team.</p>
+        )}
+    </div>
+);
 
 export default User;

--- a/src/app/views/users/groups/UserGroupsList.jsx
+++ b/src/app/views/users/groups/UserGroupsList.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Chip from "../../../components/chip/Chip";
+
+const UserGroupsList = ({ groups, handleRemove }) => (
+    <div className="chip__container chip__container--gap-10" data-testid="UserGroupsList">
+        {groups.map(group => {
+            let icon = "person";
+            let style = "standard";
+
+            if (group.precedence === 1) {
+                icon = "shield-tick";
+                style = "green";
+            }
+
+            if (group.precedence === 2) {
+                icon = "shield-person";
+                style = "blue";
+            }
+            return <Chip key={group.group_name} id={group.group_name} icon={icon} style={style} text={group.description} removeFunc={handleRemove} />;
+        })}
+    </div>
+);
+
+UserGroupsList.propTypes = {
+    groups: PropTypes.arrayOf(
+        // TODO: backend returns invalid object structure, needs updating the props.groups
+        PropTypes.shape({
+            group_name: PropTypes.string.isRequired, // id
+            description: PropTypes.string, // name
+        })
+    ).isRequired,
+    handleRemove: PropTypes.func,
+};
+
+export default UserGroupsList;

--- a/src/app/views/users/groups/__snapshots__/AddGroupsToUser.test.jsx.snap
+++ b/src/app/views/users/groups/__snapshots__/AddGroupsToUser.test.jsx.snap
@@ -40,11 +40,8 @@ exports[`AddGroupsToUser matches the snapshot 1`] = `
             Team Member
           </h2>
           <p>
-            Nothing to show.
+            User is not a member of a team. Please add them to a team.
           </p>
-          <div
-            className="selected-item-list"
-          />
         </div>
       </div>
       <div

--- a/src/scss/components/_table.scss
+++ b/src/scss/components/_table.scss
@@ -198,7 +198,7 @@
     }
 
     &__scroll {
-        overflow-y: scroll;
+        overflow-y: auto;
         display: block;
         max-height: calc(100vh - 380px); // the remaining space do not change
     }


### PR DESCRIPTION
### What

Ticket: [#741: View list of groups for user from user details screen](https://trello.com/c/Wt8KGtRL/741-741-view-list-of-groups-for-user-from-user-details-screen)
Also correcting the bug on user edit screen when user submitting changes.

<img width="1578" alt="Screenshot 2022-03-07 at 13 17 25" src="https://user-images.githubusercontent.com/17829828/157041984-79504b58-c961-451b-ad77-ab97c73596b0.png">
<img width="1622" alt="Screenshot 2022-03-07 at 13 18 33" src="https://user-images.githubusercontent.com/17829828/157041993-9b92a831-38ef-470e-9092-947243428ec5.png">

### How to review

Describe the steps required to test the changes.

### Who can review

@dandwal 
