### PR TITLE
WIP commit

### DIFF
--- a/src/app/views/collections/details/CollectionDetailsController.jsx
+++ b/src/app/views/collections/details/CollectionDetailsController.jsx
@@ -27,7 +27,7 @@ import collectionMapper from "../mapper/collectionMapper";
 import Modal from "../../../components/Modal";
 import RestoreContent from "../restore-content/RestoreContent";
 import url from "../../../utilities/url";
-import auth from "../../../utilities/auth";
+import auth, { getUserTypeFromAuthState } from "../../../utilities/auth";
 import log from "../../../utilities/logging/log";
 import CollectionDetails, { pagePropTypes, deletedPagePropTypes } from "./CollectionDetails";
 import CollectionEditController from "../edit/CollectionEditController";
@@ -84,7 +84,7 @@ export class CollectionDetailsController extends Component {
     }
 
     UNSAFE_componentWillMount() {
-        if (!auth.canViewCollectionsDetails(this.props.user)) {
+        if (!auth.canViewCollectionsDetails(this.props.user) && !auth.canViewCollectionsDetails(getUserTypeFromAuthState())) {
             this.props.dispatch(push(`${this.props.rootPath}/collections`));
             return;
         }

--- a/src/legacy/js/functions/_postComplete.js
+++ b/src/legacy/js/functions/_postComplete.js
@@ -39,30 +39,32 @@ function completeContent(collectionId, path, recursive, redirectToPath) {
 
     var url = url + '&recursive=' + recursive;
 
+    viewCollections(collectionId);
+    
     // Update content
-    isUpdatingModal.add();
-    $.ajax({
-        url: url,
-        dataType: 'json',
-        contentType: 'application/json',
-        type: 'POST',
-        success: function () {
-            isUpdatingModal.remove();
-            if (redirect) {
-                createWorkspace(redirect, collectionId, 'edit');
-                return;
-            } else {
-                // Remove selection from 'working on: collection' tab
-                $('.js-nav-item--collection').hide();
-                $('.js-nav-item').removeClass('selected');
-                $('.js-nav-item--collections').addClass('selected');
+    // isUpdatingModal.add();
+    // $.ajax({
+    //     url: url,
+    //     dataType: 'json',
+    //     contentType: 'application/json',
+    //     type: 'POST',
+    //     success: function () {
+    //         isUpdatingModal.remove();
+    //         if (redirect) {
+    //             createWorkspace(redirect, collectionId, 'edit');
+    //             return;
+    //         } else {
+    //             // Remove selection from 'working on: collection' tab
+    //             $('.js-nav-item--collection').hide();
+    //             $('.js-nav-item').removeClass('selected');
+    //             $('.js-nav-item--collections').addClass('selected');
 
-                viewCollections(collectionId);
-            }
-        },
-        error: function (response) {
-            isUpdatingModal.remove();
-            handleApiError(response);
-        }
-    });
+    //             viewCollections(collectionId);
+    //         }
+    //     },
+    //     error: function (response) {
+    //         isUpdatingModal.remove();
+    //         handleApiError(response);
+    //     }
+    // });
 }


### PR DESCRIPTION
### What

**CURRENT BEHAVIOUR** 

When working on a publication in a collection, when saving and submitting for review, the publishing officer is kicked out of the collection back to the collections screen (without the collection open) so the publishing officer has to find the collection again to continue work.

**DESIRED BEHAVIOUR** 

Return to the collection screen with the same collection selected.

**CONTEXT**

I've been investigating the codebase and found that when the legacy portion of Florence (which handles saving and submitting for review publications) redirects to florence/collections/:collectionID it is routed appropriately.

```
<Provider store={store}>
        <Router history={history}>
                <Route component={Layout}>
                    <Redirect from={"${rootPath}"} to={"${rootPath}/collections"} />
                    <Route path={"${rootPath}/collections"} component={userIsAuthenticated(Collections)}>
 --->                   <Route path=":collectionID" component={userIsAuthenticated(Collections)}>
```

This works its way down with the bug appearing to occur at this point.

```
    UNSAFE_componentWillMount() {
--->    if (!auth.canViewCollectionsDetails(this.props.user)) {
            this.props.dispatch(push(`${this.props.rootPath}/collections`));
            return;
        }
```

Now what I believe is happening here is that this.props.user is mapped to what is held in the state shown here

```
export function mapStateToProps(state) {
    return {
        isNewSignIn: getEnableNewSignIn(state.state),
--->    user: state.user,
```

Now since we are going from selecting a publication in a collection to edit -> saving said publication -> back to viewing collections,  Florence React has a reference to a user in its state -> goes to Florence Legacy thus the react portion is destroyed and loses what's held in state -> comes back to Florence React and fails the check in the UNSAFE_componentWillMount function because this.props.user which is state.user is empty thus the redirection back to collections.

**PROPOSED FIX**

I found a function in auth.js which creates a user based on whether ons_auth_state exists in local storage which it does in the journey from React -> Legacy -> React.

```
export function getUserTypeFromAuthState() {
    const userData = getAuthState();
    if (!userData) {
        // Return a new empty user object to respect the factory functions return type
        return new _UserSchema();
    }
    const _user = new _UserSchema();
    // We assume the user is authenticated if ons_auth_state exists in local storage
    _user.isAuthenticated = !!userData;
    _user.email = userData.email;
    _user.userType = user.getUserRole(userData.admin, userData.editor);
    _user.isAdmin = userData.admin;
    return _user;
}
```

I use this and add to the conditional and the redirect back works successfully as the check no longer fails.

```
        if (!auth.canViewCollectionsDetails(this.props.user) && !auth.canViewCollectionsDetails(getUserTypeFromAuthState()){
            this.props.dispatch(push(`${this.props.rootPath}/collections`));
            return;
        }
```

### WHY THE LONG EXPLANATION?

I need fresh eyes to see if this can be done better but I hope my explanation provides some much needed context and insight in what is going on and what I'm trying to achieve. 

Something I was hoping would work and I deemed a more elegant fix was adding userIsAdminOrEditor() to the routing.

`<Route path=":collectionID" component={userIsAuthenticated(userIsAdminOrEditor(Collections))}>
`

I was hoping the routing would run userIsAdminOrEditor() which as it happens runs getUserTypeFromAuthState() and then applies the user it creates to the state and thus solving the issue.

```
const userIsAdminOrEditor = connectedReduxRedirect({
    authenticatedSelector: state => {
        return auth.isAdminOrEditor(state.user) || auth.isAdmin(getUserTypeFromAuthState());
    },
```

However for whatever reason this does not seem to work :( and I am tired.

### How to review

Read the essay above, look at the code and tell me what you think.

### Who can review

Anyone.