### PR TITLE
Fixes bug on the Related Links section of the Edit Metadata (Cantabular) screen

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -1011,7 +1011,6 @@ export class CantabularMetadataController extends Component {
                     canonicalTopicsMenuArr={this.state.canonicalTopicsMenuArr}
                     secondaryTopicsMenuArr={this.state.secondaryTopicsMenuArr}
                     handleCanonicalTopicTagFieldChange={selectedOption => {
-                        console.log(selectedOption);
                         this.setState({
                             metadata: {
                                 ...this.state.metadata,

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -291,10 +291,10 @@ export class CantabularMetadataController extends Component {
                 licence: !collectionState ? cantabularMetadata.dataset.license : dataset.license,
                 relatedDatasets: !collectionState
                     ? this.mapRelatedContentToState(cantabularMetadata.dataset?.related_datasets, this.props.params.datasetID)
-                    : this.mapRelatedContentToState(dataset?.related_datasets, dataset.id),
+                    : this.mapRelatedContentToState(dataset?.related_datasets, dataset.id) || [],
                 relatedPublications: !collectionState
                     ? this.mapRelatedContentToState(cantabularMetadata.dataset?.publications, this.props.params.datasetID)
-                    : this.mapRelatedContentToState(dataset?.publications, dataset.id),
+                    : this.mapRelatedContentToState(dataset?.publications, dataset.id) || [],
                 relatedMethodologies: dataset.methodologies ? this.mapRelatedContentToState(dataset.methodologies, dataset.id) : [],
                 releaseFrequency: {
                     value: dataset.release_frequency || "",


### PR DESCRIPTION
### What

Once the cantabular dataset metadata is saved the `Add a dataset` and `Add a publications` links are not responding so the user can't add a new dataset or a new publication to the dataset ([trello ticket](https://trello.com/c/42KPQ9KW/1266-related-links-section-on-edit-metadata-cantabular-screen-cant-be-accessed)).

![Screenshot 2022-10-06 at 12 10 26](https://user-images.githubusercontent.com/70764326/194359521-3bdfe1f1-e1bc-4385-8500-21b9deb95d6c.png)


### How to review

Run the code, run through Cantabular metadata journey, save, refresh the page and then click on `Add a dataset` and `Add a publications` from the `Related links section` and check if the below window comes up . 

![Screenshot 2022-10-06 at 17 07 24](https://user-images.githubusercontent.com/70764326/194363752-fa4d06f5-1924-40ea-8e0f-97f24d0c37c0.png)

Also don't forget to run the test suite.

### Who can review

Anyone
