### PR TITLE
Feature/1199 dimensions check

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -163,7 +163,7 @@ export class CantabularMetadataController extends Component {
 
     checkDimensions = (datasetMetadata, cantabularMetadata) => {
         const datasetDimensions = datasetMetadata.version.dimensions.map(dimension => dimension.id);
-        const cantabularMetadataDimensions = cantabularMetadata.version.dimensions.map(dimension => dimension.id);
+        const cantabularMetadataDimensions = cantabularMetadata.version.dimensions.map(dimension => dimension.name);
         datasetDimensions.forEach(dimension => {
             if (!cantabularMetadataDimensions.includes(dimension)) {
                 notifications.add({

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -140,9 +140,7 @@ export class CantabularMetadataController extends Component {
             .getEditMetadata(datasetID, editionID, versionID)
             .then(metadata => {
                 this.setState({ isGettingMetadata: false });
-                this.getCantabularMetadata(datasetID, metadata).then(cantabularMetadata => {
-                    this.checkDimensions(metadata, this.state.cantabularMetadata);
-                });
+                this.getCantabularMetadata(datasetID, metadata).then(() => this.checkDimensions(metadata, this.state.cantabularMetadata));
             })
             .catch(error => {
                 this.setState({
@@ -168,20 +166,20 @@ export class CantabularMetadataController extends Component {
             if (!cantabularMetadataDimensions.includes(dimension)) {
                 notifications.add({
                     type: "neutral",
-                    message: `Error: dimension ${dimension} in Cantabular metadata but not present in recipe`,
+                    message: `Error: dimension ${dimension} in recipe but not present in Cantabular metadata`,
                     isDismissable: true,
                 });
-                console.error(`Error: dimension ${dimension} in Cantabular metadata but not present in recipe`);
+                console.error(`Error: dimension ${dimension} in recipe  but not present in Cantabular metadata`);
             }
         });
         cantabularMetadataDimensions.forEach(dimension => {
             if (!datasetDimensions.includes(dimension)) {
                 notifications.add({
                     type: "neutral",
-                    message: `Error: dimension ${dimension} in recipe but not present in Cantabular metadata`,
+                    message: `Error: dimension ${dimension} in Cantabular metadata but not present in recipe`,
                     isDismissable: true,
                 });
-                console.error(`Error: dimension ${dimension} in recipe but not present in Cantabular metadata`);
+                console.error(`Error: dimension ${dimension} in Cantabular metadata but not present in recipe`);
             }
         });
     };

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -163,7 +163,7 @@ export class CantabularMetadataController extends Component {
 
     checkDimensions = (datasetDimensions, cantabularDimensions) => {
         const datasetDimensionsArr = datasetDimensions.map(dimension => dimension.id);
-        const cantabularMetadataDimensionsArr = cantabularDimensions.map(dimension => dimension.name);
+        const cantabularMetadataDimensionsArr = cantabularDimensions.map(dimension => dimension.id);
         let datasetDimensionsErrs = [];
         let cantabularDimensionsErrs = [];
         datasetDimensionsArr.forEach(dimension => {
@@ -350,6 +350,7 @@ export class CantabularMetadataController extends Component {
             version: {
                 dimensions: cantResponse.dataset_query_result.dataset.vars.map(dimension => {
                     return {
+                        id: dimension.name,
                         name: dimension.name,
                         description: dimension.description,
                         label: dimension.label,

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -140,7 +140,9 @@ export class CantabularMetadataController extends Component {
             .getEditMetadata(datasetID, editionID, versionID)
             .then(metadata => {
                 this.setState({ isGettingMetadata: false });
-                this.getCantabularMetadata(datasetID, metadata);
+                this.getCantabularMetadata(datasetID, metadata).then(cantabularMetadata => {
+                    this.checkDimensions(metadata, this.state.cantabularMetadata);
+                });
             })
             .catch(error => {
                 this.setState({
@@ -157,6 +159,31 @@ export class CantabularMetadataController extends Component {
                 });
                 console.error("get metadata: error GETting dataset metadata from controller", error);
             });
+    };
+
+    checkDimensions = (datasetMetadata, cantabularMetadata) => {
+        const datasetDimensions = datasetMetadata.version.dimensions.map(dimension => dimension.id);
+        const cantabularMetadataDimensions = cantabularMetadata.version.dimensions.map(dimension => dimension.id);
+        datasetDimensions.forEach(dimension => {
+            if (!cantabularMetadataDimensions.includes(dimension)) {
+                notifications.add({
+                    type: "neutral",
+                    message: `Error: dimension ${dimension} in Cantabular metadata but not present in recipe`,
+                    isDismissable: true,
+                });
+                console.error(`Error: dimension ${dimension} in Cantabular metadata but not present in recipe`);
+            }
+        });
+        cantabularMetadataDimensions.forEach(dimension => {
+            if (!datasetDimensions.includes(dimension)) {
+                notifications.add({
+                    type: "neutral",
+                    message: `Error: dimension ${dimension} in recipe but not present in Cantabular metadata`,
+                    isDismissable: true,
+                });
+                console.error(`Error: dimension ${dimension} in recipe but not present in Cantabular metadata`);
+            }
+        });
     };
 
     getCantabularMetadata = (datasetID, nonCantDatasetMetadata) => {

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -147,11 +147,13 @@ const mockedCantabularDatasetMetadata = {
     version: {
         dimensions: [
             {
+                id: "Dimension1 Name",
                 name: "Dimension1 Name",
                 description: "Dimension1 description",
                 label: "Dimension1 Label",
             },
             {
+                id: "Dimension2 Name",
                 name: "Dimension2 Name",
                 description: "Dimension2 description",
                 label: "Dimension2 Label",
@@ -688,7 +690,7 @@ describe("Calling checkDimensions", () => {
 
     it("doesn't trigger notification if dimensions correspond 1-1", () => {
         const datasetDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
-        const cantabularDimensions = [{ name: "testDimension1" }, { name: "testDimension2" }];
+        const cantabularDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
         expect(mockedNotifications.length).toEqual(0);
         component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
         expect(mockedNotifications.length).toEqual(0);
@@ -696,7 +698,7 @@ describe("Calling checkDimensions", () => {
 
     it("triggers error notification if dataset dimension is not present in Cantabular dimensions", () => {
         const datasetDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
-        const cantabularDimensions = [{ name: "testDimension1" }];
+        const cantabularDimensions = [{ id: "testDimension1" }];
         expect(mockedNotifications.length).toEqual(0);
         component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
         expect(mockedNotifications.length).toEqual(1);
@@ -704,7 +706,7 @@ describe("Calling checkDimensions", () => {
 
     it("triggers error notification if Cantabular dimension is not present in dataset dimensions", () => {
         const datasetDimensions = [{ id: "testDimension1" }];
-        const cantabularDimensions = [{ name: "testDimension1" }, { name: "testDimension2" }];
+        const cantabularDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
         expect(mockedNotifications.length).toEqual(0);
         component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
         expect(mockedNotifications.length).toEqual(1);

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -689,24 +689,36 @@ describe("Calling checkDimensions", () => {
     });
 
     it("doesn't trigger notification if dimensions correspond 1-1", () => {
-        const datasetDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
-        const cantabularDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
+        const datasetDimensions = [
+            { id: "testDimensionID1", name: "testDimensionName1", description: "" },
+            { id: "testDimensionID2", name: "testDimensionName2", description: "" },
+        ];
+        const cantabularDimensions = [
+            { id: "testDimensionID1", name: "testDimensionName1", description: "" },
+            { id: "testDimensionID2", name: "testDimensionName2", description: "" },
+        ];
         expect(mockedNotifications.length).toEqual(0);
         component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
         expect(mockedNotifications.length).toEqual(0);
     });
 
     it("triggers error notification if dataset dimension is not present in Cantabular dimensions", () => {
-        const datasetDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
-        const cantabularDimensions = [{ id: "testDimension1" }];
+        const datasetDimensions = [
+            { id: "testDimensionID1", name: "testDimensionName1", description: "" },
+            { id: "testDimensionID2", name: "testDimensionName2", description: "" },
+        ];
+        const cantabularDimensions = [{ id: "testDimensionID1", name: "testDimensionName1", description: "" }];
         expect(mockedNotifications.length).toEqual(0);
         component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
         expect(mockedNotifications.length).toEqual(1);
     });
 
     it("triggers error notification if Cantabular dimension is not present in dataset dimensions", () => {
-        const datasetDimensions = [{ id: "testDimension1" }];
-        const cantabularDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
+        const datasetDimensions = [{ id: "testDimensionID1", name: "testDimensionName1", description: "" }];
+        const cantabularDimensions = [
+            { id: "testDimensionID1", name: "testDimensionName1", description: "" },
+            { id: "testDimensionID2", name: "testDimensionName2", description: "" },
+        ];
         expect(mockedNotifications.length).toEqual(0);
         component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
         expect(mockedNotifications.length).toEqual(1);

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -680,3 +680,33 @@ describe("Calling saveAndRetrieveDatasetMetadata", () => {
         expect(component.instance().retrieveDatasetMetadata).toHaveBeenCalledTimes(0);
     });
 });
+
+describe("Calling checkDimensions", () => {
+    beforeEach(() => {
+        mockedNotifications = [];
+    });
+
+    it("doesn't trigger notification if dimensions correspond 1-1", () => {
+        const datasetDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
+        const cantabularDimensions = [{ name: "testDimension1" }, { name: "testDimension2" }];
+        expect(mockedNotifications.length).toEqual(0);
+        component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
+        expect(mockedNotifications.length).toEqual(0);
+    });
+
+    it("triggers error notification if dataset dimension is not present in Cantabular dimensions", () => {
+        const datasetDimensions = [{ id: "testDimension1" }, { id: "testDimension2" }];
+        const cantabularDimensions = [{ name: "testDimension1" }];
+        expect(mockedNotifications.length).toEqual(0);
+        component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
+        expect(mockedNotifications.length).toEqual(1);
+    });
+
+    it("triggers error notification if Cantabular dimension is not present in dataset dimensions", () => {
+        const datasetDimensions = [{ id: "testDimension1" }];
+        const cantabularDimensions = [{ name: "testDimension1" }, { name: "testDimension2" }];
+        expect(mockedNotifications.length).toEqual(0);
+        component.instance().checkDimensions(datasetDimensions, cantabularDimensions);
+        expect(mockedNotifications.length).toEqual(1);
+    });
+});


### PR DESCRIPTION
### What

Checks that the dimensions in the Cantabular metadata match the dimensions in the dataset recipe.  If they do not match a neutral notification is triggered but the user may continue the journey. At a later date this may become a warning notification that prevents the user continuing the journey. This notification appears on the 'Edit metadata (Cantabular)' screen before the user saves any Cantabular metadata to the dataset api.

### How to review

1.  Run test suite
2. Clone and run the required services for the journey - instructions [here](https://github.com/ONSdigital/dp-cantabular-metadata-extractor-api/tree/develop/devstack)
3. Download the `d_cantabf_v10-1-0_recipe_usual-res_v1-0_drl_ts-dm_usual-res_oa_20220810` dataset from ons-dp-sandbox-ingest-internal-data/Datasets/ in s3.
4. Extract 'dp_synth_config.dat' and add at the end of DAT_FILES in dp-cantabular-server/cantabular/scripts/run.sh
5. Run `make setup` in `dp-cantabular-server` and rebuild the docker container.
6. Run Florence with `ENABLE_CANTABULAR_JOURNEY=true ENABLE_CANTABULAR_METADATA_EXTRACTOR_API=true make debug` command.
7. Request from me or Valentina a recipe that should generate dimension errors on the 'Edit metadata (Cantabular)' screen
8. Request from me or Valentina a recipe that should not generate dimension errors on the 'Edit metadata (Cantabular' screen

Alternatively, ask me or Valentina to demo.

### Who can review

Anyone.
