### PR TITLE
adds feature flag to back button and collection details routing

### DIFF
--- a/src/app/views/collections/details/CollectionDetailsController.jsx
+++ b/src/app/views/collections/details/CollectionDetailsController.jsx
@@ -61,6 +61,7 @@ const propTypes = {
     }),
     activePageURI: PropTypes.string,
     routes: PropTypes.arrayOf(PropTypes.object).isRequired,
+    enableCantabularJourney: PropTypes.bool,
 };
 
 export class CollectionDetailsController extends Component {
@@ -353,7 +354,7 @@ export class CollectionDetailsController extends Component {
         }
         if (page.type === "dataset_version") {
             const path = `/collections/${this.props.activeCollection.id}/datasets/${page.datasetID}/editions/${page.edition}/versions/${page.version}`;
-            const newURL = url.resolve(this.state.isCantabularDataset ? `${path}/cantabular` : path);
+            const newURL = url.resolve(this.props.enableCantabularJourney && this.state.isCantabularDataset ? `${path}/cantabular` : path);
             const version = this.props.activeCollection[state].find(collectionPage => {
                 if (collectionPage.type !== "dataset_version") {
                     return false;
@@ -684,6 +685,7 @@ export function mapStateToProps(state) {
         activePageURI: state.routing.locationBeforeTransitions.hash.replace("#", ""),
         enableDatasetImport: state.state.config.enableDatasetImport,
         isUpdating: getIsUpdatingCollection(state.state),
+        enableCantabularJourney: state.state.config.enableCantabularJourney,
     };
 }
 

--- a/src/app/views/collections/details/CollectionDetailsController.test.js
+++ b/src/app/views/collections/details/CollectionDetailsController.test.js
@@ -468,9 +468,16 @@ describe("Clicking 'edit' for a page", () => {
         expect(pageURL).toBe("/florence/workspace?collection=my-collection-12345&uri=/economy/grossdomesticproductgdp/articles/ansarticle");
     });
     it("routes to the cantabular edit metadata form if the dataset type is a cantabular_table", async () => {
+        const cantabularProps = {
+            ...defaultProps,
+            ...props,
+            enableCantabularJourney: true,
+        };
+        const cantabularEditClickComponent = shallow(<CollectionDetailsController {...cantabularProps} />);
+
         const mockedDatasetType = { next: { type: "cantabular_table" } };
         datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
-        const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
+        const versionURL = await cantabularEditClickComponent.instance().handleCollectionPageEditClick(
             {
                 type: "dataset_version",
                 datasetID: "cpi",
@@ -482,13 +489,19 @@ describe("Clicking 'edit' for a page", () => {
             },
             "complete"
         );
-        expect(editClickComponent.state("isCantabularDataset")).toBe(true);
+        expect(cantabularEditClickComponent.state("isCantabularDataset")).toBe(true);
         expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
     });
     it("routes to the cantabular edit metadata form if the dataset type is a cantabular_flexible_table", async () => {
+        const cantabularProps = {
+            ...defaultProps,
+            ...props,
+            enableCantabularJourney: true,
+        };
+        const cantabularEditClickComponent = shallow(<CollectionDetailsController {...cantabularProps} />);
         const mockedDatasetType = { next: { type: "cantabular_flexible_table" } };
         datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
-        const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
+        const versionURL = await cantabularEditClickComponent.instance().handleCollectionPageEditClick(
             {
                 type: "dataset_version",
                 datasetID: "cpi",
@@ -500,7 +513,7 @@ describe("Clicking 'edit' for a page", () => {
             },
             "complete"
         );
-        expect(editClickComponent.state("isCantabularDataset")).toBe(true);
+        expect(cantabularEditClickComponent.state("isCantabularDataset")).toBe(true);
         expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
     });
 });

--- a/src/app/views/workflow-preview/WorkflowPreview.jsx
+++ b/src/app/views/workflow-preview/WorkflowPreview.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import { push } from "react-router-redux";
+import { connect } from "react-redux";
 import { Link } from "react-router";
 import PropTypes from "prop-types";
 
@@ -17,6 +18,7 @@ const propTypes = {
         collectionID: PropTypes.string.isRequired,
     }),
     dispatch: PropTypes.func.isRequired,
+    enableCantabularJourney: PropTypes.bool,
 };
 
 export class WorkflowPreview extends Component {
@@ -27,7 +29,7 @@ export class WorkflowPreview extends Component {
 
     handleBackButton = async () => {
         await this.getDatasetType(this.props.params.datasetID);
-        const previousUrl = `${url.resolve("../")}${this.state.cantabularDataset ? "/cantabular" : ""}`;
+        const previousUrl = `${url.resolve("../")}${this.props.enableCantabularJourney && this.state.cantabularDataset ? "/cantabular" : ""}`;
         this.props.dispatch(push(previousUrl));
     };
 
@@ -100,4 +102,10 @@ export class WorkflowPreview extends Component {
 
 WorkflowPreview.propTypes = propTypes;
 
-export default WorkflowPreview;
+export function mapStateToProps(state) {
+    return {
+        enableCantabularJourney: state.state.config.enableCantabularJourney,
+    };
+}
+
+export default connect(mapStateToProps)(WorkflowPreview);


### PR DESCRIPTION
### What

Fixes two bugs which meant users were being redirected to the Edit Cantabular metadata screen despite enableCantabularMetadata feature flag being set to false.

### How to review

Ensure feature flag is set to false (export ENABLE_CANTABULAR_JOURNEY=false) & run Cantabular dataset journey.  Also run test suite.

### Who can review

Anyone
