### PR TITLE
Adds related content field to the Edit Metadata (Cantabular) form

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
@@ -31,6 +31,7 @@ const propTypes = {
             error: PropTypes.string,
         }),
         relatedDatasets: PropTypes.array,
+        relatedContent: PropTypes.array,
         relatedPublications: PropTypes.array,
         relatedMethodologies: PropTypes.array,
         releaseFrequency: PropTypes.shape({
@@ -390,6 +391,16 @@ const CantabularMetadata = ({
                 handleEditClick={handleSimpleEditableListEdit}
                 handleDeleteClick={handleSimpleEditableListDelete}
                 disableActions={disableForm || fieldsReturned.relatedMethodologies}
+            />
+            <h3 className="margin-top--1">Related content</h3>
+            <SimpleEditableList
+                addText={"Add related content"}
+                fields={metadata.relatedContent}
+                editingStateFieldName="relatedContent"
+                handleAddClick={handleSimpleEditableListAdd}
+                handleEditClick={handleSimpleEditableListEdit}
+                handleDeleteClick={handleSimpleEditableListDelete}
+                disableActions={disableForm}
             />
 
             <h2 className="margin-top--1">What's changed</h2>

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -96,6 +96,7 @@ export class CantabularMetadataController extends Component {
                 canonicalTopic: {},
                 secondaryTopics: [],
                 census: false,
+                relatedContent: [],
             },
             fieldsReturned: {
                 title: false,
@@ -353,6 +354,7 @@ export class CantabularMetadataController extends Component {
                     ? dataset.subtopics.map(topicID => this.state.allTopicsArr.find(topic => topic.value == topicID))
                     : [],
                 census: dataset.survey ? true : false,
+                relatedContent: dataset.related_content ? this.mapRelatedContentToState(dataset.related_content, dataset.id) : [],
             };
             return {
                 metadata: { ...this.state.metadata, ...mappedMetadata },
@@ -685,6 +687,7 @@ export class CantabularMetadataController extends Component {
             case "notices": {
                 return this.mapNoticesToState(newState);
             }
+            case "relatedContent":
             case "relatedDatasets":
             case "relatedPublications":
             case "relatedMethodologies": {
@@ -731,7 +734,8 @@ export class CantabularMetadataController extends Component {
             fieldName === "nextReleaseDate" ||
             fieldName === "canonicalTopic" ||
             fieldName === "secondaryTopics" ||
-            fieldName === "census"
+            fieldName === "census" ||
+            fieldName === "relatedContent"
         ) {
             return true;
         }
@@ -778,6 +782,7 @@ export class CantabularMetadataController extends Component {
                 canonical_topic: Object.keys(this.state.metadata.canonicalTopic).length ? this.state.metadata.canonicalTopic.value : "",
                 subtopics: this.state.metadata.secondaryTopics.length > 0 ? this.state.metadata.secondaryTopics.map(({ value }) => value) : [],
                 survey: this.state.metadata.census ? "census" : "",
+                related_content: this.state.metadata.relatedContent,
             },
             version: {
                 id: this.state.metadata.versionID,

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -284,6 +284,8 @@ const mockedNewNonCantDatasetMetadata = {
         methodologies: [],
         next_release: "1",
         release_frequency: "1",
+        related_content: [],
+        survey: "census",
     },
     version: {
         alerts: [],
@@ -374,6 +376,8 @@ const mockCantabularMetadataState = {
         latestChanges: mockedNewNonCantDatasetMetadata.version.latest_changes,
         canonicalTopic: {},
         secondaryTopics: [],
+        relatedContent: mockedNewNonCantDatasetMetadata.dataset.related_content,
+        census: mockedNewNonCantDatasetMetadata.dataset.survey ? true : false,
     },
     datasetCollectionState: "",
     versionCollectionState: "",
@@ -562,6 +566,8 @@ describe("Mapping state to put body", () => {
         expect(returnValue.dataset.id).toBe(mockedSavedNonCantDatasetMetadata.dataset.id);
         expect(returnValue.collection_id).toBe("123");
         expect(returnValue.collection_state).toBe("InProgress");
+        expect(returnValue.dataset.related_content).toBe(mockedNewNonCantDatasetMetadata.dataset.related_content);
+        expect(returnValue.dataset.survey).toBe("census");
     });
 
     it("maps state correctly", () => {

--- a/src/app/views/datasets-new/edit-metadata/EditMetadataItem.jsx
+++ b/src/app/views/datasets-new/edit-metadata/EditMetadataItem.jsx
@@ -95,6 +95,7 @@ export default class EditMetadatItem extends Component {
                 );
             }
             case "relatedDatasets":
+            case "relatedContent":
             case "relatedPublications":
             case "relatedMethodologies": {
                 return (


### PR DESCRIPTION
### What

Adds related content field to the Edit Metadata (Cantabular) form ([trello ticket](https://trello.com/c/dOW0n2iJ/1248-related-content)).

![Screenshot 2022-10-21 at 15 24 07](https://user-images.githubusercontent.com/70764326/197219558-b3d6e1b5-404d-4056-ac38-d68a0bca75d9.png)

### How to review

Run the code, go through Cantabular metadata journey, add data to the `Related content` pop out, save, refresh the page, then go back and edit/delete the related content data you added and also make sure you can complete the journey and publish the dataset . Don't forget to run the test suite.

![Screenshot 2022-10-21 at 15 37 23](https://user-images.githubusercontent.com/70764326/197222130-fca9d1b5-9f6f-4cfc-9f0a-320b9e1209fe.png)

### Who can review

Anyone
