### PR TITLE
925: Login fails after going from new login to old login

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -175,3 +175,16 @@ func refactoredIndexFile(cfg *config.Config) http.HandlerFunc {
 		w.Write(b)
 	}
 }
+
+func DeleteHttpCookie() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		c := &http.Cookie{
+			Name:    "access_token",
+			Value:   "",
+			Path:    "/",
+			Expires: time.Unix(0, 0),
+		}
+		http.SetCookie(w, c)
+		w.WriteHeader(http.StatusAccepted)
+	}
+}

--- a/service/service.go
+++ b/service/service.go
@@ -109,7 +109,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), modifiers.IdentityResponseModifier)
 	tableProxy := reverseproxy.Create(tableURL, directors.Director("/table"), nil)
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, directors.Director("/dataset-controller"), nil)
-	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion,""), nil)
+	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
 
 	// The following proxies and their associated routes are deprecated and should be removed once the client side code has been updated to match
 	zebedeeProxy := reverseproxy.Create(apiRouterURL, directors.Director("/zebedee"), nil)
@@ -162,7 +162,10 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	router.Handle("/table/{uri:.*}", tableProxy)
 	router.Handle("/topics", topicsProxy)
 	router.Handle("/topics/{uri:.*}", topicsProxy)
-
+	if !cfg.SharedConfig.EnableNewSignIn {
+		// Roots for !EnableNewSignIn Florence React app
+		router.HandleFunc("/cookies", DeleteHttpCookie()).Methods("DELETE")
+	}
 	// Florence endpoints
 	router.HandleFunc("/florence/dist/{uri:.*}", staticFiles)
 	router.HandleFunc("/florence/", redirectToFlorence)
@@ -176,7 +179,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	// API and Frontend Routers
 	router.Handle("/api/{uri:.*}", apiRouterProxy)
 	router.Handle("/{uri:.*}", frontendRouterProxy)
-
 	return router, nil
 }
 


### PR DESCRIPTION
### What

Toggling between the new login and the old login fails due to to existence of the tokens.

### How to review

1. Enable the JWT sessions (zebedee) and new sign in (florence) feature flags
2. Login
3. Disable the two above feature flags
4. Attempt to log in again


### Who can review

Anyone

Describe who worked on the changes, so that other people can review.
myself
