### PR TITLE
Removes preview button from refresh cantabular metadata screen 

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -506,6 +506,7 @@ export class CantabularMetadataController extends Component {
                     showUpdateCantabularMetadataPopout: false,
                     showRevertChangesButton: true,
                 },
+                allowPreview: false,
             });
         }
         this.setState({

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -232,6 +232,7 @@ const mockedCantabularDatasetMetadata = {
 
 const mockedSavedNonCantDatasetMetadata = {
     dataset: {
+        state: "associated",
         id: "456",
         methodologies: [],
         next_release: "",
@@ -562,6 +563,22 @@ describe("Allowing preview functionality", () => {
 
     it("enables preview if saving edits successful", async () => {
         await component.instance().saveMetadata();
+        expect(component.state("allowPreview")).toBe(true);
+    });
+    it("disables preview when the user checks the updated cantabular metadata ", () => {
+        component.setState({
+            refreshCantabularMetadataState: { refreshCantabularMetadata: true, isRevertChangesClicked: false },
+            fieldsReturned: { title: true, dimensions: true },
+        });
+        component.instance().handleGETSuccess(mockedSavedNonCantDatasetMetadata, mockedCantabularDatasetMetadata);
+        expect(component.state("allowPreview")).toBe(false);
+    });
+    it("enables preview if the user reverts the incoming cantabular metadata to the original one", () => {
+        component.setState({
+            refreshCantabularMetadataState: { refreshCantabularMetadata: false, isRevertChangesClicked: true },
+            fieldsReturned: { title: true, dimensions: true },
+        });
+        component.instance().handleGETSuccess(mockedSavedNonCantDatasetMetadata, mockedCantabularDatasetMetadata);
         expect(component.state("allowPreview")).toBe(true);
     });
 });


### PR DESCRIPTION
### What

Removes preview button from refresh cantabular metadata screen ([trello ticket](https://trello.com/c/P1KQTqn1/1338-refresh-metadata-preview)).

### How to review

Run the code, go through Cantabular metadata journey and at the end only click `Save` to keep the collection `inProgress`. To test the feature you can either go and manually change some of the dataset fields in mongo(from the mongo `datasets` collection you can manually change `title`,`description`,`keywords` etc and from the `instances` mongo collection you can manually change from the `dimensions` field `label`,`description`,`quality_statement_text` etc) or you can go and manually update/hard-code the `dp-cantabular-metadata-extractor-api` response.

If you, for example, go into mongo and manually change the contact name, when you go on the Edit Metadata (Cantabular) screen you will get a pop out letting you know that there are some differences between the saved cantabular metadata to the existing dataset and the latest cantabular metadata returned by the `dp-cantabular-metadata-extractor-api`.

![Screenshot 2022-12-05 at 15 40 07](https://user-images.githubusercontent.com/70764326/205681767-53163961-25d3-4fa4-a2d9-adbe01a3d051.png)

When you click the `View changes first` button the new contact name gets displayed and you can't access the preview anymore since the new cantabular metadata is not yet saved to the dataset.

![Screenshot 2022-12-05 at 15 40 19](https://user-images.githubusercontent.com/70764326/205682972-a7c67e95-87c7-4fd2-835f-ef23bb1caa86.png)

The changes can easily be reverted by clicking the `Revert to original` button which will pull up again the initial data saved in mongo on the dataset and on the instance and will enable back the preview button.

![Screenshot 2022-12-05 at 15 44 43](https://user-images.githubusercontent.com/70764326/205683941-237e3a7b-25d5-4cdb-989f-106815dbbae3.png)
![Screenshot 2022-12-05 at 15 40 28](https://user-images.githubusercontent.com/70764326/205684030-13730f93-7bcb-476c-9224-a0df87262718.png)

### Who can review

Anyone
