### PR TITLE
#951: Accessing legacy florence logs user out with JWT sessions

### DIFF
--- a/src/app/utilities/auth.js
+++ b/src/app/utilities/auth.js
@@ -34,10 +34,10 @@ export function setAuthToken(userData) {
     const userJSONData = JSON.stringify(userData);
     window.localStorage.setItem(_AUTH_TOKEN_NAME, userJSONData);
     /* Legacy florence */
-    window.localStorage.setItem("loggedInAs", userJSONData.email);
+    window.localStorage.setItem("loggedInAs", userData.email);
     // Store the user type in localStorage. Used in old Florence
     // where views can depend on user type. e.g. Browse tree
-    localStorage.setItem("userType", user.getOldUserType(userJSONData));
+    localStorage.setItem("userType", user.getOldUserType(userData));
 }
 
 export function getAuthToken() {

--- a/src/legacy/js/classes/florence.js
+++ b/src/legacy/js/classes/florence.js
@@ -50,7 +50,9 @@ Florence.globalVars = {pagePath: '', activeTab: false, pagePos: '', welsh: false
 
 Florence.Authentication = {
     accessToken: function () {
-        return CookieUtils.getCookieValue("access_token");
+        var cookie = CookieUtils.getCookieValue("access_token");
+        var token = localStorage.getItem("ons_user");
+        return cookie || token;
     },
     isAuthenticated: function () {
         return Florence.Authentication.accessToken() !== '';


### PR DESCRIPTION
### What
Unable to access legacy florence screens when logged in with JWT sessions (returned to login screen).
Describe what you have changed and why.

If florence is using the new login strategy (make debug ENCRYPTION_DISABLED=true ENABLE_PERMISSION_API=true ENABLE_NEW_SIGN_IN=True) then authenticate via local storage otherwise it should grab the cookie.
### How to review

Describe the steps required to test the changes.
Option 1:

Log into Florence as admin or publisher
Click on a collection
Click Create/Edit content button
Click Old Workspace
Option 2:

Log into Florence as admin or publisher
Click on the Publishing Queue tab
### Who can review
anyone

Describe who worked on the changes, so that other people can review.
myself
