### PR TITLE
Fix preview dropdown for Interactives

### DIFF
--- a/src/app/components/preview-nav/PreviewNav.jsx
+++ b/src/app/components/preview-nav/PreviewNav.jsx
@@ -32,7 +32,7 @@ const PreviewNav = ({ workingOn, preview, rootPath, updateSelected }) => {
                             name: createPageTitle(page),
                             isGroup: true,
                             groupOptions: page.files.map(file => {
-                                return { id: file.URI, name: file.name };
+                                return { id: file.uri, name: file.uri };
                             }),
                         };
                     }


### PR DESCRIPTION
Currently broken and not clear for multiple interactives:

<img width="1440" alt="Screenshot 2022-06-09 at 09 32 02" src="https://user-images.githubusercontent.com/20839419/172803675-bf9496b3-80d1-498d-b3d9-cf9ccf3efd2d.png">

