### PR TITLE
Improve log message

### DIFF
--- a/src/tablebuilder/handsontable-css-fix.js
+++ b/src/tablebuilder/handsontable-css-fix.js
@@ -18,7 +18,7 @@ console.log("Temporary fix until the next version of react-handsontable updates 
 console.log("It replicates the changes here: https://github.com/handsontable/handsontable/pull/4337");
 try {
     const changes = replace.sync(options);
-    console.log('Modified files:', changes.join(', '));
+    console.log('Modified files:', changes.filter(r => r.hasChanged).map(r => r.file).join(', '));
 }
 catch (error) {
     console.error('Error occurred:', error);


### PR DESCRIPTION
### What

The `handsontable-css-fix.js` is called as part of `build` and `postinstall` and generates an useless and long log message:

```
Modified files: [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object], [object Object] ...
```

Improve this log message by just outputting the files that have change, displaying the file name:

```
Modified files: node_modules/react-handsontable/dist/react-handsontable.js, node_modules/react-handsontable/dist/react-handsontable.min.js
```

### How to review

- Run `make clean`
- Run any make target using npm, for example `make audit`
- Check the log message is more descriptive (as above)

Note: if `make clean` is not run, the message might not display any files as the replacement might have already been done, as opposed to a long list of `[object Object]`)

### Who can review

Anyone
