### PR TITLE
Call cantabular metadata extractor via api router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ func Get() (*Config, error) {
 		DatasetControllerURL:              "http://localhost:24000",
 		TableRendererURL:                  "http://localhost:23300",
 		// CantabularMetadataExtractorAPIURL: "http://localhost:28300",
-		SharedConfig:                      SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false, EnableNewUpload: false, EnableNewInteractives: false, EnablePermissionsAPI: false, EnableCantabularJourney: true},
+		SharedConfig:                      SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false, EnableNewUpload: false, EnableNewInteractives: false, EnablePermissionsAPI: false, EnableCantabularJourney: false},
 		GracefulShutdownTimeout:           10 * time.Second,
 		HealthCheckInterval:               30 * time.Second,
 		HealthCheckCriticalTimeout:        90 * time.Second,

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	DatasetControllerURL string `envconfig:"DATASET_CONTROLLER_URL"`
 	TableRendererURL     string `envconfig:"TABLE_RENDERER_URL"`
 	// should be removed when we use api-router
-	CantabularMetadataExtractorAPIURL string        `envconfig:"CANTABULAR_METADATA_EXTRACTOR_API_URL"`
+	// CantabularMetadataExtractorAPIURL string        `envconfig:"CANTABULAR_METADATA_EXTRACTOR_API_URL"`
 	GracefulShutdownTimeout           time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval               time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout        time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -47,8 +47,8 @@ func Get() (*Config, error) {
 		FrontendRouterURL:                 "http://localhost:20000",
 		DatasetControllerURL:              "http://localhost:24000",
 		TableRendererURL:                  "http://localhost:23300",
-		CantabularMetadataExtractorAPIURL: "http://localhost:28300",
-		SharedConfig:                      SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false, EnableNewUpload: false, EnableNewInteractives: false, EnablePermissionsAPI: false, EnableCantabularJourney: false},
+		// CantabularMetadataExtractorAPIURL: "http://localhost:28300",
+		SharedConfig:                      SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false, EnableNewUpload: false, EnableNewInteractives: false, EnablePermissionsAPI: false, EnableCantabularJourney: true},
 		GracefulShutdownTimeout:           10 * time.Second,
 		HealthCheckInterval:               30 * time.Second,
 		HealthCheckCriticalTimeout:        90 * time.Second,

--- a/config/config.go
+++ b/config/config.go
@@ -14,8 +14,6 @@ type Config struct {
 	FrontendRouterURL    string `envconfig:"ROUTER_URL"`
 	DatasetControllerURL string `envconfig:"DATASET_CONTROLLER_URL"`
 	TableRendererURL     string `envconfig:"TABLE_RENDERER_URL"`
-	// should be removed when we use api-router
-	// CantabularMetadataExtractorAPIURL string        `envconfig:"CANTABULAR_METADATA_EXTRACTOR_API_URL"`
 	GracefulShutdownTimeout           time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval               time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout        time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
@@ -47,7 +45,6 @@ func Get() (*Config, error) {
 		FrontendRouterURL:                 "http://localhost:20000",
 		DatasetControllerURL:              "http://localhost:24000",
 		TableRendererURL:                  "http://localhost:23300",
-		// CantabularMetadataExtractorAPIURL: "http://localhost:28300",
 		SharedConfig:                      SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false, EnableNewUpload: false, EnableNewInteractives: false, EnablePermissionsAPI: false, EnableCantabularJourney: false},
 		GracefulShutdownTimeout:           10 * time.Second,
 		HealthCheckInterval:               30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			FrontendRouterURL:          "http://localhost:20000",
 			DatasetControllerURL:       "http://localhost:24000",
 			TableRendererURL:           "http://localhost:23300",
-			CantabularMetadataExtractorAPIURL: "http://localhost:28300",
+			// CantabularMetadataExtractorAPIURL: "http://localhost:28300",
 			SharedConfig:               SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false, EnableNewUpload: false, EnableCantabularJourney: false},
 			GracefulShutdownTimeout:    10 * time.Second,
 			HealthCheckInterval:        30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,7 +21,6 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			FrontendRouterURL:          "http://localhost:20000",
 			DatasetControllerURL:       "http://localhost:24000",
 			TableRendererURL:           "http://localhost:23300",
-			// CantabularMetadataExtractorAPIURL: "http://localhost:28300",
 			SharedConfig:               SharedConfig{EnableDatasetImport: true, EnableNewSignIn: false, EnableNewUpload: false, EnableCantabularJourney: false},
 			GracefulShutdownTimeout:    10 * time.Second,
 			HealthCheckInterval:        30 * time.Second,

--- a/service/service.go
+++ b/service/service.go
@@ -105,17 +105,10 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		return nil, err
 	}
 
-	// cantabularMetadataExtractorURL, err := url.Parse(cfg.CantabularMetadataExtractorAPIURL)
-	// if err != nil {
-	// 	log.Event(ctx, "error parsing cantabular metadata extractor URL", log.FATAL, log.Error(err))
-	// 	return nil, err
-	// }
-
 	frontendRouterProxy := reverseproxy.Create(frontendRouterURL, directors.Director(""), nil)
 	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), modifiers.IdentityResponseModifier)
 	tableProxy := reverseproxy.Create(tableURL, directors.Director("/table"), nil)
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, directors.Director("/dataset-controller"), nil)
-	// cantabularMetadataExtractorAPIProxy := reverseproxy.Create(cantabularMetadataExtractorURL, directors.Director("/metadata"), nil)
 	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion,""), nil)
 
 	// The following proxies and their associated routes are deprecated and should be removed once the client side code has been updated to match
@@ -151,7 +144,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		router.Handle("/instances/{uri:.*}", datasetAPIProxy)
 		router.Handle("/dataset-controller/{uri:.*}", datasetControllerProxy)
 		if cfg.SharedConfig.EnableCantabularJourney {
-			//router.Handle("/metadata/{uri:.*}", cantabularMetadataExtractorAPIProxy)
 			router.Handle("/cantabular-metadata/{uri:.*}", cantabularMetadataExtractorAPIProxy)
 		}
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -105,17 +105,18 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		return nil, err
 	}
 
-	cantabularMetadataExtractorURL, err := url.Parse(cfg.CantabularMetadataExtractorAPIURL)
-	if err != nil {
-		log.Event(ctx, "error parsing cantabular metadata extractor URL", log.FATAL, log.Error(err))
-		return nil, err
-	}
+	// cantabularMetadataExtractorURL, err := url.Parse(cfg.CantabularMetadataExtractorAPIURL)
+	// if err != nil {
+	// 	log.Event(ctx, "error parsing cantabular metadata extractor URL", log.FATAL, log.Error(err))
+	// 	return nil, err
+	// }
 
 	frontendRouterProxy := reverseproxy.Create(frontendRouterURL, directors.Director(""), nil)
 	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), modifiers.IdentityResponseModifier)
 	tableProxy := reverseproxy.Create(tableURL, directors.Director("/table"), nil)
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, directors.Director("/dataset-controller"), nil)
-	cantabularMetadataExtractorAPIProxi := reverseproxy.Create(cantabularMetadataExtractorURL, directors.Director(""), nil)
+	// cantabularMetadataExtractorAPIProxy := reverseproxy.Create(cantabularMetadataExtractorURL, directors.Director("/metadata"), nil)
+	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion,"cantabular-metadata"), nil)
 
 	// The following proxies and their associated routes are deprecated and should be removed once the client side code has been updated to match
 	zebedeeProxy := reverseproxy.Create(apiRouterURL, directors.Director("/zebedee"), nil)
@@ -150,7 +151,8 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		router.Handle("/instances/{uri:.*}", datasetAPIProxy)
 		router.Handle("/dataset-controller/{uri:.*}", datasetControllerProxy)
 		if cfg.SharedConfig.EnableCantabularJourney {
-			router.Handle("/cantabular-metadata/{uri:.*}", cantabularMetadataExtractorAPIProxi)
+			//router.Handle("/metadata/{uri:.*}", cantabularMetadataExtractorAPIProxy)
+			router.Handle("/cantabular-metadata/{uri:.*}", cantabularMetadataExtractorAPIProxy)
 		}
 	}
 	if cfg.SharedConfig.EnableNewSignIn {

--- a/service/service.go
+++ b/service/service.go
@@ -116,7 +116,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	tableProxy := reverseproxy.Create(tableURL, directors.Director("/table"), nil)
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, directors.Director("/dataset-controller"), nil)
 	// cantabularMetadataExtractorAPIProxy := reverseproxy.Create(cantabularMetadataExtractorURL, directors.Director("/metadata"), nil)
-	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion,"cantabular-metadata"), nil)
+	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion,""), nil)
 
 	// The following proxies and their associated routes are deprecated and should be removed once the client side code has been updated to match
 	zebedeeProxy := reverseproxy.Create(apiRouterURL, directors.Director("/zebedee"), nil)


### PR DESCRIPTION
### What

Update `Florence` to call the `cantabular metadata extractor api` via the `dp-api-router`.

### How to review

Read the code, run the tests and go through the Cantabular dataset journey. When running florence don't forget to set the  feature flag to true with `export ENABLE_CANTABULAR_JOURNEY=true && make debug`. To run the `dp-api-router` with the latest changes check out on `feature/add-dp-cantabular-metadata-extractor-api-routing` branch and run `export ENABLE_CANTABULAR_METADATA_EXTRACTOR_API=true && make debug`

### Who can review

Anyone
