### PR TITLE
Fixes #978: Back button doesn't implement the History API

### DIFF
--- a/src/app/components/back-button/BackButton.jsx
+++ b/src/app/components/back-button/BackButton.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import url from "../../utilities/url";
-import { Link } from "react-router";
+import { Link, useHistory } from "react-router";
 import clsx from "clsx";
 import PropTypes from "prop-types";
 

--- a/src/app/utilities/redirect.js
+++ b/src/app/utilities/redirect.js
@@ -1,5 +1,7 @@
+import { fromPairs } from "lodash";
 import { browserHistory } from "react-router";
 import { store } from "../config/store";
+import fp from "lodash/fp";
 
 /**
  * Redirects to one of the main views in Florence - chooses whether it needs to redirect to old Florence or route within the new application
@@ -31,4 +33,8 @@ export default function redirectToMainScreen(screen) {
     }
 
     browserHistory.push(`${rootPath}/collections`);
+}
+
+export function getPreviousPathnameFromProps(props) {
+    return fp.get("router.location.previousPathname")(props);
 }

--- a/src/app/views/groups/Groups.jsx
+++ b/src/app/views/groups/Groups.jsx
@@ -23,7 +23,6 @@ const Groups = props => {
     return (
         <div className="grid grid--justify-space-around">
             <div className="grid__col-11 grid__col-md-9">
-                <BackButton classNames="margin-top--2" />
                 <span className="margin-top--1">
                     <h1 className="inline-block margin-top--0 margin-bottom--0 padding-right--1">Preview teams</h1>
                     <Link className="margin-left--1" to={url.resolve("./groups/create")}>

--- a/src/app/views/groups/Groups.test.jsx
+++ b/src/app/views/groups/Groups.test.jsx
@@ -30,11 +30,6 @@ describe("Groups", () => {
         expect(defaultProps.loadTeams).toHaveBeenCalledWith(true);
     });
 
-    it("shows Back Button", () => {
-        render(<Groups {...defaultProps} />);
-        expect(screen.getByText(/Back/i)).toBeInTheDocument();
-    });
-
     it("shows, message if no teams found", () => {
         render(<Groups {...defaultProps} />);
         expect(screen.getByText(/Nothing to show/i)).toBeInTheDocument();
@@ -50,7 +45,6 @@ describe("Groups", () => {
         const props = { ...defaultProps, groups: mappedSortedGroups };
         render(<Groups {...props} />);
 
-        expect(screen.getByText(/Back/i)).toBeInTheDocument();
         expect(screen.getByText(/Preview teams/i)).toBeInTheDocument();
         expect(screen.getByText(/Hello Group/i)).toBeInTheDocument();
         expect(screen.getByText(/Test/i)).toBeInTheDocument();

--- a/src/app/views/groups/__snapshots__/Groups.test.jsx.snap
+++ b/src/app/views/groups/__snapshots__/Groups.test.jsx.snap
@@ -7,18 +7,6 @@ exports[`Groups matches the snapshot with empty props 1`] = `
   <div
     className="grid__col-11 grid__col-md-9"
   >
-    <div
-      className="margin-top--2"
-    >
-      ◀ 
-      <a
-        onClick={[Function]}
-        role="link"
-        style={Object {}}
-      >
-        Back
-      </a>
-    </div>
     <span
       className="margin-top--1"
     >
@@ -80,18 +68,6 @@ exports[`Groups matches the snapshot with groups props 1`] = `
   <div
     className="grid__col-11 grid__col-md-9"
   >
-    <div
-      className="margin-top--2"
-    >
-      ◀ 
-      <a
-        onClick={[Function]}
-        role="link"
-        style={Object {}}
-      >
-        Back
-      </a>
-    </div>
     <span
       className="margin-top--1"
     >

--- a/src/app/views/login/LoginController.jsx
+++ b/src/app/views/login/LoginController.jsx
@@ -12,7 +12,7 @@ import http from "../../utilities/http";
 import { errCodes } from "../../utilities/errorCodes";
 import user from "../../utilities/api-clients/user";
 import cookies from "../../utilities/cookies";
-import redirectToMainScreen from "../../utilities/redirectToMainScreen";
+import redirectToMainScreen from "../../utilities/redirect";
 import log from "../../utilities/logging/log";
 
 const propTypes = {

--- a/src/app/views/login/LoginController.test.js
+++ b/src/app/views/login/LoginController.test.js
@@ -28,7 +28,7 @@ jest.mock("../../utilities/api-clients/user.js", () => {
         },
     };
 });
-jest.mock("../../utilities/redirectToMainScreen.js", () => {
+jest.mock("../../utilities/redirect.js", () => {
     return {
         redirectToMainScreen: function () {
             // do nothing

--- a/src/app/views/login/SignIn.jsx
+++ b/src/app/views/login/SignIn.jsx
@@ -6,7 +6,7 @@ import LoginForm from "./SignInForm";
 import notifications from "../../utilities/notifications";
 import { errCodes } from "../../utilities/errorCodes";
 import user from "../../utilities/api-clients/user";
-import redirectToMainScreen from "../../utilities/redirectToMainScreen";
+import redirectToMainScreen from "../../utilities/redirect";
 import log from "../../utilities/logging/log";
 import ChangePasswordController from "../new-password/changePasswordController";
 import ChangePasswordConfirmed from "../new-password/changePasswordConfirmed";

--- a/src/app/views/login/SignIn.test.js
+++ b/src/app/views/login/SignIn.test.js
@@ -30,7 +30,7 @@ jest.mock("../../utilities/api-clients/user.js", () => {
     };
 });
 
-jest.mock("../../utilities/redirectToMainScreen.js", () => {
+jest.mock("../../utilities/redirect.js", () => {
     return {
         redirectToMainScreen: function () {
             // do nothing

--- a/src/app/views/security/Security.jsx
+++ b/src/app/views/security/Security.jsx
@@ -34,7 +34,6 @@ const Security = ({ signOutAllUsers, openModal, closeModal, loading }) => {
     return (
         <div className="grid grid--justify-space-around">
             <div className="grid__col-11 grid__col-md-9">
-                <BackButton classNames="margin-top--2" />
                 <h2 className="margin-top--1">Security</h2>
                 <div className="grid">
                     <div className="grid__col-lg-6">

--- a/src/app/views/security/__snapshots__/Security.test.jsx.snap
+++ b/src/app/views/security/__snapshots__/Security.test.jsx.snap
@@ -7,18 +7,6 @@ exports[`Security matches the snapshot 1`] = `
   <div
     className="grid__col-11 grid__col-md-9"
   >
-    <div
-      className="margin-top--2"
-    >
-      ◀ 
-      <a
-        onClick={[Function]}
-        role="link"
-        style={Object {}}
-      >
-        Back
-      </a>
-    </div>
     <h2
       className="margin-top--1"
     >
@@ -65,18 +53,6 @@ exports[`Security when loading matches the snapshot 1`] = `
   <div
     className="grid__col-11 grid__col-md-9"
   >
-    <div
-      className="margin-top--2"
-    >
-      ◀ 
-      <a
-        onClick={[Function]}
-        role="link"
-        style={Object {}}
-      >
-        Back
-      </a>
-    </div>
     <h2
       className="margin-top--1"
     >

--- a/src/app/views/users/UsersList.jsx
+++ b/src/app/views/users/UsersList.jsx
@@ -9,6 +9,7 @@ import Magnifier from "../../icons/Magnifier";
 import clsx from "clsx";
 import Loader from "../../components/loader/Loader";
 
+
 const mapUsers = (users, rootPath) => {
     return users.map(user => ({
         ...user,
@@ -36,7 +37,6 @@ const UsersList = props => {
     return (
         <div className="grid grid--justify-space-around">
             <div className="grid__col-9">
-                <BackButton classNames="margin-top--2" />
                 <div className="grid grid--align-baseline">
                     <div className="grid__col">
                         <h1>Users</h1>

--- a/src/app/views/users/UsersList.test.js
+++ b/src/app/views/users/UsersList.test.js
@@ -19,7 +19,6 @@ const props = {
 describe("UserList", () => {
     it("renders empty list with message if no users found", () => {
         render(<UsersList {...props} />);
-        expect(screen.getByRole("link", { name: "Back" })).toBeInTheDocument();
         expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(/Users/i);
         expect(screen.getByRole("link", { name: "Create new user" })).toBeInTheDocument();
         expect(screen.getByText(/Nothing to show/i)).toBeInTheDocument();

--- a/src/package.json
+++ b/src/package.json
@@ -88,7 +88,8 @@
     "prettier-test": "prettier --config \"prettierrc.json\" --check \"app/**/*.{js,jsx}\"",
     "prettier-cli": "prettier --config \"prettierrc.json\" --write \"app/**/*.{js,jsx}\"",
     "prettier-watch": "onchange \"app/**/*.{js,jsx}\" -- prettier --config \"prettierrc.json\" --write {{changed}}",
-    "eslint-check": "eslint -c ./.eslintrc.json 'app/**/*.{js, jsx}' --ignore-pattern node_modules/"
+    "eslint-check": "eslint -c ./.eslintrc.json 'app/**/*.{js, jsx}' --ignore-pattern node_modules/",
+    "test:update": "export NODE_ENV=testing && jest --updateSnapshot"
   },
   "dependencies": {
     "acorn": "^8.4.1",


### PR DESCRIPTION
### What
Back button doesn't implement the History API

Describe what you have changed and why.
The back buttons for groups & users doesn't implement the History API correctly, these fixes enable to user to navigate to the previous pages.

### How to review
Check that these routes are correct and if im missing any others...

Describe the steps required to test the changes.
- Click on Users and access tab
- Click on Preview teams
- Click "back" button

### Who can review
florence devs

Describe who worked on the changes, so that other people can review.
myself
