### PR TITLE
Updaate files touched by prettier in postinstall

### DIFF
--- a/src/app/utilities/http-methods/request.js
+++ b/src/app/utilities/http-methods/request.js
@@ -108,7 +108,7 @@ export default function request(method, URI, willRetry = true, onRetry = () => {
                 let responseIsJSON = false;
                 let responseIsText = false;
                 try {
-                    if(response.headers && Object.entries(response.headers).length !== 0){
+                    if (response.headers && Object.entries(response.headers).length !== 0) {
                         responseIsJSON = response.headers.get("content-type").match(/application\/json/);
                         responseIsText = response.headers.get("content-type").match(/text\/plain/);
                     }

--- a/src/app/views/interactives/InteractivesForm.jsx
+++ b/src/app/views/interactives/InteractivesForm.jsx
@@ -48,14 +48,11 @@ export default function InteractivesForm(props) {
         const { interactiveId } = props.params;
         if (interactiveId && interactive.id) {
             const { metadata } = interactive;
-            (
-                internalId !== metadata.internal_id ||
-                title !== metadata.title ||
-                label !== metadata.label ||
-                file
-            ) ? setEditMode(true) : setEditMode(false)
+            internalId !== metadata.internal_id || title !== metadata.title || label !== metadata.label || file
+                ? setEditMode(true)
+                : setEditMode(false);
         }
-    }, [internalId, title, label, file])
+    }, [internalId, title, label, file]);
 
     useEffect(() => {
         if (interactive.metadata && interactiveId) {
@@ -99,23 +96,21 @@ export default function InteractivesForm(props) {
                 },
             })
         );
-        if(interactiveId) {
-            dispatch(editInteractive(interactiveId, formData))
-            collections.addInteractive(collectionId, interactiveId)
-                .catch((error) => {
-                    console.log('error changing status to InProgress', error)
-                })
-        }  else {
+        if (interactiveId) {
+            dispatch(editInteractive(interactiveId, formData));
+            collections.addInteractive(collectionId, interactiveId).catch(error => {
+                console.log("error changing status to InProgress", error);
+            });
+        } else {
             dispatch(createInteractive(formData));
         }
     };
 
     const onSubmitApproval = async () => {
-        collections.setInteractiveStatusToReviewed(collectionId, interactiveId)
-            .catch((e) => {
-                console.log('error changing status to REVIEWED', e)
-            })
-    }
+        collections.setInteractiveStatusToReviewed(collectionId, interactiveId).catch(e => {
+            console.log("error changing status to REVIEWED", e);
+        });
+    };
 
     const handleDelete = e => {
         e.preventDefault();
@@ -369,17 +364,17 @@ export default function InteractivesForm(props) {
                             <ButtonWithShadow type="submit" buttonText="Confirm" onClick={onSubmit} isSubmitting={false} />
                         ) : (
                             <div className="inline-block">
-                                {
-                                    editMode ?
+                                {editMode ? (
                                     <ButtonWithShadow type="submit" buttonText="Save changes" onClick={onSubmit} isSubmitting={false} />
-                                        :
-                                    <ButtonWithShadow type="submit" buttonText="Save and submit for approval" onClick={onSubmitApproval} isSubmitting={false} />
-                                }
-                                <Link
-                                    to={`${rootPath}/interactives/show/${interactiveId}`}
-                                    target="_blank"
-                                    className="ons-btn ons-btn--secondary"
-                                >
+                                ) : (
+                                    <ButtonWithShadow
+                                        type="submit"
+                                        buttonText="Save and submit for approval"
+                                        onClick={onSubmitApproval}
+                                        isSubmitting={false}
+                                    />
+                                )}
+                                <Link to={`${rootPath}/interactives/show/${interactiveId}`} target="_blank" className="ons-btn ons-btn--secondary">
                                     <span className="ons-btn__inner">Preview</span>
                                 </Link>
                                 <ButtonWithShadow

--- a/src/app/views/interactives/InteractivesForm.test.js
+++ b/src/app/views/interactives/InteractivesForm.test.js
@@ -4,8 +4,8 @@ import * as reactRedux from "react-redux";
 import { render, fireEvent, screen } from "../../utilities/tests/test-utils";
 import InteractivesForm from "./InteractivesForm";
 import { show } from "../../utilities/api-clients/interactives-test";
-import * as interactivesActions from '../../actions/interactives';
-import collections from '../../utilities/api-clients/collections';
+import * as interactivesActions from "../../actions/interactives";
+import collections from "../../utilities/api-clients/collections";
 
 const initialState = {
     interactives: [],
@@ -23,12 +23,12 @@ describe("Create/Edit an Interactives", () => {
     const useDispatchMock = jest.spyOn(reactRedux, "useDispatch");
 
     const createInteractive = jest.fn();
-    const editInteractive = jest.spyOn(interactivesActions, 'editInteractive');
-    const getInteractive = jest.spyOn(interactivesActions, 'getInteractive');
+    const editInteractive = jest.spyOn(interactivesActions, "editInteractive");
+    const getInteractive = jest.spyOn(interactivesActions, "getInteractive");
     const resetInteractiveError = jest.fn();
 
-    const setInteractiveStatusToComplete = jest.spyOn(collections, 'setInteractiveStatusToComplete');
-    const setInteractiveStatusToReviewed = jest.spyOn(collections, 'setInteractiveStatusToReviewed');
+    const setInteractiveStatusToComplete = jest.spyOn(collections, "setInteractiveStatusToComplete");
+    const setInteractiveStatusToReviewed = jest.spyOn(collections, "setInteractiveStatusToReviewed");
 
     beforeEach(() => {
         const dispatch = jest.fn();
@@ -153,7 +153,9 @@ describe("Create/Edit an Interactives", () => {
 
         it("User can review the interactive and move to REVIEW status if there is not any change", async () => {
             useDispatchMock.mockReturnValue(getInteractive);
-            setInteractiveStatusToComplete.mockImplementation(() => {return Promise.resolve({data: ''});});
+            setInteractiveStatusToComplete.mockImplementation(() => {
+                return Promise.resolve({ data: "" });
+            });
             defaultProps.params.interactiveId = "2ab8d731-e3ec-4109-a573-55e12951b704";
 
             const { rerender } = render(<InteractivesForm {...defaultProps} />);
@@ -249,7 +251,7 @@ describe("Create/Edit an Interactives", () => {
             expect(internalIdInput.value).toBe("internal_id");
 
             fireEvent.change(internalIdInput, {
-                target: { value: "new value" }
+                target: { value: "new value" },
             });
 
             // input has changed, so SAVE CHANGES button appears instead


### PR DESCRIPTION
### What

Commit files touched by `prettier` in the postinstall

When running `make node-modules-react` on a fresh copy of the repository, `prettier` touches several files as part of the postinstall task. This leaves a dirty copy of the repository that cannot be updated without clearing out the changes.

### How to review

- Run `make node-modules-react`
- Verify that no files tracked by git are changed

### Who can review

Anyone
