### PR TITLE
Removes continue button from preview dataset landing page (cantabular metadata journey)

### DIFF
--- a/src/app/views/workflow-preview/WorkflowPreview.jsx
+++ b/src/app/views/workflow-preview/WorkflowPreview.jsx
@@ -85,21 +85,23 @@ export class WorkflowPreview extends Component {
                         <h1 className="margin-top--1 margin-bottom--1">Preview</h1>
                     </div>
                 </div>
-                <div className="preview--half preview--borders">
+                <div className={`preview${!this.props.enableCantabularJourney && !this.state.cantabularDataset ? "--half" : ""} preview--borders`}>
                     <Iframe path={this.getPreviewIframeURL(this.props.location.pathname)} />
                 </div>
-                <div className="grid grid--justify-center">
-                    <div className="grid__col-6">
-                        <div className="margin-top--1 margin-bottom--1">
-                            <Link
-                                className="btn btn--positive margin-right--1"
-                                to={window.location.origin + "/florence/collections/" + this.props.params.collectionID}
-                            >
-                                Continue
-                            </Link>
+                {!this.props.enableCantabularJourney && !this.state.cantabularDataset && (
+                    <div className="grid grid--justify-center">
+                        <div className="grid__col-6">
+                            <div className="margin-top--1 margin-bottom--1">
+                                <Link
+                                    className="btn btn--positive margin-right--1"
+                                    to={window.location.origin + "/florence/collections/" + this.props.params.collectionID}
+                                >
+                                    Continue
+                                </Link>
+                            </div>
                         </div>
                     </div>
-                </div>
+                )}
             </div>
         );
     }


### PR DESCRIPTION
### What

Removes what looks like a footer and the continue button from the preview dataset landing page ([trello ticket](https://trello.com/c/ZeCrYleS/1345-preview-screen-removal-of-continue-button) ) only for cantabular metadata journey.

### How to review

Run the code, go through Cantabular metadata journey and check the preview dataset landing page.

1. Before:

![Screenshot 2022-12-07 at 14 41 09](https://user-images.githubusercontent.com/70764326/206208966-3096c2cc-efee-4065-87d5-a22c3ccf499c.png)

2.After:

![Screenshot 2022-12-07 at 14 39 22](https://user-images.githubusercontent.com/70764326/206208622-ae32e61f-e790-4c88-8030-ece6337fbc25.png)


### Who can review

Anyone
