### PR TITLE
Feature/update-cantabular-metadata-extractor-url

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -115,7 +115,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), modifiers.IdentityResponseModifier)
 	tableProxy := reverseproxy.Create(tableURL, directors.Director("/table"), nil)
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, directors.Director("/dataset-controller"), nil)
-	cantabularMetadataExtractorAPIProxi := reverseproxy.Create(cantabularMetadataExtractorURL, directors.Director("/metadata"), nil)
+	cantabularMetadataExtractorAPIProxi := reverseproxy.Create(cantabularMetadataExtractorURL, directors.Director(""), nil)
 
 	// The following proxies and their associated routes are deprecated and should be removed once the client side code has been updated to match
 	zebedeeProxy := reverseproxy.Create(apiRouterURL, directors.Director("/zebedee"), nil)
@@ -150,7 +150,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		router.Handle("/instances/{uri:.*}", datasetAPIProxy)
 		router.Handle("/dataset-controller/{uri:.*}", datasetControllerProxy)
 		if cfg.SharedConfig.EnableCantabularJourney {
-			router.Handle("/metadata/{uri:.*}", cantabularMetadataExtractorAPIProxi)
+			router.Handle("/cantabular-metadata/{uri:.*}", cantabularMetadataExtractorAPIProxi)
 		}
 	}
 	if cfg.SharedConfig.EnableNewSignIn {

--- a/src/app/utilities/api-clients/datasets.js
+++ b/src/app/utilities/api-clients/datasets.js
@@ -206,7 +206,7 @@ export default class datasets {
     }
 
     static getCantabularMetadata(datasetID, cantabularDatasetId, lang) {
-        return http.get(`/metadata/dataset/${datasetID}/cantabular/${cantabularDatasetId}/lang/${lang}`);
+        return http.get(`/cantabular-metadata/dataset/${datasetID}/cantabular/${cantabularDatasetId}/lang/${lang}`);
     }
 
     static putEditMetadata(datasetID, editionID, versionID, body) {


### PR DESCRIPTION
### What

I have updated the main path of the `CantabularMetadataExtractorAPI` by adding the `/cantabular-metadata` prefix to match the current existing main url of the cantabular metadata extractor api.

### How to review

Check the code and run the  Cantabular dataset journey.

### Who can review

Steve M / Patrick F
