### PR TITLE
Bug/100 missing topic id error handling

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadata.jsx
@@ -85,7 +85,8 @@ const propTypes = {
     secondaryTopicsMenuArr: PropTypes.array.isRequired,
     handleCanonicalTopicTagFieldChange: PropTypes.func.isRequired,
     handleSecondaryTopicTagsFieldChange: PropTypes.func.isRequired,
-    topicsErr: PropTypes.string,
+    canonicalTopicErr: PropTypes.string,
+    secondaryTopicErr: PropTypes.string,
     handleCensusContentChange: PropTypes.func.isRequired,
     refreshCantabularMetadataState: PropTypes.object.isRequired,
     handleCantabularMetadataUpdate: PropTypes.func.isRequired,
@@ -121,7 +122,8 @@ const CantabularMetadata = ({
     secondaryTopicsMenuArr,
     handleCanonicalTopicTagFieldChange,
     handleSecondaryTopicTagsFieldChange,
-    topicsErr,
+    canonicalTopicErr,
+    secondaryTopicErr,
     handleCensusContentChange,
     refreshCantabularMetadataState,
     handleCantabularMetadataUpdate,
@@ -484,7 +486,7 @@ const CantabularMetadata = ({
                 contents={canonicalTopicsMenuArr}
                 handleChange={handleCanonicalTopicTagFieldChange}
                 multipleSelection={false}
-                error={topicsErr}
+                error={canonicalTopicErr}
                 disabled={disableForm}
             />
             <SelectTags
@@ -494,7 +496,7 @@ const CantabularMetadata = ({
                 handleChange={handleSecondaryTopicTagsFieldChange}
                 multiDefaultValue={metadata.secondaryTopics}
                 multipleSelection={true}
-                error={topicsErr}
+                error={secondaryTopicErr}
                 disabled={disableForm}
             />
 

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -352,6 +352,16 @@ export class CantabularMetadataController extends Component {
         }
     };
 
+    findTopics = (allTopics, selectedTopicIDs) => {
+        return selectedTopicIDs.map(topicID => {
+            const selectedTopic = allTopics.find(topic => topic.value == topicID);
+            if (!selectedTopic) {
+                this.setState({ topicsErr: `Topic ID ${topicID} in dataset metadata but not present in topic api. Please reselect topics` });
+            }
+            return selectedTopic;
+        });
+    };
+
     mapMetadataToState = (nonCantDatasetMetadata, cantabularMetadata = null) => {
         const dataset = nonCantDatasetMetadata.dataset;
         const version = nonCantDatasetMetadata.version;
@@ -395,10 +405,8 @@ export class CantabularMetadataController extends Component {
                     value: useCantabularMetadata ? cantabularMetadata.dataset.contacts?.[0].telephone : dataset.contacts?.[0].telephone,
                     error: "",
                 },
-                canonicalTopic: "canonical_topic" in dataset ? this.state.allTopicsArr.find(topic => topic.value == dataset.canonical_topic) : {},
-                secondaryTopics: dataset.subtopics
-                    ? dataset.subtopics.map(topicID => this.state.allTopicsArr.find(topic => topic.value == topicID))
-                    : [],
+                canonicalTopic: "canonical_topic" in dataset ? this.findTopics(this.state.allTopicsArr, [dataset.canonical_topic])[0] : {},
+                secondaryTopics: dataset.subtopics ? this.findTopics(this.state.allTopicsArr, dataset.subtopics) : [],
                 census: dataset.survey ? true : false,
                 relatedContent: dataset.related_content ? this.mapRelatedContentToState(dataset.related_content, dataset.id) : [],
             };

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -716,7 +716,8 @@ describe("Calling checkMandatoryFields", () => {
         };
         component.setState(mockCantabularMetadataStateNoCanonicalTopic);
         component.instance().checkMandatoryFields();
-        expect(component.state("topicsErr")).toEqual("You cannot enter a secondary topic without a canonical topic");
+        expect(component.state("canonicalTopicErr")).toEqual("You cannot enter a secondary topic without a canonical topic");
+        expect(component.state("secondaryTopicErr")).toEqual("You cannot enter a secondary topic without a canonical topic");
     });
 });
 


### PR DESCRIPTION
### What

We have added error handling to cover the possibility that a topic ID may be saved to a dataset in Florence that later is removed or modified in the topic-api.

![Screenshot 2022-12-14 at 12 14 53](https://user-images.githubusercontent.com/70749355/207593084-62743261-bb79-4179-849d-87013f1f13a6.png)

### How to review

Read the code, check the tests pass, run the journey locally and modify a topic/subtopic ID in mongo to trigger the error.

### Who can review

Anyone
