### PR TITLE
Bug/topic fields save

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
@@ -376,7 +376,7 @@ const CantabularMetadata = ({
             </h2>
 
             <SelectTags
-                singleDefaultValue={metadata.primaryTopic}
+                singleDefaultValue={Object.keys(metadata.primaryTopic).length ? metadata.primaryTopic : null}
                 id="primaryTopic"
                 label="Primary Topic"
                 contents={primaryTopicsMenuArr}

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
@@ -53,7 +53,7 @@ const propTypes = {
         qmi: PropTypes.string,
         latestChanges: PropTypes.array,
         usageNotes: PropTypes.array,
-        primaryTopic: PropTypes.string,
+        canonicalTopic: PropTypes.string,
         secondaryTopics: PropTypes.array,
     }).isRequired,
     fieldsReturned: PropTypes.shape({
@@ -99,9 +99,9 @@ const propTypes = {
     disableForm: PropTypes.bool.isRequired,
     isSaving: PropTypes.bool,
     disableCancel: PropTypes.bool,
-    primaryTopicsMenuArr: PropTypes.array.isRequired,
+    canonicalTopicsMenuArr: PropTypes.array.isRequired,
     secondaryTopicsMenuArr: PropTypes.array.isRequired,
-    handlePrimaryTopicTagFieldChange: PropTypes.func.isRequired,
+    handlecanonicalTopicTagFieldChange: PropTypes.func.isRequired,
     handleSecondaryTopicTagsFieldChange: PropTypes.func.isRequired,
     topicsErr: PropTypes.string,
 };
@@ -130,9 +130,9 @@ const CantabularMetadata = ({
     allowPreview,
     disableCancel,
     fieldsReturned,
-    primaryTopicsMenuArr,
+    canonicalTopicsMenuArr,
     secondaryTopicsMenuArr,
-    handlePrimaryTopicTagFieldChange,
+    handlecanonicalTopicTagFieldChange,
     handleSecondaryTopicTagsFieldChange,
     topicsErr,
 }) => {
@@ -376,18 +376,18 @@ const CantabularMetadata = ({
             </h2>
 
             <SelectTags
-                singleDefaultValue={Object.keys(metadata.primaryTopic).length ? metadata.primaryTopic : null}
-                id="primaryTopic"
-                label="Primary Topic"
-                contents={primaryTopicsMenuArr}
-                handleChange={handlePrimaryTopicTagFieldChange}
+                singleDefaultValue={Object.keys(metadata.canonicalTopic).length ? metadata.canonicalTopic : null}
+                id="canonicalTopic"
+                label="Canonical topic"
+                contents={canonicalTopicsMenuArr}
+                handleChange={handlecanonicalTopicTagFieldChange}
                 multipleSelection={false}
                 error={topicsErr}
                 disabled={disableForm}
             />
             <SelectTags
                 id="secondaryTopics"
-                label="Secondary Topics"
+                label="Secondary topics"
                 contents={secondaryTopicsMenuArr}
                 handleChange={handleSecondaryTopicTagsFieldChange}
                 multiDefaultValue={metadata.secondaryTopics}

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
@@ -101,7 +101,7 @@ const propTypes = {
     disableCancel: PropTypes.bool,
     canonicalTopicsMenuArr: PropTypes.array.isRequired,
     secondaryTopicsMenuArr: PropTypes.array.isRequired,
-    handlecanonicalTopicTagFieldChange: PropTypes.func.isRequired,
+    handleCanonicalTopicTagFieldChange: PropTypes.func.isRequired,
     handleSecondaryTopicTagsFieldChange: PropTypes.func.isRequired,
     topicsErr: PropTypes.string,
 };
@@ -132,7 +132,7 @@ const CantabularMetadata = ({
     fieldsReturned,
     canonicalTopicsMenuArr,
     secondaryTopicsMenuArr,
-    handlecanonicalTopicTagFieldChange,
+    handleCanonicalTopicTagFieldChange,
     handleSecondaryTopicTagsFieldChange,
     topicsErr,
 }) => {
@@ -380,7 +380,7 @@ const CantabularMetadata = ({
                 id="canonicalTopic"
                 label="Canonical topic"
                 contents={canonicalTopicsMenuArr}
-                handleChange={handlecanonicalTopicTagFieldChange}
+                handleChange={handleCanonicalTopicTagFieldChange}
                 multipleSelection={false}
                 error={topicsErr}
                 disabled={disableForm}

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -329,12 +329,13 @@ export class CantabularMetadataController extends Component {
                     value: !collectionState ? cantabularMetadata.dataset.contacts[0]?.telephone : dataset.contacts[0]?.telephone,
                     error: "",
                 },
-                primaryTopic: dataset.canonical_topic
-                    ? {
-                          value: dataset.canonical_topic.id,
-                          label: dataset.canonical_topic.title,
-                      }
-                    : null,
+                primaryTopic:
+                    "canonical_topic" in dataset
+                        ? {
+                              value: dataset.canonical_topic.id,
+                              label: dataset.canonical_topic.title,
+                          }
+                        : {},
                 secondaryTopics: dataset.sub_topics ? dataset.sub_topics.map(({ id, title }) => ({ value: id, label: title })) : [],
             };
             return {
@@ -756,9 +757,9 @@ export class CantabularMetadataController extends Component {
                 ],
                 next_release: this.state.metadata.nextReleaseDate.value,
                 unit_of_measure: this.state.metadata.unitOfMeasure,
-                canonical_topic: this.state.metadata.primaryTopic
+                canonical_topic: Object.keys(this.state.metadata.primaryTopic).length
                     ? { id: this.state.metadata.primaryTopic.value, title: this.state.metadata.primaryTopic.label }
-                    : null,
+                    : {},
                 sub_topics: this.state.metadata.secondaryTopics.map(({ value, label }) => ({ id: value, title: label })),
             },
             version: {
@@ -926,7 +927,7 @@ export class CantabularMetadataController extends Component {
             this.setState({ metadata: newMetadataState });
             document.getElementById("contact-details-heading").scrollIntoView({ behavior: "smooth", block: "start" });
             return;
-        } else if (this.state.metadata.secondaryTopics.length > 0 && this.state.metadata.primaryTopic == null) {
+        } else if (this.state.metadata.secondaryTopics.length > 0 && Object.keys(this.state.metadata.primaryTopic).length == 0) {
             this.setState({ topicsErr: "You cannot enter a secondary topic without a primary topic" });
             document.getElementById("topic-tags-heading").scrollIntoView({ behavior: "smooth", block: "start" });
             return;
@@ -1010,10 +1011,11 @@ export class CantabularMetadataController extends Component {
                     primaryTopicsMenuArr={this.state.primaryTopicsMenuArr}
                     secondaryTopicsMenuArr={this.state.secondaryTopicsMenuArr}
                     handlePrimaryTopicTagFieldChange={selectedOption => {
+                        console.log(selectedOption);
                         this.setState({
                             metadata: {
                                 ...this.state.metadata,
-                                primaryTopic: selectedOption,
+                                primaryTopic: selectedOption || {},
                             },
                             topicsErr: "",
                         });

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -47,7 +47,7 @@ export class CantabularMetadataController extends Component {
             dimensionsUpdated: false,
             datasetMetadataHasChanges: false,
             versionMetadataHasChanges: false,
-            primaryTopicsMenuArr: [],
+            canonicalTopicsMenuArr: [],
             secondaryTopicsMenuArr: [],
             topicsErr: "",
             metadata: {
@@ -92,7 +92,7 @@ export class CantabularMetadataController extends Component {
                 usageNotes: [],
                 latestChanges: [],
                 qmi: "",
-                primaryTopic: {},
+                canonicalTopic: {},
                 secondaryTopics: [],
             },
             fieldsReturned: {
@@ -160,7 +160,7 @@ export class CantabularMetadataController extends Component {
             };
             const allTopics = [rootTopics, subTopics];
             this.setState({
-                primaryTopicsMenuArr: [...allTopics],
+                canonicalTopicsMenuArr: [...allTopics],
                 secondaryTopicsMenuArr: [...allTopics],
             });
         } catch (error) {
@@ -329,7 +329,7 @@ export class CantabularMetadataController extends Component {
                     value: !collectionState ? cantabularMetadata.dataset.contacts[0]?.telephone : dataset.contacts[0]?.telephone,
                     error: "",
                 },
-                primaryTopic:
+                canonicalTopic:
                     "canonical_topic" in dataset && Object.keys(dataset.canonical_topic).length
                         ? {
                               value: dataset.canonical_topic.id,
@@ -712,7 +712,7 @@ export class CantabularMetadataController extends Component {
             fieldName === "unitOfMeasure" ||
             fieldName === "qmi" ||
             fieldName === "nextReleaseDate" ||
-            fieldName === "primaryTopic" ||
+            fieldName === "canonicalTopic" ||
             fieldName === "secondaryTopics"
         ) {
             return true;
@@ -757,8 +757,8 @@ export class CantabularMetadataController extends Component {
                 ],
                 next_release: this.state.metadata.nextReleaseDate.value,
                 unit_of_measure: this.state.metadata.unitOfMeasure,
-                canonical_topic: Object.keys(this.state.metadata.primaryTopic).length
-                    ? { id: this.state.metadata.primaryTopic.value, title: this.state.metadata.primaryTopic.label }
+                canonical_topic: Object.keys(this.state.metadata.canonicalTopic).length
+                    ? { id: this.state.metadata.canonicalTopic.value, title: this.state.metadata.canonicalTopic.label }
                     : {},
                 sub_topics: this.state.metadata.secondaryTopics.map(({ value, label }) => ({ id: value, title: label })),
             },
@@ -927,8 +927,8 @@ export class CantabularMetadataController extends Component {
             this.setState({ metadata: newMetadataState });
             document.getElementById("contact-details-heading").scrollIntoView({ behavior: "smooth", block: "start" });
             return;
-        } else if (this.state.metadata.secondaryTopics.length > 0 && Object.keys(this.state.metadata.primaryTopic).length == 0) {
-            this.setState({ topicsErr: "You cannot enter a secondary topic without a primary topic" });
+        } else if (this.state.metadata.secondaryTopics.length > 0 && Object.keys(this.state.metadata.canonicalTopic).length == 0) {
+            this.setState({ topicsErr: "You cannot enter a secondary topic without a canonical topic" });
             document.getElementById("topic-tags-heading").scrollIntoView({ behavior: "smooth", block: "start" });
             return;
         }
@@ -1008,14 +1008,14 @@ export class CantabularMetadataController extends Component {
                     handleMarkAsReviewedClick={this.handleMarkAsReviewedClick}
                     fieldsReturned={this.state.fieldsReturned}
                     handleRedirectOnReject={this.handleCancelClick}
-                    primaryTopicsMenuArr={this.state.primaryTopicsMenuArr}
+                    canonicalTopicsMenuArr={this.state.canonicalTopicsMenuArr}
                     secondaryTopicsMenuArr={this.state.secondaryTopicsMenuArr}
-                    handlePrimaryTopicTagFieldChange={selectedOption => {
+                    handlecanonicalTopicTagFieldChange={selectedOption => {
                         console.log(selectedOption);
                         this.setState({
                             metadata: {
                                 ...this.state.metadata,
-                                primaryTopic: selectedOption || {},
+                                canonicalTopic: selectedOption || {},
                             },
                             topicsErr: "",
                         });

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -330,7 +330,7 @@ export class CantabularMetadataController extends Component {
                     error: "",
                 },
                 primaryTopic:
-                    "canonical_topic" in dataset
+                    "canonical_topic" in dataset && Object.keys(dataset.canonical_topic).length
                         ? {
                               value: dataset.canonical_topic.id,
                               label: dataset.canonical_topic.title,

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -1010,7 +1010,7 @@ export class CantabularMetadataController extends Component {
                     handleRedirectOnReject={this.handleCancelClick}
                     canonicalTopicsMenuArr={this.state.canonicalTopicsMenuArr}
                     secondaryTopicsMenuArr={this.state.secondaryTopicsMenuArr}
-                    handlecanonicalTopicTagFieldChange={selectedOption => {
+                    handleCanonicalTopicTagFieldChange={selectedOption => {
                         console.log(selectedOption);
                         this.setState({
                             metadata: {

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -324,7 +324,7 @@ const mockCantabularMetadataState = {
         dimensions: mockedCantabularDatasetMetadata.version.dimensions,
         usageNotes: mockedNewNonCantDatasetMetadata.version.usage_notes,
         latestChanges: mockedNewNonCantDatasetMetadata.version.latest_changes,
-        primaryTopic: {},
+        canonicalTopic: {},
         secondaryTopics: [],
     },
     datasetCollectionState: "",
@@ -346,7 +346,7 @@ const mockDatasetApiMetadataState = {
         unitOfMeasure: mockedSavedNonCantDatasetMetadata.dataset.unit_of_measure,
         nextReleaseDate: { value: mockedSavedNonCantDatasetMetadata.dataset.next_release, error: "" },
         qmi: mockedSavedNonCantDatasetMetadata.dataset.qmi?.href,
-        primaryTopic: { value: "testID1", label: "Test title 1" },
+        canonicalTopic: { value: "testID1", label: "Test title 1" },
         secondaryTopics: [
             { value: "testID1", label: "Test title 1" },
             { value: "testSubtopicID1", label: "Test subtopic title 1" },
@@ -620,7 +620,7 @@ describe("Calling checkMandatoryFields", () => {
         });
     });
     it("raises error if there is only a secondary topics selection and no primary topic selection ", async () => {
-        const mockCantabularMetadataStateNoPrimaryTopic = {
+        const mockCantabularMetadataStateNoCanonicalTopic = {
             ...mockCantabularMetadataState,
             metadata: {
                 ...mockCantabularMetadataState.metadata,
@@ -630,9 +630,9 @@ describe("Calling checkMandatoryFields", () => {
                 ],
             },
         };
-        component.setState(mockCantabularMetadataStateNoPrimaryTopic);
+        component.setState(mockCantabularMetadataStateNoCanonicalTopic);
         component.instance().checkMandatoryFields();
-        expect(component.state("topicsErr")).toEqual("You cannot enter a secondary topic without a primary topic");
+        expect(component.state("topicsErr")).toEqual("You cannot enter a secondary topic without a canonical topic");
     });
 });
 
@@ -903,7 +903,7 @@ describe("Calling getTopics", () => {
         topics.getSubTopics.mockImplementationOnce(() => Promise.resolve(mockSubtopicsResp));
         await component.instance().getTopics();
 
-        expect(component.state("primaryTopicsMenuArr")).toEqual(allMockTopics);
+        expect(component.state("canonicalTopicsMenuArr")).toEqual(allMockTopics);
         expect(component.state("secondaryTopicsMenuArr")).toEqual(allMockTopics);
     });
     it("logs error and notification when topics.getRootTopics errors", async () => {

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -324,7 +324,7 @@ const mockCantabularMetadataState = {
         dimensions: mockedCantabularDatasetMetadata.version.dimensions,
         usageNotes: mockedNewNonCantDatasetMetadata.version.usage_notes,
         latestChanges: mockedNewNonCantDatasetMetadata.version.latest_changes,
-        primaryTopic: null,
+        primaryTopic: {},
         secondaryTopics: [],
     },
     datasetCollectionState: "",


### PR DESCRIPTION
### What

Fixes bug that meant topics could not be saved as part of metadata on first save click.  Also renames "Primary topic" to "Canonical topic".

### How to review

Run the code, run through Cantabular metadata journey, add topics, save and refresh page to check they are still present. Run test suite.

### Who can review

Anyone.