### PR TITLE
Fix `make watch-src`

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -73,10 +73,9 @@
   },
   "comment": "The handsontable and replace-in-file devDependencies, plus the 'node tablebuilder/handsontable-css-fix.js' build & postinstall scripts are only necessary until version 0.3.2+ of react-handsontable is available and pulled in by dp-table-builder-ui",
   "scripts": {
-    "dev": "export NODE_ENV=development && npx webpack -w",
     "audit": "npx auditjs ossi --whitelist ./audit-allowlist.json --quiet",
     "watch": "cd legacy && npm run watch & npm run watch-refactored",
-    "watch-refactored": "node ./node_modules/webpack/bin/webpack.js -d --watch & npm run prettier-watch",
+    "watch-refactored": "export NODE_ENV=development && npx webpack -w & npm run prettier-watch",
     "build": "node tablebuilder/handsontable-css-fix.js && cd legacy && npm run build && cd ../ && npm run build-refactored",
     "build-refactored": "npm run prettier-cli; node ./node_modules/webpack/bin/webpack.js --mode=production",
     "build-refactored:dev": "node ./node_modules/webpack/bin/webpack.js -d",


### PR DESCRIPTION
This is a duplicate of #821 that was approved by @gilesburdett. I've renamed the branch to follow GitFlow naming convention assuming this was the reason of declined merge.

### What

Fixed `watch-refactored` so `make watch-src` works as intended and rebuilds the files with changes.

I really wanted to add HMR or at least LiveReload in there but it doesn't seem that we actually use the webpack development server in serve mode, likely due to the convoluted structure and port mappings. There seems to be leftovers from webpack v4 config in there but that's a whole different story: there's a lot in there that could do with a solid cleanup, but this must suffice for now.

### How to review

0. Fire up `florence`
1.  Run `make watch-src`
2. Edit a legacy / old workspace file, refresh, see rebuilt changes
3. Edit a refactored / new workspace file, refresh, see rebuilt changes

### Who can review

Anyone
