### PR TITLE
Fixes #976: Navigate from Preview Teams to group renders duplicate users

### DIFF
--- a/src/app/config/reducer.js
+++ b/src/app/config/reducer.js
@@ -2,6 +2,7 @@ import { initialState } from "./initialState";
 import * as types from "./constants";
 import * as groupsTypes from "./groups/constants";
 
+
 export default function reducer(state = initialState, action) {
     switch (action.type) {
         case types.CREATE_COLLECTION_SUCCESS: {
@@ -707,7 +708,7 @@ export default function reducer(state = initialState, action) {
                 ...state,
                 groups: {
                     ...state.groups,
-                    members: state.groups.members.concat(action.members),
+                    members: action.members,
                     isLoadingMembers: false,
                 },
             };


### PR DESCRIPTION
### What

Describe what you have changed and why.
If you switch from the Preview Teams page to Team detail page it duplicates the list of members each time.

To fix this i have fixed a bug in the members reducer.

### How to review
Run Florence with `ENABLE_NEW_SIGN_IN=true`

Describe the steps required to test the changes.

Goto http://localhost:8081/florence/groups
click on a group
Either use the browser back button or click the Back link
Click on the same group again
You should now see the duplicated members
Repeat & each time will duplicate another line of members

### Who can review
Florence devs

Describe who worked on the changes, so that other people can review.
myself
