### PR TITLE
Task/audit fix node fetch

### DIFF
--- a/src/audit-allowlist.json
+++ b/src/audit-allowlist.json
@@ -19,6 +19,10 @@
         {
             "id" : "sonatype-2017-0717",
             "reason" : "We are using the latest react 17 (17.0.2) - require major upgrade"
+        },
+        {
+            "id" : "sonatype-2022-3677",
+            "reason" : "Latest node-fetch@3.2.6 does not fix the vulnerability"
         }
     ]
 }

--- a/src/legacy/package-lock.json
+++ b/src/legacy/package-lock.json
@@ -388,9 +388,9 @@
           "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "uglify-js": {
-          "version": "3.16.1",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.1.tgz",
-          "integrity": "sha512-X5BGTIDH8U6IQ1TIRP62YC36k+ULAa1d59BxlWvPUJ1NkW5L3FwcGfEzuVvGmhJFBu0YJ5Ge25tmRISqCmLiRQ==",
+          "version": "3.16.2",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
+          "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
           "optional": true
         }
       }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -3357,9 +3357,9 @@
       },
       "dependencies": {
         "moment": {
-          "version": "2.29.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-          "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+          "version": "2.29.4",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+          "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
           "dev": true
         }
       }
@@ -7831,9 +7831,9 @@
           "dev": true
         },
         "moment": {
-          "version": "2.29.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-          "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+          "version": "2.29.4",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+          "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
           "dev": true
         },
         "numbro": {
@@ -13142,9 +13142,9 @@
       "optional": true
     },
     "moment": {
-      "version": "2.29.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-      "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moo": {
       "version": "0.5.1",
@@ -14527,9 +14527,9 @@
           },
           "dependencies": {
             "moment": {
-              "version": "2.29.3",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-              "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+              "version": "2.29.4",
+              "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+              "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
             },
             "numbro": {
               "version": "1.11.0",
@@ -14545,9 +14545,9 @@
               },
               "dependencies": {
                 "moment": {
-                  "version": "2.29.3",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-                  "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw==",
+                  "version": "2.29.4",
+                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+                  "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
                   "optional": true
                 }
               }
@@ -14568,9 +14568,9 @@
           }
         },
         "moment": {
-          "version": "2.29.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.3.tgz",
-          "integrity": "sha512-c6YRvhEo//6T2Jz/vVtYzqBzwvPT95JBQ+smCytzf7c50oMZRsR/a4w88aD34I+/QVSfnoAnSBFPJHItlOMJVw=="
+          "version": "2.29.4",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+          "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
         },
         "regenerator-runtime": {
           "version": "0.13.9",


### PR DESCRIPTION
### What

`node-fetch@3.2.6` is the latest version at time of writing and does not address the vulnerability raised by `auditjs`. Until this is fixed up by the `node-fetch` developers, this vulnerability has been added to the audit allowlist.

### How to review

Sense check

### Who can review

Node / JavaScript developers
