### PR TITLE
#1003: Viewer collections page reload causes sign out / session expired

### DIFF
--- a/src/app/utilities/auth.js
+++ b/src/app/utilities/auth.js
@@ -87,6 +87,13 @@ export function getIsAdminFromAuthState() {
     return fp.get("admin")(getAuthState());
 }
 
+/** @returns True if user type = "VIEWER" */
+export function isViewerFromAuthState() {
+    const isAdmin = fp.get("admin")(getAuthState());
+    const isPublisher = fp.get("publisher")(getAuthState());
+    return !isAdmin && !isPublisher;
+}
+
 /** User Schema - represents the `user` type stored in redux. */
 class _UserSchema {
     isAuthenticated = false;

--- a/src/app/views/collections/Collections.jsx
+++ b/src/app/views/collections/Collections.jsx
@@ -6,10 +6,14 @@ import CreateNewCollection from "./create/";
 import DoubleSelectableBox from "../../components/selectable-box/double-column/DoubleSelectableBox";
 import CollectionDetailsController from "./details/CollectionDetailsController";
 import Search from "../../components/search";
+import ConfirmUserDeleteController from "../users/confirm-delete/ConfirmUserDeleteController";
+import { getAuthState, isViewerFromAuthState } from "../../utilities/auth";
+import fp from "lodash/fp";
 
 const Collections = props => {
     const { user, collections, isLoading, workingOn, updateWorkingOn, search } = props;
-    const isViewer = user && user.userType === "VIEWER";
+    // Get viewer from local storage as we don't want to make a call to /groups if userType is undefined
+    const isViewer = isViewerFromAuthState();
 
     useEffect(() => {
         props.loadCollections(`${props.rootPath}/collections`);

--- a/src/app/views/collections/Collections.test.js
+++ b/src/app/views/collections/Collections.test.js
@@ -2,9 +2,38 @@ import React from "react";
 import { render, screen, createMockUser, within } from "../../utilities/tests/test-utils";
 import Collections from "./Collections";
 import userEvent from "@testing-library/user-event";
+import { setAuthState } from "../../utilities/auth";
 
 const admin = createMockUser("admin@test.com", true, true, "ADMIN");
 const viewer = createMockUser("viewer@test.com", true, true, "VIEWER");
+
+// Local Storage
+var localStorageMock = (function () {
+    var store = {};
+    return {
+        getItem: function (key) {
+            return store[key];
+        },
+        setItem: function (key, value) {
+            store[key] = value.toString();
+        },
+        clear: function () {
+            store = {};
+        },
+        removeItem: function (key) {
+            delete store[key];
+        },
+    };
+})();
+
+beforeEach(() => {
+    Object.defineProperty(window, "localStorage", { value: localStorageMock, writable: true });
+    window.localStorage.setItem("ons_auth_state", {});
+});
+
+afterEach(() => {
+    window.localStorage.clear();
+});
 
 describe("Collections", () => {
     const defaultProps = {
@@ -22,6 +51,10 @@ describe("Collections", () => {
 
     describe("when there are no collections", () => {
         it("has two headings", () => {
+            setAuthState({
+                admin: true,
+                editor: true,
+            });
             render(<Collections {...defaultProps} />);
 
             expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(2);
@@ -30,6 +63,10 @@ describe("Collections", () => {
         });
 
         it("has Create Collection form", () => {
+            setAuthState({
+                admin: true,
+                editor: true,
+            });
             render(<Collections {...defaultProps} />);
 
             expect(screen.getByLabelText("Collection name")).toHaveValue("");
@@ -113,6 +150,10 @@ describe("Collections", () => {
 
         describe("when admin user", () => {
             it("shows list of not approved collections", () => {
+                setAuthState({
+                    admin: true,
+                    editor: true,
+                });
                 render(<Collections {...propsWithCollections} />);
 
                 expect(screen.queryByText("No items to display")).not.toBeInTheDocument();
@@ -127,6 +168,10 @@ describe("Collections", () => {
             });
 
             it("dispatches push action on collection click", () => {
+                setAuthState({
+                    admin: true,
+                    editor: true,
+                });
                 render(<Collections {...propsWithCollections} />);
                 const box = screen.getByTestId("selectable-box");
 
@@ -162,6 +207,10 @@ describe("Collections", () => {
 
             it("dispatches push and updateWorkingOn actions on collection click", () => {
                 render(<Collections {...propsWithViewer} />);
+                setAuthState({
+                    admin: true,
+                    editor: true,
+                });
                 const box = screen.getByTestId("selectable-box");
 
                 expect(within(box).getAllByRole("listitem")).toHaveLength(2);


### PR DESCRIPTION
### What


When a user is logged in as a VIEWER & refreshes the page on the collections screen , their is a request to fetch the groups but viewers do not have permission to view groups
### How to review

Describe the steps required to test the changes.
ask for a demo
### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself
