### PR TITLE
Fixes login for new user password change

### DIFF
--- a/src/app/config/user/userHooks.js
+++ b/src/app/config/user/userHooks.js
@@ -5,6 +5,8 @@ import sessionManagement from "../../utilities/sessionManagement";
 import { getAuthState } from "../../utilities/auth";
 import fp from "lodash/fp";
 
+const nonAuthRoutes = ["/florence/login", "/florence/forgotten-password"];
+
 export const useGetPermissions = (authState, setShouldUpdateAccessToken) => {
     const [userState, setUserState] = useState();
     useEffect(() => {
@@ -28,7 +30,7 @@ export const useGetPermissions = (authState, setShouldUpdateAccessToken) => {
 
 export const useUpdateTimers = (props, sessionTimerIsActive, dispatch) => {
     useEffect(() => {
-        if (props.location.pathname !== "/florence/login" && !sessionTimerIsActive) {
+        if (!nonAuthRoutes.includes(props.location.pathname) && !sessionTimerIsActive) {
             const enableNewSignIn = fp.get("config.enableNewSignIn")(props);
             const authState = getAuthState(); // Get the lastest authState
             const session_expiry_time = fp.get("session_expiry_time")(authState);

--- a/src/app/views/login/SignIn.jsx
+++ b/src/app/views/login/SignIn.jsx
@@ -186,6 +186,10 @@ export class LoginController extends Component {
             });
     };
 
+    redirectToLogin = () => {
+        location.reload();
+    };
+
     clearErrors = () => {
         this.setState({
             validationErrors: {},
@@ -270,7 +274,11 @@ export class LoginController extends Component {
     };
 
     passwordChangeSuccess = response => {
-        sessionManagement.setSessionExpiryTime(response.body.expirationTime, response.body.refreshTokenExpirationTime);
+        if (response) {
+            console.debug("[FLORENCE] passwordChangeSuccess: ", resp);
+            // TODO convert to UTC
+            sessionManagement.setSessionExpiryTime(response.body.expirationTime, response.body.refreshTokenExpirationTime);
+        }
         this.setState({
             status: status.SUBMITTED_PASSWORD_CHANGE,
         });
@@ -296,6 +304,7 @@ export class LoginController extends Component {
                     this.passwordChangeSuccess(response);
                 })
                 .catch(error => {
+                    console.error(error);
                     this.passwordChangeFail(error);
                 });
         });
@@ -307,7 +316,7 @@ export class LoginController extends Component {
                 heading: "Change your password",
                 buttonText: "Change password",
                 requestPasswordChange: this.requestPasswordChange,
-                changeConformation: <ChangePasswordConfirmed handleClick={this.setPermissions} />,
+                changeConformation: <ChangePasswordConfirmed handleClick={this.redirectToLogin} />,
                 status: this.state.status,
             };
 

--- a/src/app/views/new-password/changePasswordConfirmed.jsx
+++ b/src/app/views/new-password/changePasswordConfirmed.jsx
@@ -17,8 +17,9 @@ const ChangePasswordConfirmed = props => {
         <div className="grid grid--justify-center">
             <div className="grid__col-3">
                 <h1>Your password has been changed</h1>
+                <p>Please Sign back in to start using Florence</p>
                 <button type="button" onClick={props.handleClick} className="btn btn--primary margin-bottom--2 margin-right--5">
-                    Start using Florence
+                    Sign back in
                 </button>
                 <Panel type={"information"} body={changePasswordPanelBody} />
             </div>

--- a/src/app/views/new-password/forgottenPasswordController.jsx
+++ b/src/app/views/new-password/forgottenPasswordController.jsx
@@ -7,7 +7,7 @@ import { errCodes } from "../../utilities/errorCodes";
 import notifications from "../../utilities/notifications";
 
 const propTypes = {
-    dispatch: PropTypes.func.isRequired,
+    // dispatch: PropTypes.func.isRequired, // not used, can we remove?
 };
 
 export class ForgottenPasswordController extends Component {


### PR DESCRIPTION
### What

When a new user logins in the first time, they are asked to change their temp password, then a button is displayed to inform the user that they can start using Florence. When they click this button they are signed in. We dont want them to be signed in like this, rather redirect them back to the login screen.

Also added a fix that blows up a page.
### How to review
read through the changes, and if necessary ask for a demo
### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself & Geoff