### PR TITLE
Checks for multivariate dataset type - ticket#1379

### DIFF
--- a/src/app/views/collections/details/CollectionDetailsController.jsx
+++ b/src/app/views/collections/details/CollectionDetailsController.jsx
@@ -596,7 +596,10 @@ export class CollectionDetailsController extends Component {
             const type = response.next.type;
             try {
                 await datasets.getCantabularMetadata(datasetID, "en");
-                this.setState({ isCantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+                this.setState({
+                    isCantabularDataset:
+                        type === "cantabular_flexible_table" || type === "cantabular_table" || type === "cantabular_multivariate_table",
+                });
             } catch {
                 console.log("Dataset ID not present in Cantabular metadata server");
             }

--- a/src/app/views/collections/details/CollectionDetailsController.test.js
+++ b/src/app/views/collections/details/CollectionDetailsController.test.js
@@ -519,6 +519,30 @@ describe("Clicking 'edit' for a page", () => {
         expect(cantabularEditClickComponent.state("isCantabularDataset")).toBe(true);
         expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
     });
+    it("routes to the cantabular edit metadata form if the dataset type is a cantabular_multivariate_table", async () => {
+        const cantabularProps = {
+            ...defaultProps,
+            ...props,
+            enableCantabularJourney: true,
+        };
+        const cantabularEditClickComponent = shallow(<CollectionDetailsController {...cantabularProps} />);
+        const mockedDatasetType = { next: { type: "cantabular_multivariate_table" } };
+        datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
+        const versionURL = await cantabularEditClickComponent.instance().handleCollectionPageEditClick(
+            {
+                type: "dataset_version",
+                datasetID: "cpi",
+                id: "cpi/editions/current/versions/2",
+                uri: "/datasets/cpi/editions/current/versions/2",
+                edition: "current",
+                version: "2",
+                lastEditedBy: "test.user@email.com",
+            },
+            "complete"
+        );
+        expect(cantabularEditClickComponent.state("isCantabularDataset")).toBe(true);
+        expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
+    });
 });
 
 describe("Edit Homepage functionality", () => {

--- a/src/app/views/datasets-new/versions/DatasetVersionsController.jsx
+++ b/src/app/views/datasets-new/versions/DatasetVersionsController.jsx
@@ -48,7 +48,9 @@ export class DatasetVersionsController extends Component {
         const type = response.next.type;
         try {
             await datasets.getCantabularMetadata(datasetID, "en");
-            this.setState({ cantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+            this.setState({
+                cantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" || type === "cantabular_multivariate_table",
+            });
         } catch {
             console.log("Dataset ID not present in Cantabular metadata server");
         }

--- a/src/app/views/datasets-new/versions/DatasetVersionsController.test.js
+++ b/src/app/views/datasets-new/versions/DatasetVersionsController.test.js
@@ -159,6 +159,23 @@ describe("Maps dataset versions to state ", () => {
             details: ["Release date: 15 March 2021"],
         });
     });
+    it("maps the dataset versions to state for a cantabular_multivariate_table dataset", async () => {
+        const mockedDatasetType = {
+            next: {
+                type: "cantabular_multivariate_table",
+            },
+        };
+        datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
+        await component.instance().getDatasetType(mockedDataset.id);
+        const mapped = component.instance().mapDatasetVersionsToState(mockedResponse.versions);
+        expect(component.state("cantabularDataset")).toBe(true);
+        expect(mapped[1]).toMatchObject({
+            id: "6b59a885-f4ca-4b78-9b89-4e9a8e939d55",
+            title: "Version: 1 (published)",
+            url: "florence/collections/12345/datasets/6789/versions/1/cantabular",
+            details: ["Release date: 15 March 2021"],
+        });
+    });
     it("maps the dataset versions to state for a non cantabular dataset", async () => {
         const mockedDatasetType = {
             next: {

--- a/src/app/views/workflow-preview/WorkflowPreview.jsx
+++ b/src/app/views/workflow-preview/WorkflowPreview.jsx
@@ -38,7 +38,10 @@ export class WorkflowPreview extends Component {
             const type = response.next.type;
             try {
                 await datasets.getCantabularMetadata(datasetID, "en");
-                this.setState({ cantabularDataset: type === "cantabular_flexible_table" || type === "cantabular_table" });
+                this.setState({
+                    cantabularDataset:
+                        type === "cantabular_flexible_table" || type === "cantabular_table" || type === "cantabular_multivariate_table",
+                });
             } catch {
                 console.log("Dataset ID not present in Cantabular metadata server");
             }


### PR DESCRIPTION
### What

Includes the dataset multivariate type in the cantabular metadata journey ([Multivariate type added](https://trello.com/c/8RJ1wUYE/1379-multivariate-type-added)).

### How to review

Read the code, check the tests pass, run the journey locally and make sure to use a recipe which has a `cantabular_multivariate_table` format to check if after creating a dataset you are redirected  to the `Edit metadata (Cantabular)` form and not to the CMD `Edit metadata` form. Also test that the `back` button on the preview screen and the `Edit` button on the collection details screen takes you back to the  `Edit metadata (Cantabular)` form.

1. `back` button on the preview screen

![Screenshot 2023-01-17 at 12 11 38](https://user-images.githubusercontent.com/70764326/212896205-99a3694e-b443-4345-a108-d619166710c1.png)

2.  `Edit` button on the collection details screen

![Screenshot 2023-01-17 at 12 08 44](https://user-images.githubusercontent.com/70764326/212896324-b39f98a7-87e3-4af7-9eeb-6ef40b7dadfe.png)

### Who can review

Anyone
