### PR TITLE
adds uglify-js to audit allowlist until vulnerability is fixed

### DIFF
--- a/src/audit-allowlist.json
+++ b/src/audit-allowlist.json
@@ -42,7 +42,7 @@
         },
         {
             "id" : "CVE-2022-37598",
-            "reason" : "Uglify-js@3.17.4 (latest version) does not fix the vulnerability"
+            "reason" : "Uglify-js@3.17.4 (latest version) does not fix the vulnerability. It requires upgrading when a fix is released. See https://trello.com/c/eXXr4ago/1294-upgrade-uglify-js-package"
         }
     ]
 }

--- a/src/audit-allowlist.json
+++ b/src/audit-allowlist.json
@@ -39,6 +39,10 @@
         {
             "id" : "sonatype-2017-0422",
             "reason" : "Moment.js"
+        },
+        {
+            "id" : "CVE-2022-37598",
+            "reason" : "Uglify-js@3.17.4 (latest version) does not fix the vulnerability"
         }
     ]
 }

--- a/src/legacy/package-lock.json
+++ b/src/legacy/package-lock.json
@@ -390,9 +390,9 @@
           "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "uglify-js": {
-          "version": "3.17.3",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-          "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+          "version": "3.17.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+          "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
           "optional": true
         }
       }


### PR DESCRIPTION
### What

Uglify-js v3.17.4 is the latest version currently and contains a vulnerability. Until this is fixed, this vulnerability has been added to the audit allowlist.

### How to review

Sense check

### Who can review

Anyone