### PR TITLE
feature/908 - add errors handling

### DIFF
--- a/src/app/components/simple-selectable-list/SimpleSelectableList.jsx
+++ b/src/app/components/simple-selectable-list/SimpleSelectableList.jsx
@@ -37,7 +37,7 @@ export default class SimpleSelectableList extends Component {
                       })
                     : null}
                 {showLoadingState && <span data-testid="loader" className="margin-top--1 loader loader--dark" />}
-                {!hasRows && !showLoadingState ? <p>Nothing to show</p> : ""}
+                {!hasRows && !showLoadingState && <p className="padding-top--1">Nothing to show.</p>}
             </ul>
         );
     }

--- a/src/app/config/groups/thunks.js
+++ b/src/app/config/groups/thunks.js
@@ -3,6 +3,7 @@ import * as actions from "./actions";
 import notifications from "../../utilities/notifications";
 import teams from "../../utilities/api-clients/teams";
 import url from "../../utilities/url";
+import { errCodes } from "../../utilities/errorCodes";
 
 export const fetchGroupRequest = id => dispatch => {
     dispatch(actions.loadGroupProgress());
@@ -82,9 +83,22 @@ export const fetchGroupsRequest = isNewSignIn => dispatch => {
               })
               .catch(error => {
                   dispatch(actions.loadGroupsFailure());
-                  //TODO: map responses to user friendly by content designer
-                  if (error) {
-                      notifications.add({ type: "warning", message: error?.message || error.status, autoDismiss: 5000 });
+                  if (error.status != null && error.status === 400) {
+                      const notification = {
+                          type: "warning",
+                          isDismissable: true,
+                          autoDismiss: 15000,
+                          message: errCodes.GET_GROUPS_NOT_FOUND, // TODO
+                      };
+                      notifications.add(notification);
+                  } else {
+                      const notification = {
+                          type: "warning",
+                          isDismissable: true,
+                          autoDismiss: 15000,
+                          message: errCodes.GET_GROUPS_UNEXPECTED_ERROR_SHORT, // TODO
+                      };
+                      notifications.add(notification);
                   }
                   console.error(error);
               })

--- a/src/app/config/groups/thunks.js
+++ b/src/app/config/groups/thunks.js
@@ -83,23 +83,12 @@ export const fetchGroupsRequest = isNewSignIn => dispatch => {
               })
               .catch(error => {
                   dispatch(actions.loadGroupsFailure());
-                  if (error.status != null && error.status === 400) {
-                      const notification = {
-                          type: "warning",
-                          isDismissable: true,
-                          autoDismiss: 15000,
-                          message: errCodes.GET_GROUPS_NOT_FOUND, // TODO
-                      };
-                      notifications.add(notification);
-                  } else {
-                      const notification = {
-                          type: "warning",
-                          isDismissable: true,
-                          autoDismiss: 15000,
-                          message: errCodes.GET_GROUPS_UNEXPECTED_ERROR_SHORT, // TODO
-                      };
-                      notifications.add(notification);
-                  }
+                  notifications.add({
+                      type: "warning",
+                      isDismissable: true,
+                      autoDismiss: 15000,
+                      message: error.status === 400 ? errCodes.GET_GROUPS_NOT_FOUND : errCodes.GET_GROUPS_UNEXPECTED_ERROR_SHORT,
+                  });
                   console.error(error);
               })
         : teams

--- a/src/app/config/thunks.js
+++ b/src/app/config/thunks.js
@@ -202,8 +202,22 @@ export const getUsersRequest = () => dispatch => {
         })
         .catch(error => {
             dispatch(actions.loadUsersFailure());
-            if (error) {
-                notifications.add({ type: "warning", message: error?.message || error.status, autoDismiss: 5000 });
+            if (error.status != null && error.status === 400) {
+                const notification = {
+                    type: "warning",
+                    isDismissable: true,
+                    autoDismiss: 15000,
+                    message: errCodes.GET_USERS_NOT_FOUND, // TODO
+                };
+                notifications.add(notification);
+            } else {
+                const notification = {
+                    type: "warning",
+                    isDismissable: true,
+                    autoDismiss: 15000,
+                    message: errCodes.GET_USERS_UNEXPECTED_ERROR_SHORT, // TODO
+                };
+                notifications.add(notification);
             }
             console.error(error);
         });
@@ -330,7 +344,6 @@ export const deleteTokensRequest = () => dispatch => {
     dispatch(actions.singOutAllUsersProgress());
     user.deleteTokens()
         .then(response => {
-            console.log("deleteTokensRequest", response); // TODO: leaving this here to check what is actually coming back as couldn't test locally
             dispatch(actions.singOutAllUsersSuccess());
             //TODO: can not test the response object atm so will change this later
             notifications.add({ type: "positive", message: "All users signed out successfully.", autoDismiss: 5000 });

--- a/src/app/utilities/errorCodes.js
+++ b/src/app/utilities/errorCodes.js
@@ -11,11 +11,14 @@ export const errCodes = {
     GET_USERS_NOT_FOUND: "Could not retrieve users. Please try again shortly, if the issue persists please contact an administrator",
     GET_USERS_UNEXPECTED_ERROR_SHORT:
         "An unexpected error has occurred whilst trying to get users. Please try again shortly, if the error persists please contact an administrator.",
+    GET_GROUPS_UNEXPECTED_ERROR_SHORT:
+        "An unexpected error has occurred whilst trying to get teams. Please try again shortly, if the error persists please contact an administrator.",
     GET_USERS_UNEXPECTED_ERROR:
         "An unexpected error's occurred whilst trying to get users. You may only be able to see previously loaded information.",
     GET_USERS_NETWORK_ERROR: "There's been a network error whilst trying to get users. You may only be able to see previously loaded information.",
     UNIQ_NAME_ERROR: "A collection with this name already exists.",
     GET_USERS_RESPONSE_ERROR: "An error has occurred whilst trying to get users. You may only be able to see previously loaded information.",
+    GET_GROUPS_NOT_FOUND: "An error has occurred whilst trying to get teams. You may only be able to see previously loaded information.",
     GET_USERS_UNEXPECTED_FILTER_ERROR: "An error has occurred whilst trying to get users. Please contact an administrator",
     CREATE_GROUP_UNEXPECTED_ERROR: "An error has occurred whilst creating the new team. Please contact an administrator",
     INVALID_NEW_TEAM_NAME: "An invalid team name was provided, please change the name",

--- a/src/app/views/groups/__snapshots__/Groups.test.jsx.snap
+++ b/src/app/views/groups/__snapshots__/Groups.test.jsx.snap
@@ -62,8 +62,10 @@ exports[`Groups matches the snapshot 1`] = `
     <ul
       className="list list--neutral simple-select-list"
     >
-      <p>
-        Nothing to show
+      <p
+        className="padding-top--1"
+      >
+        Nothing to show.
       </p>
     </ul>
   </div>

--- a/src/app/views/users/UsersList.jsx
+++ b/src/app/views/users/UsersList.jsx
@@ -91,7 +91,11 @@ const UsersList = props => {
                                 </div>
                             </div>
                         </div>
-                        {users ? <SimpleSelectableList rows={search.value ? getFilteredUsers() : users} /> : "Nothing to show."}
+                        {users ? (
+                            <SimpleSelectableList rows={search.value ? getFilteredUsers() : users} />
+                        ) : (
+                            <p className="padding-top--1">Nothing to show.</p>
+                        )}
                     </>
                 )}
             </div>


### PR DESCRIPTION
### What

[Feature 908: Users and teams screens not displaying errors when getting 5xx ](https://trello.com/c/mqiR1Dmh/908-908-users-and-teams-screens-not-displaying-errors-when-getting-5xx-errors-from-identity-api)

<img width="1532" alt="Screenshot 2022-03-24 at 15 07 50" src="https://user-images.githubusercontent.com/17829828/159958601-4c099fd2-e6ae-435f-b22d-bcf2f3aa654d.png">
<img width="1535" alt="Screenshot 2022-03-24 at 14 37 36" src="https://user-images.githubusercontent.com/17829828/159958635-cbdda5f6-048d-45a1-8dde-43d20e9ca751.png">

### How to review
code

### Who can review

Describe who worked on the changes, so that other people can review.
