### PR TITLE
 #899: Security tab being shown when feature flag is off

### DIFF
--- a/src/app/components/navbar/NavBar.jsx
+++ b/src/app/components/navbar/NavBar.jsx
@@ -8,34 +8,32 @@ import cookies from "../../utilities/cookies";
 import PreviewNav from "../preview-nav";
 
 const LANG = {
-    "en": "English",
-    "cy" : "Welsh"
-}
+    en: "English",
+    cy: "Welsh",
+};
 
 const NavBar = props => {
     const [previewLanguage, setPreviewLanguage] = useState(null);
 
     useEffect(() => {
-        if(cookies.get("lang")) {
-            setPreviewLanguage(cookies.get("lang"))
+        if (cookies.get("lang")) {
+            setPreviewLanguage(cookies.get("lang"));
+        } else {
+            cookies.add("lang", "en", null);
+            setPreviewLanguage("en");
         }
-        else {
-            cookies.add("lang", "en", null)
-            setPreviewLanguage("en")
-            };
-
     }, []);
 
     useEffect(() => {
-        if(previewLanguage) {
-            changeLanguageCookie(previewLanguage)
+        if (previewLanguage) {
+            changeLanguageCookie(previewLanguage);
         }
     }, [previewLanguage, changeLanguageCookie]);
 
-    const changeLanguageCookie = (previewLanguage) => {
+    const changeLanguageCookie = previewLanguage => {
         cookies.remove("lang");
-        cookies.add("lang", previewLanguage, null)
-    }
+        cookies.add("lang", previewLanguage, null);
+    };
 
     const renderWorkingOnItem = () => {
         const workingOn = props.workingOn || {};
@@ -109,37 +107,28 @@ const NavBar = props => {
                                 Publishing queue
                             </a>
                         </li>
-
                         <li className="global-nav__item">
                             <a className="global-nav__link" href="/florence/reports">
                                 Reports
                             </a>
-                        </li>
-
-                        <li className="global-nav__item">
-                            <Link to={`${rootPath}/users`} activeClassName="selected" className="global-nav__link">
-                                Users and access
-                            </Link>
-                        </li>
-
-                        <li className="global-nav__item">
-                            <Link to={`${rootPath}/teams`} activeClassName="selected" className="global-nav__link">
-                                Teams
-                            </Link>
                         </li>
                         <li className="global-nav__item">
                             <Link to={`${rootPath}/interactives`} activeClassName="selected" className="global-nav__link">
                                 Interactives
                             </Link>
                         </li>
-                        {props.config?.enableNewSignIn && (
+                        <li className="global-nav__item">
+                            <Link to={`${rootPath}/users`} activeClassName="selected" className="global-nav__link">
+                                Users and access
+                            </Link>
+                        </li>
+                        {props.isNewSignIn ? (
                             <li className="global-nav__item">
                                 <Link to={`${rootPath}/groups`} activeClassName="selected" className="global-nav__link">
                                     Preview teams
                                 </Link>
                             </li>
-                        )}
-                        {!props.config?.enableNewSignIn && (
+                        ) : (
                             <li className="global-nav__item">
                                 <Link to={`${rootPath}/teams`} activeClassName="selected" className="global-nav__link">
                                     Teams
@@ -148,7 +137,7 @@ const NavBar = props => {
                         )}
                     </>
                 )}
-                {auth.isAdmin(props.user) && (
+                {auth.isAdmin(props.user) && props.isNewSignIn && (
                     <li className="global-nav__item">
                         <Link to={`${rootPath}/security`} activeClassName="selected" className="global-nav__link">
                             Security

--- a/src/app/components/navbar/NavBar.test.js
+++ b/src/app/components/navbar/NavBar.test.js
@@ -29,7 +29,7 @@ const withPreviewNavProps = {
     },
 };
 
-const NavbarItems = ["Collections", "Users and access", "Teams", "Interactives", "Teams", "Security", "Sign out"];
+const NavbarItems = ["Collections", "Interactives", "Users and access", "Teams", "Sign out"];
 
 describe("NavBar", () => {
     describe("when user is not authenticated", () => {
@@ -65,15 +65,13 @@ describe("NavBar", () => {
         describe("when enableNewSignIn feature flag is enabled", () => {
             const props = {
                 ...defaultProps,
-                config: {
-                    ...defaultProps.config,
-                    enableNewSignIn: true,
-                },
+                isNewSignIn: true
             };
             const component = shallow(<NavBar {...props} user={authenticatedUser} />);
             it("Preview teams option should be present", () => {
                 const link = component.find("Link[to='/florence/groups']");
                 expect(link.getElement().props.children[0].includes("Preview teams"));
+                expect(link.getElement().props.children[0].includes("Security"));
             });
         });
 

--- a/src/app/components/navbar/index.jsx
+++ b/src/app/components/navbar/index.jsx
@@ -1,5 +1,5 @@
 import { connect } from "react-redux";
-import { getActive } from "../../config/selectors";
+import { getActive, getGroupsLoading, getEnableNewSignIn } from "../../config/selectors";
 import NavBar from "./NavBar";
 
 const mapStateToProps = state => ({
@@ -7,6 +7,7 @@ const mapStateToProps = state => ({
     rootPath: state.state.rootPath,
     workingOn: getActive(state.state),
     config: state.state.config,
+    isNewSignIn: getEnableNewSignIn(state.state),
 });
 
 export default connect(mapStateToProps)(NavBar);


### PR DESCRIPTION
### What
[BUG: #899: Security tab being shown when feature flag is off](https://trello.com/c/pcwDM8YV/899-899-security-tab-being-shown-when-feature-flag-is-off
)

additionally in this PR:
- linting correction
- remove duplication of `Interactives` link and move it out of the User / Teams block

FLAG enablePermissionsAPI ON 
<img width="1352" alt="Screenshot 2022-04-08 at 10 57 07" src="https://user-images.githubusercontent.com/17829828/162414170-5c2bd542-910a-4140-a14f-b05ecef574b0.png">


--------------------------
FLAG enablePermissionsAPI OFF
<img width="1348" alt="Screenshot 2022-04-08 at 10 54 21" src="https://user-images.githubusercontent.com/17829828/162414271-9a094c36-7ef9-42a9-b306-b810c2a0773e.png">

### How to review

Describe the steps required to test the changes.

### Who can review

Describe who worked on the changes, so that other people can review.
