### PR TITLE
Add legacy interactive css content

### DIFF
--- a/src/legacy/scss/components/_page.scss
+++ b/src/legacy/scss/components/_page.scss
@@ -153,6 +153,11 @@
                 content: 'VIS';
             }
         }
+        &--interactive {
+            &:after {
+                content: 'INT';
+            }
+        }
         &--directory {
             &:after {
                 background: transparent url(../../img/sprite.png) no-repeat -4px -418px;


### PR DESCRIPTION
### What

Adds the styling for rendering content in publishDetails page. Currently looks like:

<img width="1325" alt="Screenshot 2022-06-09 at 16 38 01" src="https://user-images.githubusercontent.com/20839419/172887974-59a0bbc3-2e2f-447f-8cc1-2b8e157d55ea.png">

### How to review

Sanity check Im adding in correct place

### Who can review

Anyone
