### PR TITLE
fixes interactive auth

### DIFF
--- a/src/app/components/layout/Layout.jsx
+++ b/src/app/components/layout/Layout.jsx
@@ -35,7 +35,7 @@ const Layout = props => {
                 isDismissable: true,
             });
         }
-    }, [userPermissions, isCheckingAuthentication]);
+    }, [userPermissions, isCheckingAuthentication], props.user);
 
     useEffect(() => {
         log.initialise();

--- a/src/app/components/layout/index.jsx
+++ b/src/app/components/layout/index.jsx
@@ -6,6 +6,7 @@ function mapStateToProps(state) {
     return {
         notifications: getNotifications(state.state),
         popouts: state.state.popouts,
+        user: state.user,
     };
 }
 

--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -207,10 +207,7 @@ export default class user {
             if (cookies.get("collection")) {
                 cookies.remove("collection");
             }
-            removeAuthToken(); // TODO added
-            // TODO remove
-            // localStorage.removeItem("loggedInAs");
-            // localStorage.removeItem("userType");
+            removeAuthToken();
             store.dispatch(userLoggedOut());
             store.dispatch(reset());
         }

--- a/src/app/utilities/auth.js
+++ b/src/app/utilities/auth.js
@@ -47,6 +47,8 @@ export function getAuthToken() {
 
 export function removeAuthToken() {
     window.localStorage.removeItem(_AUTH_TOKEN_NAME);
+    /* ENABLE_NEW_SIGN_IN legacy */
+    window.localStorage.removeItem("access_token");
     /* Florence legacy */
     window.localStorage.removeItem("loggedInAs");
     window.localStorage.removeItem("userType");

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, {useState} from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 import { Router, Route, IndexRoute, IndexRedirect, Redirect } from "react-router";
@@ -6,7 +6,7 @@ import { routerActions } from "react-router-redux";
 import { connectedReduxRedirect } from "redux-auth-wrapper/history3/redirect";
 import { store, history } from "./app/config/store";
 import { setConfig } from "./app/config/actions";
-import auth from "./app/utilities/auth";
+import auth, {getAuthToken} from "./app/utilities/auth";
 import Layout from "./app/components/layout";
 import LoginController from "./app/views/login/LoginController";
 import SignInController from "./app/views/login/SignIn";
@@ -66,7 +66,8 @@ const rootPath = store.getState().state.rootPath;
 
 const userIsAuthenticated = connectedReduxRedirect({
     authenticatedSelector: state => {
-        return state.user.isAuthenticated;
+        // TODO Remove getAuthToken() call when ENABLE_NEW_INTERACTIVES feature in prod
+        return state.user.isAuthenticated || getAuthToken();
     },
     redirectAction: routerActions.replace,
     wrapperDisplayName: "UserIsAuthenticated",


### PR DESCRIPTION
### What
Interactive screens doesnt refresh
Describe what you have changed and why.

The auth can check the state or if we have a token. the reason for this is that the state should have been passed top down , all the auth should have been set in the top level and then passed down through the router. But as we are removing the current auth then this is not an issue in the new auth. We could use context api to pass the state back up to the connected router.
### How to review

pull the code down and run with interactive flags
Describe the steps required to test the changes.

### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself