### PR TITLE
Adds quality statement fields to Edit Metadata (Cantabular) screen

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
@@ -210,7 +210,7 @@ const CantabularMetadata = ({
             />
 
             <h2>Dimensions</h2>
-            {metadata.dimensions.map(dimension => {
+            {metadata.dimensions.map((dimension, i) => {
                 return (
                     <div key={`dimension-${dimension.id}`}>
                         <Input
@@ -227,6 +227,7 @@ const CantabularMetadata = ({
                             value={dimension.description}
                             onChange={handleDimensionDescriptionChange}
                             disabled={disableForm || versionIsPublished || fieldsReturned.dimensions}
+                            inline={true}
                         />
                         <h3>Quality statement</h3>
                         <Input
@@ -243,6 +244,7 @@ const CantabularMetadata = ({
                             onChange={handleDimensionNameChange}
                             disabled={true}
                         />
+                        {i < metadata.dimensions.length - 1 && <hr class="margin-bottom--1 element-divider" />}
                     </div>
                 );
             })}

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
@@ -228,6 +228,21 @@ const CantabularMetadata = ({
                             onChange={handleDimensionDescriptionChange}
                             disabled={disableForm || versionIsPublished || fieldsReturned.dimensions}
                         />
+                        <h3>Quality statement</h3>
+                        <Input
+                            id={`dimension-quality-statement-text-${dimension.id}`}
+                            label="Text"
+                            value={dimension.quality_statement_text ? dimension.quality_statement_text : ""}
+                            onChange={handleDimensionNameChange}
+                            disabled={true}
+                        />
+                        <Input
+                            id={`dimension-quality-statement-url-${dimension.id}`}
+                            label="URL"
+                            value={dimension.quality_statement_url ? dimension.quality_statement_url : ""}
+                            onChange={handleDimensionNameChange}
+                            disabled={true}
+                        />
                     </div>
                 );
             })}

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -403,6 +403,8 @@ export class CantabularMetadataController extends Component {
                         name: dimension.name,
                         description: dimension.description,
                         label: dimension.label,
+                        quality_statement_text: dimension.meta.ONS_Variable.quality_statement_text,
+                        quality_statement_url: dimension.meta.ONS_Variable.quality_statement_url,
                     };
                 }),
             },

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -409,7 +409,7 @@ export class CantabularMetadataController extends Component {
                         description: dimension.description,
                         label: dimension.label,
                         quality_statement_text: dimension.meta.ONS_Variable.quality_statement_text,
-                        quality_statement_url: dimension.meta.ONS_Variable.quality_statement_url,
+                        quality_statement_url: dimension.meta.ONS_Variable.quality_summary_url,
                     };
                 }),
             },

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -267,9 +267,14 @@ export class CantabularMetadataController extends Component {
     integrateDimensions = (datasetVersionDimensions, cantabularMetadataDimensions, versionID) => {
         try {
             return datasetVersionDimensions.map(versionDimension => {
+                let cantabularDimension = cantabularMetadataDimensions.find(cantDimension => cantDimension.id == versionDimension.id);
                 return {
                     ...versionDimension,
-                    description: cantabularMetadataDimensions.find(cantDimension => cantDimension.id == versionDimension.id).description,
+                    description: cantabularDimension.description,
+                    quality_statement_text: cantabularDimension.quality_statement_text,
+                    quality_statement_url: cantabularDimension.quality_statement_url,
+                    name: cantabularDimension.name,
+                    label: cantabularDimension.label,
                 };
             });
         } catch (err) {

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -89,7 +89,7 @@ const mockedRecipeDimensions = [
 
 const mockedCompleteDimensions = [
     {
-        label: "Dimension1 label",
+        label: "Dimension1 Label",
         description: "Dimension1 description",
         links: [],
         href: "dimension-href",
@@ -98,9 +98,11 @@ const mockedCompleteDimensions = [
         variable: "dimensionVariable",
         number_of_options: 1,
         is_area_type: true,
+        quality_statement_text: "quality statement text 1",
+        quality_statement_url: "quality statement url 1",
     },
     {
-        label: "Dimension2 label",
+        label: "Dimension2 Label",
         description: "Dimension2 description",
         links: [],
         href: "dimension-href",
@@ -109,6 +111,8 @@ const mockedCompleteDimensions = [
         variable: "dimensionVariable",
         number_of_options: 3,
         is_area_type: false,
+        quality_statement_text: "quality statement text 2",
+        quality_statement_url: "quality statement url 2",
     },
 ];
 
@@ -167,11 +171,23 @@ const mockedCantabularExtractorResp = {
                     name: "Dimension1 Name",
                     description: "Dimension1 description",
                     label: "Dimension1 Label",
+                    meta: {
+                        ONS_Variable: {
+                            quality_statement_text: "quality statement text 1",
+                            quality_statement_url: "quality statement url 1",
+                        },
+                    },
                 },
                 {
                     name: "Dimension2 Name",
                     description: "Dimension2 description",
                     label: "Dimension2 Label",
+                    meta: {
+                        ONS_Variable: {
+                            quality_statement_text: "quality statement text 2",
+                            quality_statement_url: "quality statement url 2",
+                        },
+                    },
                 },
             ],
         },
@@ -207,12 +223,16 @@ const mockedCantabularDatasetMetadata = {
                 name: "Dimension1 Name",
                 description: "Dimension1 description",
                 label: "Dimension1 Label",
+                quality_statement_text: "quality statement text 1",
+                quality_statement_url: "quality statement url 1",
             },
             {
                 id: "Dimension2 Name",
                 name: "Dimension2 Name",
                 description: "Dimension2 description",
                 label: "Dimension2 Label",
+                quality_statement_text: "quality statement text 2",
+                quality_statement_url: "quality statement url 2",
             },
         ],
     },

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -174,7 +174,7 @@ const mockedCantabularExtractorResp = {
                     meta: {
                         ONS_Variable: {
                             quality_statement_text: "quality statement text 1",
-                            quality_statement_url: "quality statement url 1",
+                            quality_summary_url: "quality statement url 1",
                         },
                     },
                 },
@@ -185,7 +185,7 @@ const mockedCantabularExtractorResp = {
                     meta: {
                         ONS_Variable: {
                             quality_statement_text: "quality statement text 2",
-                            quality_statement_url: "quality statement url 2",
+                            quality_summary_url: "quality statement url 2",
                         },
                     },
                 },

--- a/src/scss/elements/_lists.scss
+++ b/src/scss/elements/_lists.scss
@@ -68,3 +68,7 @@
 .expandable-item__header {
     position: relative;
 }
+
+.element-divider {
+    border: 1px solid $iron-dark;
+}


### PR DESCRIPTION
### What

Adds quality statement fields to every dimension of the dataset on the  Edit Metadata (Cantabular) screen ([see trello ticket](https://trello.com/c/38rHCrB1/1287-quality-statement)).

![Screenshot 2022-10-25 at 16 01 39](https://user-images.githubusercontent.com/70764326/197810228-2f49a092-cd0b-447d-99d8-475246572c02.png)

### How to review

Run the code, go through Cantabular metadata journey,  save, refresh the page and check if the data persists. Don't forget to run the test suite.

### Who can review

Anyone
