### PR TITLE
#983: Remove access token expiry pop-up

### DIFF
--- a/src/app/utilities/sessionManagement.js
+++ b/src/app/utilities/sessionManagement.js
@@ -49,7 +49,7 @@ export default class sessionManagement {
         // Timer to start monitoring user interaction to add additional time to their session
         this.startExpiryTimer("sessionTimerPassive", sessionExpiryTime, this.timeOffsets.passiveRenewal, this.monitorInteraction);
         // Timer to tell the user their session is about to expire unless they interact with the page
-        this.startExpiryTimer("sessionTimerInvasive", sessionExpiryTime, this.timeOffsets.invasiveRenewal, this.warnSessionSoonExpire);
+        this.startExpiryTimer("sessionTimerInvasive", sessionExpiryTime, this.timeOffsets.invasiveRenewal, this.refreshAccessToken);
     }
 
     static startRefreshTimer(refreshExpiryTime) {
@@ -107,23 +107,10 @@ export default class sessionManagement {
         });
     };
 
-    static warnSessionSoonExpire = () => {
+    static refreshAccessToken = () => {
         this.removeInteractionMonitoring();
-        const popoutOptions = {
-            id: "session-expire-soon",
-            title: "Your session will end in 1 minute",
-            body: "This is because you have been inactive. If you want to continue using Florence you must stay signed in. If not, you will be signed out and will need to sign in again.",
-            buttons: [
-                {
-                    onClick: () => {
-                        this.refreshSession();
-                    },
-                    text: "Stay signed in",
-                    style: "primary",
-                },
-            ],
-        };
-        store.dispatch(addPopout(popoutOptions));
+        // refresh token & PUT /api/v1/tokens/self & restart timers
+        this.refreshSession();
     };
 
     static warnRefreshSoonExpire = () => {


### PR DESCRIPTION
### What

- Remove the "Your session will expire" pop up as isn't adding value ✅ 
  - Pop up isn't adding any user value since their session isn't actually about to expire it is just the access token that is ✅ 
- What needs changing:
  * Remove last interaction/active timer (3 below) in session refresh login in Florence ✅ 
  * Update the "auth state" with the new access token expiry time ✅ 
  * Replace current session refresh logic (incl. the popup it produces) with logic that just before access token expiry (maybe 1 min before) based on access token expiry timer (1 below), refresh the access token (i.e. `PUT /api/v1/tokens/self`) and then reset timer ✅ 

Describe what you have changed and why.

### How to review
Check the code does meets the above expectations

Describe the steps required to test the changes.

### Who can review
Forence devs

Describe who worked on the changes, so that other people can review.
myself
