### PR TITLE
Unify checkbox handling

### DIFF
--- a/src/legacy/js/functions/_t16ReleaseEditor.js
+++ b/src/legacy/js/functions/_t16ReleaseEditor.js
@@ -87,40 +87,24 @@ function releaseEditor(collectionId, data) {
     });
 
     /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-    var checkBoxStatus = function (id) {
-        if (id === 'natStat') {
-            if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
-                return false;
-            } else {
-                return true;
-            }
-        } else if (id === 'cancelled') {
-            if (data.description.cancelled === "false" || data.description.cancelled === false) {
-                return false;
-            } else {
-                return true;
-            }
-        } else if (id === 'finalised') {
-            if (data.description.finalised === "false" || data.description.finalised === false) {
-                return false;
-            } else {
-                return true;
-            }
+    var checkBoxStatus = function (value) {
+        if (value === "" || value === "false" || value === false) {
+            return false;
         }
+        return true;
     };
 
     // Gets status of checkbox and sets JSON to match
-    $("#natStat input[type='checkbox']").prop('checked', checkBoxStatus($('#natStat').attr('id'))).click(function () {
-        data.description.nationalStatistic = $("#natStat input[type='checkbox']").prop('checked') ? true : false;
-        
+    $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+        data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
     });
 
-    $("#census").click(function () {
-        data.description.survey = $("#census").prop('checked') ? 'census' : null;
+    $("#census-checkbox").prop('checked', data.description.survey ? true : false).click(function () {
+        data.description.survey = $("#census-checkbox").prop('checked') ? 'census' : null;
     });
 
-    $("#cancelled input[type='checkbox']").prop('checked', checkBoxStatus($('#cancelled').attr('id'))).click(function () {
-        data.description.cancelled = $("#cancelled input[type='checkbox']").prop('checked') ? true : false;
+    $("#cancelled input[type='checkbox']").prop('checked', checkBoxStatus(data.description.cancelled)).click(function () {
+        data.description.cancelled = $("#cancelled input[type='checkbox']").prop('checked');
         if (data.description.cancelled) {
             var editedSectionValue = {};
             editedSectionValue.title = "Please enter the reason for the cancellation";
@@ -150,12 +134,12 @@ function releaseEditor(collectionId, data) {
     });
 
     if (data.description.finalised) {
-        $("#finalised input[type='checkbox']").prop('checked', checkBoxStatus($('#finalised').attr('id'))).click(function (e) {
+        $("#finalised input[type='checkbox']").prop('checked', checkBoxStatus(data.description.finalised)).click(function (e) {
             sweetAlert('You cannot change this field once it is finalised.');
             e.preventDefault();
         });
     } else {
-        $("#finalised input[type='checkbox']").prop('checked', checkBoxStatus($('#finalised').attr('id'))).click(function () {
+        $("#finalised input[type='checkbox']").prop('checked', checkBoxStatus(data.description.finalised)).click(function () {
             swal({
                 title: "Warning",
                 text: "You will not be able reset the date to provisional once you've done this. Are you sure you want to proceed?",

--- a/src/legacy/js/functions/_t4ArticleDownloadEditor.js
+++ b/src/legacy/js/functions/_t4ArticleDownloadEditor.js
@@ -78,15 +78,15 @@ function ArticleDownloadEditor(collectionId, data) {
 
   /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
    is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-  var checkBoxStatus = function () {
-    if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
+  var checkBoxStatus = function (value) {
+    if (value === "" || value === "false" || value === false) {
       return false;
     }
     return true;
   };
 
-  $("#metadata-list input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-    data.description.nationalStatistic = $("#metadata-list input[type='checkbox']").prop('checked') ? true : false;
+  $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+    data.description.nationalStatistic = $("natStat-checkbox").prop('checked');
   });
 
   // Save

--- a/src/legacy/js/functions/_t4ArticleEditor.js
+++ b/src/legacy/js/functions/_t4ArticleEditor.js
@@ -77,12 +77,21 @@ function articleEditor(collectionId, data) {
     data.description.metaDescription = $(this).val();
   });
 
-  $("#natStat-checkbox").click(function () {
+  /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
+  is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
+  var checkBoxStatus = function (value) {
+    if (value === "" || value === "false" || value === false) {
+      return false;
+    }
+    return true;
+  };
+
+  $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
       data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
   });
 
-  $("#census").click(function () {
-    data.description.survey = $("#census").prop('checked') ? 'census' : null;
+  $("#census-checkbox").prop('checked', data.description.survey ? true : false).click(function () {
+    data.description.survey = $("#census-checkbox").prop('checked') ? 'census' : null;
   });
   
   $("#articleType-checkbox").click(function () {

--- a/src/legacy/js/functions/_t4BulletinEditor.js
+++ b/src/legacy/js/functions/_t4BulletinEditor.js
@@ -90,19 +90,19 @@ function bulletinEditor(collectionId, data) {
 
     /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
      is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-    var checkBoxStatus = function () {
-        if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
+    var checkBoxStatus = function (value) {
+        if (value === "" || value === "false" || value === false) {
             return false;
         }
         return true;
     };
 
-    $("#metadata-list input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-        data.description.nationalStatistic = $("#metadata-list input[type='checkbox']").prop('checked') ? true : false;
+    $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+        data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
     });
 
-    $("#census").prop('checked', data.description.survey ? true : false).click(function () {
-        data.description.survey = $("#census").prop('checked') ? 'census' : null;
+    $("#census-checkbox").prop('checked', data.description.survey ? true : false).click(function () {
+        data.description.survey = $("#census-checkbox").prop('checked') ? 'census' : null;
     });
 
     // Save

--- a/src/legacy/js/functions/_t5TimeseriesEditor.js
+++ b/src/legacy/js/functions/_t5TimeseriesEditor.js
@@ -73,28 +73,19 @@ function timeseriesEditor(collectionId, data) {
 
   /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
    is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-  var checkBoxStatus = function () {
-    if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
-      return false;
-    } else {
-      return true;
+   var checkBoxStatus = function (value) {
+    if (value === "" || value === "false" || value === false) {
+        return false;
     }
+    return true;
   };
 
-  $("#metadata-list #natStat input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-    data.description.nationalStatistic = $("#metadata-list #natStat input[type='checkbox']").prop('checked') ? true : false;
+  $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+    data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
   });
 
-  var isIndexStatus = function () {
-    if (data.description.isIndex === true) {
-      return true;
-    } else {
-      return false;
-    }
-  };
-
-  $("#metadata-list #isIndex input[type='checkbox']").prop('checked', isIndexStatus).click(function () {
-    data.description.isIndex = $("#metadata-list #isIndex input[type='checkbox']").prop('checked') ? true : false;
+  $("#metadata-list #isIndex input[type='checkbox']").prop('checked', checkBoxStatus(data.description.isIndex)).click(function () {
+    data.description.isIndex = $("#metadata-list #isIndex input[type='checkbox']").prop('checked');
   });
 
   // Save

--- a/src/legacy/js/functions/_t6CompendiumChapterEditor.js
+++ b/src/legacy/js/functions/_t6CompendiumChapterEditor.js
@@ -77,16 +77,15 @@ function compendiumChapterEditor(collectionId, data) {
 
     /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
      is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-    var checkBoxStatus = function () {
-        if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
+    var checkBoxStatus = function (value) {
+        if (value === "" || value === "false" || value === false) {
             return false;
-        } else {
-            return true;
         }
+        return true;
     };
 
-    $("#metadata-list input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-        data.description.nationalStatistic = $("#metadata-list input[type='checkbox']").prop('checked') ? true : false;
+    $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+        data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
     });
 
     // Save

--- a/src/legacy/js/functions/_t6CompendiumDataEditor.js
+++ b/src/legacy/js/functions/_t6CompendiumDataEditor.js
@@ -81,15 +81,15 @@ function compendiumDataEditor(collectionId, data) {
 
     /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
      is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-    var checkBoxStatus = function () {
-        if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
+    var checkBoxStatus = function (value) {
+        if (value === "" || value === "false" || value === false) {
             return false;
-        } else {
-            return true;
         }
+        return true;
     };
-    $("#metadata-list input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-        data.description.nationalStatistic = $("#metadata-list input[type='checkbox']").prop('checked') ? true : false;
+    
+    $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+        data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
     });
 
     // Save

--- a/src/legacy/js/functions/_t6CompendiumEditor.js
+++ b/src/legacy/js/functions/_t6CompendiumEditor.js
@@ -85,15 +85,15 @@ function compendiumEditor(collectionId, data, templateData) {
 
   /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
    is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-  var checkBoxStatus = function () {
-    if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
-      return false;
+   var checkBoxStatus = function (value) {
+    if (value === "" || value === "false" || value === false) {
+        return false;
     }
     return true;
   };
 
-  $("#metadata-list input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-    data.description.nationalStatistic = $("#metadata-list input[type='checkbox']").prop('checked') ? true : false;
+  $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+    data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
   });
 
   //Add new chapter

--- a/src/legacy/js/functions/_t7QmiEditor.js
+++ b/src/legacy/js/functions/_t7QmiEditor.js
@@ -91,15 +91,15 @@ function qmiEditor(collectionId, data) {
 
   /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
    is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-  var checkBoxStatus = function () {
-    if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
-      return false;
+   var checkBoxStatus = function (value) {
+    if (value === "" || value === "false" || value === false) {
+        return false;
     }
     return true;
   };
 
-  $("#metadata-list input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-    data.description.nationalStatistic = $("#metadata-list input[type='checkbox']").prop('checked') ? true : false;
+  $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+    data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
   });
 
   // Save

--- a/src/legacy/js/functions/_t8LandingPageEditor.js
+++ b/src/legacy/js/functions/_t8LandingPageEditor.js
@@ -84,19 +84,19 @@ function datasetLandingEditor(collectionId, data) {
   });
   /* The checked attribute is a boolean attribute, which means the corresponding property is true if the attribute
    is present at all—even if, for example, the attribute has no value or is set to empty string value or even "false" */
-  var checkBoxStatus = function () {
-    if (data.description.nationalStatistic === "false" || data.description.nationalStatistic === false) {
-      return false;
-    } else {
-      return true;
+  var checkBoxStatus = function (value) {
+    if (value === "" || value === "false" || value === false) {
+        return false;
     }
+    return true;
   };
-  $("#metadata-list input[type='checkbox']").prop('checked', checkBoxStatus).click(function () {
-    data.description.nationalStatistic = $("#metadata-list input[type='checkbox']").prop('checked') ? true : false;
+
+  $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+    data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
   });
 
-  $("#census").prop('checked', data.description.survey ? true : false).click(function () {
-    data.description.survey = $("#census").prop('checked') ? 'census' : null;
+  $("#census-checkbox").prop('checked', data.description.survey ? true : false).click(function () {
+    data.description.survey = $("#census-checkbox").prop('checked') ? 'census' : null;
   });
 
   // Save

--- a/src/legacy/templates/workEditT16.handlebars
+++ b/src/legacy/templates/workEditT16.handlebars
@@ -83,8 +83,8 @@
                         <input type="checkbox" name="cancelled" value="false" class="checkbox"/>
                     </div>
                     <div id="census">
-                        <label for="census">Census </label>
-                        <input id="census" type="checkbox" name="census" {{#if this.description.survey}}checked{{/if}}/>
+                        <label for="census-checkbox">Census </label>
+                        <input id="census-checkbox" type="checkbox" name="census" />
                     </div>
                 </div>
             </div>

--- a/src/legacy/templates/workEditT4Article.handlebars
+++ b/src/legacy/templates/workEditT4Article.handlebars
@@ -77,11 +77,11 @@
                         </div>
                         <div id="natStat">
                             <label for="natStat-checkbox">National statistic</label>
-                            <input id="natStat-checkbox" type="checkbox" name="natStat" {{#if this.description.nationalStatistic}}checked{{/if}}/>
+                            <input id="natStat-checkbox" type="checkbox" name="natStat" />
                         </div>
                         <div id="census">
-                            <label for="census">Census </label>
-                            <input id="census" type="checkbox" name="census" {{#if this.description.survey}}checked{{/if}}/>
+                            <label for="census-checkbox">Census </label>
+                            <input id="census-checkbox" type="checkbox" name="census"/>
                         </div>
                         <div>
                             <label for="keywords">Keywords

--- a/src/legacy/templates/workEditT4Bulletin.handlebars
+++ b/src/legacy/templates/workEditT4Bulletin.handlebars
@@ -62,8 +62,8 @@
                             <input id="natStat-checkbox" type="checkbox" name="natStat" value="false"/>
                         </div>
                         <div id="census">
-                            <label for="census">Census </label>
-                            <input id="census" type="checkbox" name="census"/>
+                            <label for="census-checkbox">Census </label>
+                            <input id="census-checkbox" type="checkbox" name="census"/>
                         </div>
                         <div id="headline1-p">
                             <label for="headline1">Headline 1

--- a/src/legacy/templates/workEditT8LandingPage.handlebars
+++ b/src/legacy/templates/workEditT8LandingPage.handlebars
@@ -53,8 +53,8 @@
             <input id="natStat-checkbox" type="checkbox" name="natStat" value="false" />
           </div>
           <div id="census">
-              <label for="census">Census </label>
-              <input id="census" type="checkbox" name="census"/>
+              <label for="census-checkbox">Census </label>
+              <input id="census-checkbox" type="checkbox" name="census"/>
           </div>
           <div>
             <label for="keywords">Keywords


### PR DESCRIPTION
### What

Checkbox handling is being done differently across files and this PR will make them consistent.
- Handlebar templates will not including the checked attribute
- Js will add the checked prop using a generic `checkBoxStatus` function with the relevant field
- Js will refer to checkboxes by id rather than wider selectors

### How to review

Check code makes sense. Test check boxes retain the value for different page type

### Who can review

Anyone
