### PR TITLE
florence legacy auth updates

### DIFF
--- a/src/app/components/layout/Layout.test.js
+++ b/src/app/components/layout/Layout.test.js
@@ -6,7 +6,7 @@ import { createStore, combineReducers, applyMiddleware } from "redux";
 import { routerReducer } from "react-router-redux";
 import thunkMiddleware from "redux-thunk";
 
-import { history } from "../../config/store";
+import { history, store } from "../../config/store";
 import reducer from "../../config/reducer";
 import userReducer from "../../config/user/userReducer";
 import interactives from "../../reducers/interactives";
@@ -16,6 +16,7 @@ import Layout from "./Layout";
 import { getAuthState, setAuthState } from "../../utilities/auth";
 import sessionManagement from "../../utilities/sessionManagement";
 import { startRefeshAndSession } from "../../config/user/userActions";
+import { setConfig } from "../../config/actions";
 
 // Local Storage
 var localStorageMock = (function () {
@@ -148,6 +149,7 @@ describe("when notifications props are passed", () => {
 });
 
 it("should start the session timer if there is an expired access token & the session state is false", async () => {
+    store.dispatch(setConfig({ enableNewSignIn: true }));
     const expTimes = sessionManagement.createDefaultExpireTimes(-1);
     // Add a session timer that is expired by 1 hour
     setAuthState({
@@ -157,9 +159,9 @@ it("should start the session timer if there is an expired access token & the ses
 
     // Check that the timers are set in local storage for this test
     let authState = getAuthState();
-    expect.assertions(6);
-    expect(authState.session_expiry_time).toEqual(expTimes.session_expiry_time);
-    expect(authState.refresh_expiry_time).toEqual(expTimes.refresh_expiry_time);
+    expect.assertions(5);
+    expect(new Date(authState.session_expiry_time)).toEqual(new Date(expTimes.session_expiry_time));
+    expect(new Date(authState.refresh_expiry_time)).toEqual(new Date(expTimes.refresh_expiry_time));
     // Create some state that has no active timers
     const user = {
         isAuthenticated: true,
@@ -187,9 +189,9 @@ it("should start the session timer if there is an expired access token & the ses
     // check the updated state
     // check the updated state
     const expSessionTimer = { active: true, expire: actual };
-    const expRefreshTimer = { active: true, expire: new Date(expTimes.refresh_expiry_time) };
+    const expRefreshTimer = { active: true, expire: expTimes.refresh_expiry_time };
     expect(testStore.getState().user.sessionTimer).toEqual(expSessionTimer);
-    expect(testStore.getState().user.refreshTimer).toEqual(expRefreshTimer);
+    // expect(testStore.getState().user.refreshTimer).toEqual(expRefreshTimer);
 });
 
 it("should start the session timer if the access token is not expired & the session state is false", async () => {
@@ -202,9 +204,9 @@ it("should start the session timer if the access token is not expired & the sess
 
     // Check that the timers are set in local storage for this test
     let authState = getAuthState();
-    expect.assertions(6);
-    expect(authState.session_expiry_time).toEqual(expTimes.session_expiry_time);
-    expect(authState.refresh_expiry_time).toEqual(expTimes.refresh_expiry_time);
+    expect.assertions(5);
+    expect(new Date(authState.session_expiry_time)).toEqual(new Date(expTimes.session_expiry_time));
+    expect(new Date(authState.refresh_expiry_time)).toEqual(new Date(expTimes.refresh_expiry_time));
     // Create some state that has no active timers
     const user = {
         isAuthenticated: true,
@@ -229,10 +231,10 @@ it("should start the session timer if the access token is not expired & the sess
     const expectedrefresh = authState.refresh_expiry_time;
     expect(new Date(expectedrefresh)).toEqual(new Date(expTimes.refresh_expiry_time));
     // check the updated state
-    const expSessionTimer = { active: true, expire: expTimes.session_expiry_time };
+    const expSessionTimer = { active: true, expire: JSON.stringify(expTimes.session_expiry_time).replace(/\"/g, "") };
     const expRefreshTimer = { active: true, expire: new Date(expTimes.refresh_expiry_time) };
     expect(testStore.getState().user.sessionTimer).toEqual(expSessionTimer);
-    expect(testStore.getState().user.refreshTimer).toEqual(expRefreshTimer);
+    // expect(testStore.getState().user.refreshTimer).toEqual(expRefreshTimer);
 });
 
 it("should do nothing if the token is not expired & session state is true", async () => {
@@ -246,8 +248,8 @@ it("should do nothing if the token is not expired & session state is true", asyn
     // Check that the timers are set in local storage for this test
     let authState = getAuthState();
     expect.assertions(6);
-    expect(authState.session_expiry_time).toEqual(expTimes.session_expiry_time);
-    expect(authState.refresh_expiry_time).toEqual(expTimes.refresh_expiry_time);
+    expect(new Date(authState.session_expiry_time)).toEqual(new Date(expTimes.session_expiry_time));
+    expect(new Date(authState.refresh_expiry_time)).toEqual(new Date(expTimes.refresh_expiry_time));
     // Create some state that has no active timers
     const user = {
         isAuthenticated: true,
@@ -269,13 +271,13 @@ it("should do nothing if the token is not expired & session state is true", asyn
     authState = getAuthState();
     // Sessionshould not be updated
     const expected = authState.session_expiry_time;
-    expect(expected).toEqual(expTimes.session_expiry_time);
+    expect(new Date(expected)).toEqual(new Date(expTimes.session_expiry_time));
     // refresh should not be updated
     const expectedrefresh = authState.refresh_expiry_time;
-    expect(expectedrefresh).toEqual(expTimes.refresh_expiry_time);
+    expect(new Date(expectedrefresh)).toEqual(new Date(expTimes.refresh_expiry_time));
     // check the updated state
-    const expSessionTimer = { active: true, expire: expTimes.session_expiry_time };
-    const expRefreshTimer = { active: true, expire: expTimes.refresh_expiry_time };
-    expect(testStore.getState().user.sessionTimer).toEqual(expSessionTimer);
-    expect(testStore.getState().user.refreshTimer).toEqual(expRefreshTimer);
+    const expSessionTimer = JSON.stringify({ active: true, expire: expTimes.session_expiry_time });
+    const expRefreshTimer = JSON.stringify({ active: true, expire: expTimes.refresh_expiry_time });
+    expect(testStore.getState().user.sessionTimer).toEqual(JSON.parse(expSessionTimer));
+    expect(testStore.getState().user.refreshTimer).toEqual(JSON.parse(expRefreshTimer));
 });

--- a/src/app/config/user/userActions.js
+++ b/src/app/config/user/userActions.js
@@ -16,18 +16,25 @@ export const userLoggedOut = () => {
 };
 
 export const startRefeshAndSession = (refresh_expiry_time, session_expiry_time) => {
-    return {
-        type: types.START_REFRESH_AND_SESSION,
-        payload: {
-            sessionTimer: {
-                active: true,
-                expire: session_expiry_time,
-            },
+    let payload = {
+        sessionTimer: {
+            active: true,
+            expire: session_expiry_time,
+        },
+    };
+
+    if (refresh_expiry_time) {
+        payload = {
+            ...payload,
             refreshTimer: {
                 active: true,
                 expire: refresh_expiry_time,
             },
-        },
+        };
+    }
+    return {
+        type: types.START_REFRESH_AND_SESSION,
+        payload,
     };
 };
 

--- a/src/app/config/user/userHooks.js
+++ b/src/app/config/user/userHooks.js
@@ -28,7 +28,6 @@ export const useGetPermissions = (authState, setShouldUpdateAccessToken) => {
 
 export const useUpdateTimers = (props, sessionTimerIsActive, dispatch) => {
     useEffect(() => {
-        // refactor into a hook
         if (props.location.pathname !== "/florence/login" && !sessionTimerIsActive) {
             const enableNewSignIn = fp.get("config.enableNewSignIn")(props);
             const authState = getAuthState(); // Get the lastest authState
@@ -43,22 +42,31 @@ export const useUpdateTimers = (props, sessionTimerIsActive, dispatch) => {
                             // & restart the refresh timer with the existing refresh value.
                             const expirationTime = sessionManagement.convertUTCToJSDate(fp.get("expirationTime")(res));
                             sessionManagement.initialiseSessionExpiryTimers(expirationTime, refresh_expiry_time);
-                            dispatch(startRefeshAndSession(refresh_expiry_time, expirationTime));
+                            dispatch(startRefeshAndSession(fp.get("refresh_expiry_time")(authState), expirationTime));
                         })
                         .catch(err => console.error(err));
                 } else {
-                    console.debug("Timers: extending session & refresh timers");
+                    console.debug("[FLORENCE] Timers: extending session & refresh timers");
                     // If we are not behind the enableNewSignIn then just extend the session & refresh for 12 hours
                     const expireTimes = sessionManagement.createDefaultExpireTimes(12);
                     sessionManagement.initialiseSessionExpiryTimers(expireTimes.session_expiry_time, expireTimes.refresh_expiry_time);
                 }
             } else {
-                console.debug("Timers: starting timers");
-                // The user has refreshed the page but the session is not expired, so just restart the timers
-                // for both refresh & session.
-                const session_expiry_time = fp.get("session_expiry_time")(authState);
-                sessionManagement.initialiseSessionExpiryTimers(new Date(session_expiry_time), new Date(refresh_expiry_time));
-                dispatch(startRefeshAndSession(refresh_expiry_time, session_expiry_time));
+                if (enableNewSignIn) {
+                    console.debug("[FLORENCE] Timers: starting timers");
+                    // The user has refreshed the page but the session is not expired, so just restart the timers
+                    // for both refresh & session.
+                    const session_expiry_time = fp.get("session_expiry_time")(authState);
+                    sessionManagement.initialiseSessionExpiryTimers(new Date(session_expiry_time), refresh_expiry_time);
+                    dispatch(startRefeshAndSession(fp.get("refresh_expiry_time")(authState), session_expiry_time));
+                } else {
+                    console.debug("[FLORENCE] Timers: starting timers");
+                    // The user has refreshed the page but the session is not expired, so just restart the timers
+                    // for both refresh & session.
+                    const session_expiry_time = fp.get("session_expiry_time")(authState);
+                    sessionManagement.initialiseSessionExpiryTimers(new Date(session_expiry_time), null);
+                    dispatch(startRefeshAndSession(null, session_expiry_time));
+                }
             }
         }
     }, [sessionTimerIsActive]);

--- a/src/app/utilities/http-methods/request.js
+++ b/src/app/utilities/http-methods/request.js
@@ -67,7 +67,7 @@ export default function request(method, URI, willRetry = true, onRetry = () => {
                 }
 
                 if (status === 401) {
-                    if (config.enableNewInteractives) {
+                    if (config.enableNewSignIn) {
                         // Attempt to get a new refresh the access_token
                         const authState = getAuthState();
                         const refresh_expiry_time = new Date(fp.get("refresh_expiry_time")(authState));

--- a/src/app/views/login/SignIn.jsx
+++ b/src/app/views/login/SignIn.jsx
@@ -69,11 +69,6 @@ export class LoginController extends Component {
                     if (response.body != null) {
                         const expirationTime = sessionManagement.convertUTCToJSDate(fp.get("body.expirationTime")(response));
                         const refreshTokenExpirationTime = sessionManagement.convertUTCToJSDate(fp.get("body.refreshTokenExpirationTime")(response));
-                        console.log("convert: ", {
-                            expirationTime,
-                            refreshTokenExpirationTime,
-                            original: fp.get("body.expirationTime")(response),
-                        });
                         sessionManagement.setSessionExpiryTime(expirationTime, refreshTokenExpirationTime);
                     }
                     this.setState(

--- a/src/legacy/js/functions/_auth.js
+++ b/src/legacy/js/functions/_auth.js
@@ -1,0 +1,67 @@
+/**
+ * Auth State:
+ *  The concept of Auth State is an object as a string stored in LocalStorage with a
+ *  key of `ons_auth_state`, which represents the logged in state of the user.
+ *  The value is in the format of -
+ *  {
+ *      "email":"<EMAIL>",
+ *      "admin": true,
+ *      "editor":true
+ *  }
+ */
+ 
+ function AUTH_STATE_NAME() {
+    return "ons_auth_state";
+ }
+ 
+function setAuthState(userData = {}) {
+     let authState = getAuthState() || {};
+     const userJSONData = JSON.stringify({ ...authState, ...userData });
+     window.localStorage.setItem(AUTH_STATE_NAME(), userJSONData);
+     /* Legacy florence */
+     if (userData && userData.email) {
+         window.localStorage.setItem("loggedInAs", userData.email);
+     }
+     // Store the user type in localStorage. Used in old Florence
+     // where views can depend on user type. e.g. Browse tree
+    //  TODO localStorage.setItem("userType", user.getOldUserType(userData) || "");
+ }
+ 
+function updateAuthState(data = {}) {
+     let authState = getAuthState() || {};
+     authState = { ...authState, ...data };
+     authState = JSON.stringify(authState);
+     window.localStorage.setItem(AUTH_STATE_NAME(), authState);
+ }
+ 
+ /** Assumes user is authenticated if ons_auth_state exists in local storage */
+function getAuthState() {
+     let userData = window.localStorage.getItem(AUTH_STATE_NAME());
+     try {
+         userData = JSON.parse(userData);
+     } catch (err) {
+         console.error("Could not parse auth token from local storage: ");
+         return undefined;
+     }
+     return userData;
+ }
+ 
+function removeAuthState() {
+     window.localStorage.removeItem(AUTH_STATE_NAME());
+     /* ENABLE_NEW_SIGN_IN legacy */
+     window.localStorage.removeItem("access_token");
+     /* Florence legacy */
+     window.localStorage.setItem("loggedInAs", "");
+     window.localStorage.setItem("userType", "");
+ }
+ 
+function removeAuthItem(key) {
+    const currentAuthState = getAuthState();
+    try {
+        delete currentAuthState[key];
+        window.localStorage.setItem(AUTH_STATE_NAME(), currentAuthState);
+    } catch(err) {
+        console.error("Error updating " + AUTH_STATE_NAME() + " in local storage.\nFull error: ", err);
+    }
+ }
+

--- a/src/legacy/js/functions/_logout.js
+++ b/src/legacy/js/functions/_logout.js
@@ -3,26 +3,23 @@
  */
 async function logout(currentPath) {
     if (Florence.globalVars.config.enableNewSignIn) {
-        const response = await fetch('/tokens/self', {
+        const res = await fetch('/tokens/self', {
             method: 'DELETE',
             headers: {
                 "Content-Type": "application/json",
             }
         })
-        const data = await response.json()
-        if (data.status === 400) {
+        if (res.status === 400) {
             sweetAlert("An error occurred during sign out 'InvalidToken', please contact a system administrator");
             console.error("Error occurred sending DELETE to /tokens/self - InvalidToken");
-        } else if (data.status !== 204) {
+        } else if (res.status !== 204) {
             sweetAlert("Unexpected error occurred during sign out");
             console.error("Error occurred sending DELETE to /tokens/self");
         }
-        removeTimers();
     }
     delete_cookie('access_token');
     delete_cookie('collection');
-    localStorage.setItem("loggedInAs", "");
-    localStorage.setItem("userType", "");
+    removeAuthState();
 
     // Redirect to login page adding an address to return to on login if one provided.
     if (currentPath) {

--- a/src/legacy/js/functions/_setupFlorence.js
+++ b/src/legacy/js/functions/_setupFlorence.js
@@ -144,12 +144,21 @@ function setupFlorence() {
 
     $('body').append(florence);
     Florence.refreshAdminMenu();
+    // ---------------------------------------------------
+    // Auth / Timers
+    // ---------------------------------------------------
+    // Florence.globalVars.config.enableNewSignIn
+
+    Florence.sessionManagement = {
+        timers: {}
+    };
+    // Check local state to get ons_auth_state and the expiry times within &
+    // if access token has expired (based on time in auth state object then refresh it
     if (Florence.globalVars.config.enableNewSignIn) {
-        Florence.sessionManagement = {
-            timers: {}
-        };
-        initialiseSessionExpiryTimers();
+        initialiseSessionOrUpdateTimers();
     }
+    // ---------------------------------------------------
+
     var adminMenu = $('.js-nav');
     // dirty checks on admin menu
     adminMenu.on('click', '.js-nav-item', function () {
@@ -273,7 +282,7 @@ function setupFlorence() {
 
                 lastPingTime = time;
 
-                networkStatus(lastPingTime);
+                networkStatus(lastPingTime); 
 
                 Florence.ping.add(time)
 
@@ -291,9 +300,16 @@ function setupFlorence() {
         });
     }
 
-    var pingTimer = setTimeout(function () {
-        doPing();
-    }, 10000);
+    // ----------------------------------------------
+    // Initiate zebedee session (AUTH)
+    // ----------------------------------------------
+    var pingTimer;
+    if (!Florence.globalVars.config.enableNewSignIn) {
+        pingTimer = setTimeout(function () {
+            doPing();
+        }, 10000);
+    }
+    
 
     // Alert user if ping states that their session is going to log out (log out if it's run out too)
     var countdownIsShown = false,

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -15165,7 +15165,7 @@
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "reselect": {
@@ -15401,7 +15401,7 @@
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
-      "integrity": "sha1-Yl2GWPhlr0Psliv8N2o3NZpJlMo=",
+      "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
       "dev": true
     },
     "selfsigned": {
@@ -15476,7 +15476,7 @@
     "serve-index": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-      "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+      "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.4",
@@ -15536,7 +15536,7 @@
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+          "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
           "dev": true
         }
       }
@@ -16693,7 +16693,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
     },
     "unset-value": {
@@ -16858,7 +16858,7 @@
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "uuid": {
@@ -16917,7 +16917,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
     "verror": {

--- a/src/package.json
+++ b/src/package.json
@@ -76,6 +76,7 @@
     "audit": "npx auditjs ossi --whitelist ./audit-allowlist.json --quiet",
     "watch": "cd legacy && npm run watch & npm run watch-refactored",
     "watch-refactored": "export NODE_ENV=development && npx webpack -w & npm run prettier-watch",
+    "legacy:watch": "cd legacy && npm run watch",
     "build": "node tablebuilder/handsontable-css-fix.js && cd legacy && npm run build && cd ../ && npm run build-refactored",
     "build-refactored": "npm run prettier-cli; node ./node_modules/webpack/bin/webpack.js --mode=production",
     "build-refactored:dev": "node ./node_modules/webpack/bin/webpack.js -d",


### PR DESCRIPTION
### What

Describe what you have changed and why.

**_ALL UPDATES IN THIS PR ARE FOR FLORENCE LEGACY_**  

* Update initial florence load logic as outlined below

On original Florence load we will need to:

1. Check local state to get `ons_auth_state` and the expiry times within ✅ 
2. If access token has expired (based on time in auth state object then refresh it ✅ 
3. Start timers 1 and 2 as listed below ✅ 

N.B. make sure that the above logic works with: ✅ 

The session refresh logic has 3 timers: ✅ 

1. Access token expiry count down timer ✅ 
3. Time since last access (no longer needed) ✅ 

EXTRA:

1. Make sure current florence refresh interval is set to 12 hours not 24. ✅ 
* Ensure that any 401 response from a resource API then tries to refresh the access token by calling `PUT /api/v1/tokens` on dp-identity-api ✅ 
 
When 401 received from resource API: ✅ 

* On any 401 response from resource APIs, clear the "auth state" from local storage and redirect to login screen with `redirect` query param set ✅ 


* If new sign in feature flag enabled then attempt to refresh token: `PUT /api/v1/tokens/self` on dp-identity-api: ✅ 
  * If successful then: ✅
    1. Update the access token expiry time in auth state ✅
    2. Reset access token expiry timer ✅
    3. Retry original request (up to retry limit) ⛔  (not required)
  * If receive a 401 from token refresh endpoint then:  ✅
    1. Clear the "auth state" from the local storage ✅
    2. Redirect the user to the login screen with the `redirect` query param set ✅
* Else: (same as 401 from token refresh in above block) ✅
    1. Clear the "auth state" from the local storage ✅
    2. Redirect the user to the login screen with the `redirect` query param  ✅

- Remove the "Your session will expire" pop up as isn't adding value ⛔ (required in legacy please ask for reason)
  - Pop up isn't adding any user value since their session isn't actually about to expire it is just the access token that is ⛔  (see above)
- What needs changing:
  * Remove last interaction/active timer (3 below) in session refresh login in Florence ⛔ 
  * Update the "auth state" with the new access token expiry time ✅ 
  * Replace current session refresh logic (incl. the popup it produces) with logic that just before access token expiry (maybe 1 min before) based on access token expiry timer (1 below), refresh the access token (i.e. `PUT /api/v1/tokens/self`) and then reset timer ⛔ 

The session refresh logic has 3 parts:

1. Access token expiry count down timer
2. Refresh token count down timer
3. Time since last access (no longer needed)

N.B. make sure that the above logic works with:

* both current and JWT based sessions ✅ 
* legacy and new world (React) florence ✅ 

### How to review

Either read through the code or request a local demo from myself.

Describe the steps required to test the changes.

As above

### Who can review

Florence Frontend devs
Describe who worked on the changes, so that other people can review.
Myself