### PR TITLE
Bug/ unable to add team to collection

### DIFF
--- a/src/app/utilities/api-clients/teams.js
+++ b/src/app/utilities/api-clients/teams.js
@@ -46,7 +46,7 @@ export default class teams {
     }
 
     static addMemberToTeam(id, userID) {
-        return http.post(`/groups/${teamID}/members`, { user_id: userID }).then(response => {
+        return http.post(`/groups/${id}/members`, { user_id: userID }).then(response => {
             return response;
         });
     }

--- a/src/app/views/collections/create/CreateNewCollection.jsx
+++ b/src/app/views/collections/create/CreateNewCollection.jsx
@@ -56,7 +56,7 @@ const CreateNewCollection = props => {
         if (!e) return;
         setNewCollection(prevState => ({
             ...prevState,
-            teams: prevState.teams.concat(props.teams.find(team => team.id === e.target.value)),
+            teams: prevState.teams.concat(props.teams.find(team => team.id == e.target.value)),
         }));
     };
 


### PR DESCRIPTION
### What

Ticket: [Bug/ unable to add team to collection](https://trello.com/c/z1G8RkIm/926-unable-to-add-a-team-to-a-new-collection)

Fix bug created when mapping the groups was removed. 
The change is for old legacy auth so those views will be removed soon.
My solution for this bug is to change the comparison operator to compare values but do not type as old api returns id as a numbers but javascript always sends values in events as a string. 

I also spotted bug on api call so corrected this as well.

<img width="1330" alt="Screenshot 2022-03-30 at 14 55 23" src="https://user-images.githubusercontent.com/17829828/160852848-c18349de-f3c8-48bc-8e9b-3af18ec72d3d.png">

before:

<img width="1313" alt="Screenshot 2022-03-30 at 15 01 31" src="https://user-images.githubusercontent.com/17829828/160852955-1269af2a-4f7f-442d-b15d-14c6d2486473.png">

### How to review

Describe the steps required to test the changes.

### Who can review
devs
