### PR TITLE
reverts Cantabular dataset title to just label field

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -380,7 +380,7 @@ export class CantabularMetadataController extends Component {
     marshalCantabularMetadata = cantResponse => {
         return {
             dataset: {
-                title: `${cantResponse.table_query_result.service.tables[0].name} (${cantResponse.table_query_result.service.tables[0].label})`,
+                title: cantResponse.table_query_result.service.tables[0].label,
                 description: cantResponse.table_query_result.service.tables[0].description,
                 keywords: cantResponse.table_query_result.service.tables[0].vars,
                 national_statistic:

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -122,7 +122,7 @@ const mockedCantabularExtractorResp = {
             tables: [
                 {
                     name: "Cantabular metadata",
-                    label: "",
+                    label: "Cantabular dataset label",
                     description: "Cantabular metadata description",
                     vars: ["Dimension1", "Dimension2"],
                     meta: {
@@ -196,7 +196,7 @@ const mockedCantabularExtractorResp = {
 
 const mockedCantabularDatasetMetadata = {
     dataset: {
-        title: `Cantabular metadata (${mockedCantabularExtractorResp.table_query_result.service.tables[0].label})`,
+        title: mockedCantabularExtractorResp.table_query_result.service.tables[0].label,
         description: "Cantabular metadata description",
         keywords: ["Dimension1", "Dimension2"],
         national_statistic: true,


### PR DESCRIPTION
### What

Simplifies title field for Cantabular datasets, using only label rather than concatenating name (i.e. dataset code) + label. As requested by outputs.

### How to review

Check tests pass, sense check.

### Who can review

Anyone
