### PR TITLE
Fix content state

### DIFF
--- a/src/app/utilities/api-clients/collections.js
+++ b/src/app/utilities/api-clients/collections.js
@@ -168,7 +168,7 @@ export default class collections {
     }
 
     static setInteractiveStatusToComplete(collectionID, interactiveID) {
-        const body = { state: "Completed" };
+        const body = { state: "Complete" };
         return http.put(`/zebedee/collections/${collectionID}/interactives/${interactiveID}`, body, true).then(response => {
             return response;
         });


### PR DESCRIPTION
### What

The correct state Zebedee is expecting is [Complete](https://github.com/ONSdigital/zebedee/blob/develop/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/json/ContentStatus.java). 
This happens to work by coincidence as it is failing to deserialise the body, using an empty state which results in it [being set to Complete](https://github.com/ONSdigital/zebedee/blob/0380bdd386fc8d969cb292540cec0f6be7cfaf53/zebedee-cms/src/main/java/com/github/onsdigital/zebedee/service/InteractivesServiceImpl.java#L60)

### How to review

Check the expected values is `Complete` and interactives continue moving states correctly

### Who can review

Anyone
