### PR TITLE
Fixes #981: Edit team/group error trying to add/remove members

### DIFF
--- a/src/app/views/groups/edit/EditGroup.jsx
+++ b/src/app/views/groups/edit/EditGroup.jsx
@@ -91,7 +91,7 @@ const EditGroup = props => {
         if (hasUpdatedMembers) {
             updateGroupMembers(
                 id,
-                groupMembers.map(({ id }) => id)
+                groupMembers.map(({ id }) => ({"user_id": id})),
             );
         }
     };


### PR DESCRIPTION
### What

Describe what you have changed and why.
Fixes Error when trying to edit an existing group to add or remove team members.
### How to review

Run the florence `ENABLE_PERMISSION_API=true`
Describe the steps required to test the changes.
1. Login as Admin.
2. Preview Teams tab.
3. select an existing  preview team
4. remove a member from the team and/or select a member to add to the team
6. Open network tab of the dev tools
7. Create Team button

### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself
