### PR TITLE
Commit post install legacy package lock updates

### DIFF
--- a/src/legacy/package-lock.json
+++ b/src/legacy/package-lock.json
@@ -127,7 +127,7 @@
     "cat": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/cat/-/cat-0.2.0.tgz",
-      "integrity": "sha1-/YUM2n1BYuaQTzO3/PdDsSQ/1DQ="
+      "integrity": "sha512-FrG38TVBt6XKcbWHNZ1AsnFr+eozwypXhaMRHuJrC1JvC+3GaG8G/MwuChyJOVVdPT5VsH91PiRFaheQlK/6Gg=="
     },
     "chalk": {
       "version": "3.0.0",
@@ -497,7 +497,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "js-yaml": {
       "version": "3.13.1",


### PR DESCRIPTION
### What

Commit `package-lock.json` touched by `npm` during install.

When running `make node-modules-legacy` on a fresh copy of the repository, `npm` updates hashes in the package lock as part of the installation process. This leaves a dirty copy of the repository that cannot be updated without clearing out the changes.

### How to review

- Run `make node-modules-legacy`
- Verify that no files tracked by git are changed

### Who can review

Anyone
