### PR TITLE
Feature/hide users tabs for non admins

### DIFF
--- a/src/app/components/layout/Layout.test.js
+++ b/src/app/components/layout/Layout.test.js
@@ -51,6 +51,7 @@ jest.mock("../../utilities/api-clients/user", () => {
     class user {}
     user.setUserState = jest.fn();
     user.getOldUserType = jest.fn();
+    user.getUserRole = jest.fn();
     user.renewSession = () => {
         return new Promise((resolve, reject) => {
             // setTimeout(() => {

--- a/src/app/components/navbar/NavBar.jsx
+++ b/src/app/components/navbar/NavBar.jsx
@@ -86,7 +86,7 @@ const NavBar = props => {
                                 Publishing queue
                             </a>
                         </li>
-                        {auth.isAdminOrEditor(props.user) && (
+                        {auth.isAdmin(props.user) && (
                             <li className="global-nav__item">
                                 <Link to={`${rootPath}/users`} activeClassName="selected" className="global-nav__link">
                                     Users and access

--- a/src/app/components/navbar/NavBar.test.js
+++ b/src/app/components/navbar/NavBar.test.js
@@ -5,6 +5,7 @@ import { createMockUser } from "../../utilities/tests/test-utils";
 import NavBar from "./NavBar";
 
 const notLoggedUser = createMockUser();
+const authenticatedEditor = createMockUser("user@test.com", true, true, "EDITOR");
 const authenticatedUser = createMockUser("user@test.com", true, true, "ADMIN");
 const authenticatedViewer = createMockUser("user@test.com", true, true, "VIEWER");
 
@@ -116,14 +117,26 @@ describe("NavBar", () => {
         });
     });
 
+    describe("when user is authenticated as Editor", () => {
+        it("should not display Users and access", () => {
+            const component = shallow(<NavBar {...defaultProps} user={authenticatedEditor} />);
+            expect(component.find("Link[to='/florence/users']").exists()).toBe(false);
+        });
+    });
+
     describe("when user is authenticated as Viewer", () => {
-        it("should only ender navigation with accessible links", () => {
+        it("should only render navigation with accessible links", () => {
             const component = shallow(<NavBar {...defaultProps} user={authenticatedViewer} />);
 
             expect(component.hasClass("global-nav__list")).toBe(true);
             expect(component.find(Link)).toHaveLength(2);
             expect(component.find(Link).getElements()[0].props.children).toBe("Collections");
             expect(component.find(Link).getElements()[1].props.children).toBe("Sign out");
+        });
+
+        it("should not display Users and access", () => {
+            const component = shallow(<NavBar {...defaultProps} user={authenticatedViewer} />);
+            expect(component.find("Link[to='/florence/users']").exists()).toBe(false);
         });
 
         describe("when on collections url", () => {

--- a/src/app/utilities/auth.js
+++ b/src/app/utilities/auth.js
@@ -53,6 +53,7 @@ export function setAuthState(userData = {}) {
     // Store the user type in localStorage. Used in old Florence
     // where views can depend on user type. e.g. Browse tree
     localStorage.setItem("userType", user.getOldUserType(userData) || "");
+    localStorage.setItem("userRole", user.getUserRole(userData.admin, userData.editor) || "");
 }
 
 export function updateAuthState(data = {}) {

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const userIsAuthenticated = connectedReduxRedirect({
 
 const userIsAdminOrEditor = connectedReduxRedirect({
     authenticatedSelector: state => {
-        return auth.isAdminOrEditor(state.user) || auth.isAdmin(getUserTypeFromAuthState());
+        return auth.isAdminOrEditor(state.user) || auth.isAdminOrEditor(getUserTypeFromAuthState());
     },
     redirectAction: routerActions.replace,
     wrapperDisplayName: "userIsAdminOrEditor",

--- a/src/legacy/js/classes/florence.js
+++ b/src/legacy/js/classes/florence.js
@@ -62,6 +62,9 @@ Florence.Authentication = {
     },
     userType: function() {
         return localStorage.getItem("userType");
+    },
+    isAdmin: function() {
+        return localStorage.getItem("userRole") === "ADMIN";
     }
 };
 

--- a/src/legacy/templates/mainNav.handlebars
+++ b/src/legacy/templates/mainNav.handlebars
@@ -23,7 +23,9 @@
             </li>
         {{/if}}
         <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--publish" href="javascript:void(0)">Publishing queue</a></li>
-        <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--users" href="javascript:void(0)">Users and access</a></li>
+        {{#if this.Authentication.isAdmin}}
+            <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--users" href="javascript:void(0)">Users and access</a></li>
+        {{/if}}
         <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--teams" href="javascript:void(0)">Teams</a></li>
         <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--logout" href="javascript:void(0)">Sign out</a></li>
     {{else}}


### PR DESCRIPTION
### What

Hidden 'Users and access' tab in florence and legacy from non-admins. 
Fixed a redirect for editors switching between legacy and non-legacy

### How to review

Initial issue was editors and viewers could see 'users' tab - this is now not rendered for them.
The subsequent issue was when changing back and forth between legacy (in this case, publishing-queue), the Router redirects 'editors' to the 'collections' page, which looks to be incorrect as once in place in the React app it allows access just fine. Logic looked incorrect on closer inspection, so I've corrected - happy to take it out if this is expected behaviour. 

### Who can review

Someone with Florence knowledge. 