### PR TITLE
Feature/strengthens dataset type check

### DIFF
--- a/src/app/views/collections/details/CollectionDetailsController.jsx
+++ b/src/app/views/collections/details/CollectionDetailsController.jsx
@@ -594,7 +594,12 @@ export class CollectionDetailsController extends Component {
             const datasetID = pageID.split("/")[0].trim();
             const response = await datasets.get(datasetID);
             const type = response.next.type;
-            this.setState({ isCantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+            try {
+                await datasets.getCantabularMetadata(datasetID, "en");
+                this.setState({ isCantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+            } catch {
+                console.log("Dataset ID not present in Cantabular metadata server");
+            }
         }
     };
 

--- a/src/app/views/collections/details/CollectionDetailsController.test.js
+++ b/src/app/views/collections/details/CollectionDetailsController.test.js
@@ -41,6 +41,9 @@ jest.mock("../../../utilities/api-clients/datasets", () => {
         get: jest.fn(() => {
             return Promise.resolve();
         }),
+        getCantabularMetadata: jest.fn(() => {
+            return Promise.resolve();
+        }),
     };
 });
 

--- a/src/app/views/datasets-new/versions/DatasetVersionsController.jsx
+++ b/src/app/views/datasets-new/versions/DatasetVersionsController.jsx
@@ -46,7 +46,12 @@ export class DatasetVersionsController extends Component {
     getDatasetType = async datasetID => {
         const response = await datasets.get(datasetID);
         const type = response.next.type;
-        this.setState({ cantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+        try {
+            await datasets.getCantabularMetadata(datasetID, "en");
+            this.setState({ cantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+        } catch {
+            console.log("Dataset ID not present in Cantabular metadata server");
+        }
     };
 
     getAllVersions = (datasetID, editions) => {

--- a/src/app/views/datasets-new/versions/DatasetVersionsController.test.js
+++ b/src/app/views/datasets-new/versions/DatasetVersionsController.test.js
@@ -28,6 +28,9 @@ jest.mock("../../../utilities/api-clients/datasets", () => {
         get: jest.fn(() => {
             return Promise.resolve();
         }),
+        getCantabularMetadata: jest.fn(() => {
+            return Promise.resolve();
+        }),
     };
 });
 

--- a/src/app/views/workflow-preview/WorkflowPreview.jsx
+++ b/src/app/views/workflow-preview/WorkflowPreview.jsx
@@ -34,9 +34,14 @@ export class WorkflowPreview extends Component {
     };
 
     getDatasetType = datasetID => {
-        return datasets.get(datasetID).then(response => {
+        return datasets.get(datasetID).then(async response => {
             const type = response.next.type;
-            this.setState({ cantabularDataset: type === "cantabular_table" || type === "cantabular_flexible_table" });
+            try {
+                await datasets.getCantabularMetadata(datasetID, "en");
+                this.setState({ cantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+            } catch {
+                console.log("Dataset ID not present in Cantabular metadata server");
+            }
         });
     };
 


### PR DESCRIPTION
### What

Strengthens dataset type check to ensure that the dataset ID being used is present in Cantabular metadata server. This will further restrict the datasets that can be redirected to the 'Edit metadata (Cantabular)' screen and therefore should further protect the CMD journey for Team B to use for development purposes.

### How to review

Read the code, run the tests, for manual test instructions contact me for assistance in setting up a local environment.

### Who can review

Anyone but me or Valentina.