### PR TITLE
Fixes no title saved bug on the What's changed? cantabular metadata field

### DIFF
--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -600,9 +600,9 @@ export class CantabularMetadataController extends Component {
         try {
             return latestChanges?.map((latestChange, index) => ({
                 id: index,
-                title: latestChange.title,
+                title: latestChange.title || latestChange.name,
                 description: latestChange.description,
-                simpleListHeading: latestChange.title,
+                simpleListHeading: latestChange.title || latestChange.name,
                 simpleListDescription: latestChange.description,
             }));
         } catch (error) {
@@ -862,7 +862,10 @@ export class CantabularMetadataController extends Component {
                 release_date: this.state.metadata.releaseDate.value,
                 alerts: this.state.metadata.notices,
                 usage_notes: this.state.metadata.usageNotes,
-                latest_changes: this.state.metadata.latestChanges,
+                latest_changes:
+                    this.state.metadata.latestChanges.length > 0
+                        ? this.state.metadata.latestChanges.map(latestChange => ({ ...latestChange, name: latestChange.title }))
+                        : [],
                 dimensions: [...this.state.metadata.dimensions],
             },
             dimensions: [...this.state.metadata.dimensions],


### PR DESCRIPTION
### What

Fixes [No title saved bug](https://trello.com/c/miEOFwcK/1347-bug-whats-changed-metadata-field). 
The `What's changed?` metadata field is defined in the dataset-api models as being a list of objects with the following properties : `description`, `name` and `type`, but currently the only property which gets sent through from florence in the put request body is the `description`. This change updates the code to send through also the `name`(title) .

![Screenshot 2022-12-15 at 09 32 30](https://user-images.githubusercontent.com/70764326/207824158-8a556cc9-ded5-4f60-85fa-ce47d5cfdba7.png)

### How to review

Read the code, check the tests pass, run the journey locally add an entry for the `What's changed?` metadata field,save, refresh the page and make sure that the title is still coming through.

![Screenshot 2022-12-15 at 09 33 00](https://user-images.githubusercontent.com/70764326/207824338-834af890-3559-4c9f-b787-a264a12cd0f9.png)

### Who can review

Anyone
