### PR TITLE
#993: publisher should not see Users tab

### DIFF
--- a/src/app/components/navbar/NavBar.jsx
+++ b/src/app/components/navbar/NavBar.jsx
@@ -91,12 +91,14 @@ const NavBar = props => {
                                 Reports
                             </a>
                         </li>
-                        <li className="global-nav__item">
-                            <Link to={`${rootPath}/users`} activeClassName="selected" className="global-nav__link">
-                                Users and access
-                            </Link>
-                        </li>
-                        {!props.isNewSignIn && (
+                        {auth.isAdmin(props.user) && (
+                            <li className="global-nav__item">
+                                <Link to={`${rootPath}/users`} activeClassName="selected" className="global-nav__link">
+                                    Users and access
+                                </Link>
+                            </li>
+                        )}
+                        {!props.isNewSignIn && auth.isAdmin(props.user) && (
                             <li className="global-nav__item">
                                 <Link to={`${rootPath}/teams`} activeClassName="selected" className="global-nav__link">
                                     Teams


### PR DESCRIPTION
### What

 publisher should not see Users tab

### How to review

- login as publisher
- see Users&access tab (should not see this)
- click Reports (can now see Team - should not see this)
- should not see those tabs
### Who can review
anyone
Describe who worked on the changes, so that other people can review.
myself