### PR TITLE
fix file URL in DatasetUploadDetails to work between feature toggled upload systems

### DIFF
--- a/src/app/views/uploads/dataset/upload-details/DatasetUploadDetails.jsx
+++ b/src/app/views/uploads/dataset/upload-details/DatasetUploadDetails.jsx
@@ -280,8 +280,8 @@ class DatasetUploadController extends Component {
 
                 http.get(UPLOAD_FETCH_PATH_ENDPOINT)
                     .then(response => {
+                        const fileUrl = this.props.enableNewUpload ? response.path : response.url;
                         const files = this.state.activeDataset.files.map(currentFile => {
-                            fileUrl = this.props.enableNewUpload ? response.path : response.url;
                             if (currentFile.alias_name === aliasName) {
                                 currentFile.progress = null;
                                 currentFile.url = fileUrl;


### PR DESCRIPTION
### What

Small fix to the instantiation of the `fileURL` variable. This variable is provided with the path based on whether the new or old upload system is being used.  This value is then passed to the import services

### How to review

Sense check the change

### Who can review

Anyone