### PR TITLE
Use 24h format for publish time

### DIFF
--- a/src/app/views/collections/edit/CollectionEditController.jsx
+++ b/src/app/views/collections/edit/CollectionEditController.jsx
@@ -75,7 +75,7 @@ export class CollectionEditController extends Component {
                     errorMsg: "",
                 },
                 publishTime: {
-                    value: date.format(this.props.publishDate, "hh:MM"),
+                    value: date.format(this.props.publishDate, "HH:MM"),
                     errorMsg: "",
                 },
             });


### PR DESCRIPTION
### What

When editing scheduled collection time was reset to morning. 
Fix it by using 24h format to set the publish time

https://trello.com/c/TVPszylu/2404-s2-afternoon-publish-date-time-is-reset-to-morning-on-collection-edit

### How to review

- click on a collection
- schedule an afternoon publish time (e.g. 2PM)
- save
- go back in to edit, note that the time stays as afternoon (e.g. 14:00)

### Who can review

Frontend devs
