### PR TITLE
generate assets on make debug-run and reflex to ignore assets folder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM onsdigital/dp-concourse-tools-ubuntu
+FROM onsdigital/dp-concourse-tools-ubuntu-20:ubuntu20.4-rc.1
 
 WORKDIR /app/
 

--- a/Dockerfile.concourse
+++ b/Dockerfile.concourse
@@ -1,4 +1,4 @@
-FROM onsdigital/dp-concourse-tools-ubuntu
+FROM onsdigital/dp-concourse-tools-ubuntu-20:ubuntu20.4-rc.1
 
 WORKDIR /app/
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ debug: generate-go-debug
 	HUMAN_LOG=1 BIND_ADDR=${BIND_ADDR} $(BINPATH)/florence
 
 .PHONY: debug-run
-debug-run:
+debug-run: generate-go-debug
 	HUMAN_LOG=1 BIND_ADDR=${BIND_ADDR} go run -tags 'debug' -race $(LDFLAGS) main.go
 
 .PHONY: ensure-main-min-css

--- a/reflex
+++ b/reflex
@@ -1,3 +1,3 @@
-# Watch all files ending in .go, excluding files in `.go` directory or files
+# Watch all files ending in .go, excluding files in `.go` or `assets` directory or files
 # ending in `_test.go` & run `make debug` when any matching file is changed
--s -r \.go$ -R ^\.go/ -R _test\.go$ make debug-run
+-s -r \.go$ -R ^\.go/ -R ^assets/ -R _test\.go$ make debug-run

--- a/src/legacy/package-lock.json
+++ b/src/legacy/package-lock.json
@@ -90,9 +90,9 @@
       },
       "dependencies": {
         "@xmldom/xmldom": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-          "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+          "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg==",
           "dev": true
         }
       }
@@ -390,9 +390,9 @@
           "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
         },
         "uglify-js": {
-          "version": "3.17.3",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.3.tgz",
-          "integrity": "sha512-JmMFDME3iufZnBpyKL+uS78LRiC+mK55zWfM5f/pWBJfpOttXAqYfdDGRukYhJuyRinvPVAtUhvy7rlDybNtFg==",
+          "version": "3.17.4",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+          "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
           "optional": true
         }
       }

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -4262,9 +4262,9 @@
       },
       "dependencies": {
         "@xmldom/xmldom": {
-          "version": "0.8.3",
-          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-          "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ=="
+          "version": "0.8.6",
+          "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.6.tgz",
+          "integrity": "sha512-uRjjusqpoqfmRkTaNuLJ2VohVr67Q5YwDATW3VU7PfzTj6IRaihGrYI7zckGZjxQPBIp63nfvJbM+Yu5ICh0Bg=="
         },
         "js-yaml": {
           "version": "3.13.1",
@@ -12298,19 +12298,9 @@
       "dev": true
     },
     "json5": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-      "requires": {
-        "minimist": "^1.2.5"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-          "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
-        }
-      }
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
     },
     "jsonfile": {
       "version": "6.1.0",

--- a/src/package.json
+++ b/src/package.json
@@ -100,6 +100,7 @@
     "install": "^0.8.7",
     "is-empty-object": "^1.1.1",
     "jest-snapshot": "^27.4.2",
+    "json5": "^2.2.2",
     "localforage": "^1.5.0",
     "minimongo": "^6.9.0",
     "moment": "^2.29.1",


### PR DESCRIPTION
### What

- [Trello card](https://trello.com/c/S2KyzIGX/1024-create-census-hub-stack-using-docker)
- Automatically generate assets on make debug-run
- Configure reflex to ignore changes on `assets` folder

- Upgraded json5 library to version 2.2.2 to fix vulnerability detected by `make audit`

### How to review

- Make sure changes are ok
- You may run the dp-compose stack using [the branch for this PR](https://github.com/ONSdigital/dp-compose/pull/123)\
- Make sure the upgrade is fine

### Who can review

Anyone