### PR TITLE
Handles the errors returned by the dataset-api & cantabular-metadata-extractor-api services

### DIFF
--- a/src/app/views/collections/details/CollectionDetailsController.test.js
+++ b/src/app/views/collections/details/CollectionDetailsController.test.js
@@ -6,8 +6,17 @@ import collections from "../../../utilities/api-clients/collections";
 import notifications from "../../../utilities/notifications";
 import { UPDATE_PAGES_IN_ACTIVE_COLLECTION, UPDATE_ACTIVE_COLLECTION } from "../../../config/constants";
 import datasets from "../../../utilities/api-clients/datasets";
+import log from "../../../utilities/logging/log";
 
 console.error = () => {};
+
+jest.mock("../../../utilities/logging/log", () => {
+    return {
+        event: function () {},
+        data: function () {},
+        error: jest.fn(),
+    };
+});
 
 jest.mock("../../../utilities/notifications", () => ({
     add: jest.fn(() => {}),
@@ -39,9 +48,6 @@ jest.mock("../../../utilities/api-clients/datasets", () => {
             return Promise.resolve("/datasets/cpi/editions/current/versions/2");
         }),
         get: jest.fn(() => {
-            return Promise.resolve();
-        }),
-        getCantabularMetadata: jest.fn(() => {
             return Promise.resolve();
         }),
     };
@@ -432,6 +438,9 @@ describe("Map state to props function", () => {
 });
 
 describe("Clicking 'edit' for a page", () => {
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
     const props = {
         ...defaultProps,
         collectionID: "my-collection-12345",
@@ -459,117 +468,158 @@ describe("Clicking 'edit' for a page", () => {
         },
     };
     const editClickComponent = shallow(<CollectionDetailsController {...props} />);
-
-    it("routes to the datasets screen for dataset/versions", async () => {
-        const mockedDatasetType = {
-            next: {
-                type: "test_type",
-            },
-        };
-        datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
-        const datasetURL = await editClickComponent
-            .instance()
-            .handleCollectionPageEditClick(
-                { type: "dataset_details", id: "cpi", uri: "/datasets/cpi", lastEditedBy: "test.user@email.com" },
-                "inProgress"
+    describe("When the cantabular journey is enabled", () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+            editClickComponent.setProps({ enableCantabularJourney: true });
+            editClickComponent.setState({ errorGettingDatasetType: false, isCantabularDataset: false });
+        });
+        it("routes to the workspace for a non-dataset pages", async () => {
+            const pageURL = await editClickComponent
+                .instance()
+                .handleCollectionPageEditClick({ type: "article", uri: "/economy/grossdomesticproductgdp/articles/ansarticle" });
+            expect(editClickComponent.state("isCantabularDataset")).toBe(false);
+            expect(pageURL).toBe("/florence/workspace?collection=my-collection-12345&uri=/economy/grossdomesticproductgdp/articles/ansarticle");
+        });
+        it("routes to the CMD edit metadata form", async () => {
+            const mockedDatasetType = { next: { type: "test-type" } };
+            datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
+            const pageURL = await editClickComponent.instance().handleCollectionPageEditClick(
+                {
+                    type: "dataset_version",
+                    datasetID: "cpi",
+                    id: "cpi/editions/current/versions/2",
+                    uri: "/datasets/cpi/editions/current/versions/2",
+                    edition: "current",
+                    version: "2",
+                    lastEditedBy: "test.user@email.com",
+                },
+                "complete"
             );
-        expect(datasetURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2");
+            expect(editClickComponent.state("isCantabularDataset")).toBe(false);
+            expect(pageURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2");
+        });
+        it("routes to the cantabular edit metadata form if the dataset type is a cantabular_table", async () => {
+            const mockedDatasetType = { next: { type: "cantabular_table" } };
+            datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
+            const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
+                {
+                    type: "dataset_version",
+                    datasetID: "cpi",
+                    id: "cpi/editions/current/versions/2",
+                    uri: "/datasets/cpi/editions/current/versions/2",
+                    edition: "current",
+                    version: "2",
+                    lastEditedBy: "test.user@email.com",
+                },
+                "complete"
+            );
+            expect(editClickComponent.state("isCantabularDataset")).toBe(true);
+            expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
+        });
+        it("routes to the cantabular edit metadata form if the dataset type is a cantabular_flexible_table", async () => {
+            const mockedDatasetType = { next: { type: "cantabular_flexible_table" } };
+            datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
+            const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
+                {
+                    type: "dataset_version",
+                    datasetID: "cpi",
+                    id: "cpi/editions/current/versions/2",
+                    uri: "/datasets/cpi/editions/current/versions/2",
+                    edition: "current",
+                    version: "2",
+                    lastEditedBy: "test.user@email.com",
+                },
+                "complete"
+            );
+            expect(editClickComponent.state("isCantabularDataset")).toBe(true);
+            expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
+        });
+        it("routes to the cantabular edit metadata form if the dataset type is a cantabular_multivariate_table", async () => {
+            const mockedDatasetType = { next: { type: "cantabular_multivariate_table" } };
+            datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
+            const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
+                {
+                    type: "dataset_version",
+                    datasetID: "cpi",
+                    id: "cpi/editions/current/versions/2",
+                    uri: "/datasets/cpi/editions/current/versions/2",
+                    edition: "current",
+                    version: "2",
+                    lastEditedBy: "test.user@email.com",
+                },
+                "complete"
+            );
+            expect(editClickComponent.state("isCantabularDataset")).toBe(true);
+            expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
+        });
+        it("handles the error returned by the dataset api", async () => {
+            console.error = jest.fn();
+            notifications.add.mockClear();
+            expect(notifications.add.mock.calls.length).toEqual(0);
+            datasets.get.mockImplementationOnce(() => Promise.reject({}));
+            await editClickComponent.instance().getDatasetType("cpi/editions/current/versions/2");
+            expect(editClickComponent.state("errorGettingDatasetType")).toBe(true);
+            expect(notifications.add.mock.calls.length).toBe(1);
+            expect(log.error).toHaveBeenCalledTimes(1);
+            expect(console.error).toHaveBeenCalledWith("Something went wrong when trying to retrieve the dataset type.", {});
+            const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
+                {
+                    type: "dataset_version",
+                    datasetID: "cpi",
+                    id: "cpi/editions/current/versions/2",
+                    uri: "/datasets/cpi/editions/current/versions/2",
+                    edition: "current",
+                    version: "2",
+                    lastEditedBy: "test.user@email.com",
+                },
+                "complete"
+            );
+            expect(versionURL).toBe("/florence/collections/my-collection-12345");
+        });
+    });
+    describe("When the cantabular journey is disabled", () => {
+        beforeEach(() => {
+            jest.resetAllMocks();
+            editClickComponent.setProps({ enableCantabularJourney: false });
+            editClickComponent.setState({ errorGettingDatasetType: false, isCantabularDataset: false });
+        });
+        it("routes to the workspace for a non-dataset pages and doesn't call the getDatasetType function", async () => {
+            editClickComponent.instance().getDatasetType = jest.fn();
+            const pageURL = await editClickComponent
+                .instance()
+                .handleCollectionPageEditClick({ type: "article", uri: "/economy/grossdomesticproductgdp/articles/ansarticle" });
+            expect(editClickComponent.state("isCantabularDataset")).toBe(false);
+            expect(pageURL).toBe("/florence/workspace?collection=my-collection-12345&uri=/economy/grossdomesticproductgdp/articles/ansarticle");
+            expect(editClickComponent.instance().getDatasetType).toHaveBeenCalledTimes(0);
+        });
+        it("routes to the datasets screen for dataset/versions and doesn't call the getDatasetType function", async () => {
+            editClickComponent.instance().getDatasetType = jest.fn();
+            datasets.getLatestVersionURL.mockImplementationOnce(() => Promise.resolve("/datasets/cpi/editions/current/versions/2"));
+            const datasetURL = await editClickComponent
+                .instance()
+                .handleCollectionPageEditClick(
+                    { type: "dataset_details", id: "cpi", uri: "/datasets/cpi", lastEditedBy: "test.user@email.com" },
+                    "inProgress"
+                );
+            expect(datasetURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2");
 
-        const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
-            {
-                type: "dataset_version",
-                datasetID: "cpi",
-                id: "cpi/editions/current/versions/2",
-                uri: "/datasets/cpi/editions/current/versions/2",
-                edition: "current",
-                version: "2",
-                lastEditedBy: "test.user@email.com",
-            },
-            "complete"
-        );
-        expect(editClickComponent.state("isCantabularDataset")).toBe(false);
-        expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2");
-    });
-
-    it("routes to the workspace for a non-dataset pages", async () => {
-        const pageURL = await editClickComponent
-            .instance()
-            .handleCollectionPageEditClick({ type: "article", uri: "/economy/grossdomesticproductgdp/articles/ansarticle" });
-        expect(editClickComponent.state("isCantabularDataset")).toBe(false);
-        expect(pageURL).toBe("/florence/workspace?collection=my-collection-12345&uri=/economy/grossdomesticproductgdp/articles/ansarticle");
-    });
-    it("routes to the cantabular edit metadata form if the dataset type is a cantabular_table", async () => {
-        const cantabularProps = {
-            ...defaultProps,
-            ...props,
-            enableCantabularJourney: true,
-        };
-        const cantabularEditClickComponent = shallow(<CollectionDetailsController {...cantabularProps} />);
-
-        const mockedDatasetType = { next: { type: "cantabular_table" } };
-        datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
-        const versionURL = await cantabularEditClickComponent.instance().handleCollectionPageEditClick(
-            {
-                type: "dataset_version",
-                datasetID: "cpi",
-                id: "cpi/editions/current/versions/2",
-                uri: "/datasets/cpi/editions/current/versions/2",
-                edition: "current",
-                version: "2",
-                lastEditedBy: "test.user@email.com",
-            },
-            "complete"
-        );
-        expect(cantabularEditClickComponent.state("isCantabularDataset")).toBe(true);
-        expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
-    });
-    it("routes to the cantabular edit metadata form if the dataset type is a cantabular_flexible_table", async () => {
-        const cantabularProps = {
-            ...defaultProps,
-            ...props,
-            enableCantabularJourney: true,
-        };
-        const cantabularEditClickComponent = shallow(<CollectionDetailsController {...cantabularProps} />);
-        const mockedDatasetType = { next: { type: "cantabular_flexible_table" } };
-        datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
-        const versionURL = await cantabularEditClickComponent.instance().handleCollectionPageEditClick(
-            {
-                type: "dataset_version",
-                datasetID: "cpi",
-                id: "cpi/editions/current/versions/2",
-                uri: "/datasets/cpi/editions/current/versions/2",
-                edition: "current",
-                version: "2",
-                lastEditedBy: "test.user@email.com",
-            },
-            "complete"
-        );
-        expect(cantabularEditClickComponent.state("isCantabularDataset")).toBe(true);
-        expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
-    });
-    it("routes to the cantabular edit metadata form if the dataset type is a cantabular_multivariate_table", async () => {
-        const cantabularProps = {
-            ...defaultProps,
-            ...props,
-            enableCantabularJourney: true,
-        };
-        const cantabularEditClickComponent = shallow(<CollectionDetailsController {...cantabularProps} />);
-        const mockedDatasetType = { next: { type: "cantabular_multivariate_table" } };
-        datasets.get.mockImplementationOnce(() => Promise.resolve(mockedDatasetType));
-        const versionURL = await cantabularEditClickComponent.instance().handleCollectionPageEditClick(
-            {
-                type: "dataset_version",
-                datasetID: "cpi",
-                id: "cpi/editions/current/versions/2",
-                uri: "/datasets/cpi/editions/current/versions/2",
-                edition: "current",
-                version: "2",
-                lastEditedBy: "test.user@email.com",
-            },
-            "complete"
-        );
-        expect(cantabularEditClickComponent.state("isCantabularDataset")).toBe(true);
-        expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2/cantabular");
+            const versionURL = await editClickComponent.instance().handleCollectionPageEditClick(
+                {
+                    type: "dataset_version",
+                    datasetID: "cpi",
+                    id: "cpi/editions/current/versions/2",
+                    uri: "/datasets/cpi/editions/current/versions/2",
+                    edition: "current",
+                    version: "2",
+                    lastEditedBy: "test.user@email.com",
+                },
+                "complete"
+            );
+            expect(editClickComponent.instance().getDatasetType).toHaveBeenCalledTimes(0);
+            expect(editClickComponent.state("isCantabularDataset")).toBe(false);
+            expect(versionURL).toBe("/florence/collections/my-collection-12345/datasets/cpi/editions/current/versions/2");
+        });
     });
 });
 

--- a/src/app/views/collections/details/CollectionDetailsController.test.js
+++ b/src/app/views/collections/details/CollectionDetailsController.test.js
@@ -689,7 +689,7 @@ describe("When the component mounts with a collection id", () => {
                 userType: "ADMIN",
             },
         };
-
+        collections.get.mockImplementationOnce(() => Promise.resolve({ id: "test-collection-12345" }));
         const callsCounter = collections.get.mock.calls.length;
         expect(collections.get.mock.calls.length).toBe(callsCounter);
         const component = shallow(<CollectionDetailsController {...props} />);
@@ -708,7 +708,7 @@ describe("When the component mounts with a collection id", () => {
             "admin": true,
             "editor": true
         }));
-
+        collections.get.mockImplementationOnce(() => Promise.resolve({ id: "test-collection-12345" }));
         const callsCounter = collections.get.mock.calls.length;
         expect(collections.get.mock.calls.length).toBe(callsCounter);
         const component = shallow(<CollectionDetailsController {...props} />);


### PR DESCRIPTION
### What

This PR fixes multiple issues on cantabular metadata journey.

1. Handles the error returned by the `dataset-api` when trying to retrieve the dataset type (ticket#1428): 

If the cantabular metadata journey is enabled the dataset type has to be checked to either redirect the user to  the cantabular metadata journey or to the CMD one. To check the type, the `dataset-api` gets called and now, with the changes in this PR, if an error is returned that error is handled, the user is alerted and the journey is stopped (the existing behaviour is to redirect the user by default to the CMD journey even if an error was returned when trying to retrieve the dataset type from the `dataset-api` and there is no message displaying on the screen telling the user about the error) . 

2. Handles the errors returned by the cantabular-metadata-extractor-api (ticket#1421&ticket#1420).

### How to review

Read the code, check the tests pass, run the cantabular metadata journey locally and to test the first change, either stop the `dataset-api` when you get to the following 3 screens or just go and convert to a string the argument passed down to the `getDatasetType` function in the `CollectionDetailsController.jsx/DatasetVersionsController.jsx/WorkflowPreview.jsx` files.

a. Dataset version screen:

![Screenshot 2023-02-13 at 09 26 50](https://user-images.githubusercontent.com/70764326/218420586-72d8b4b6-abb6-42e5-9f90-e0c8db838958.png)

You will come across this screen only when you first go through the journey and you are trying to attach a dataset to a collection. If an error is returned by the `dataset-api` when checking the dataset type you should see the below message and the version options should be disabled, stopping you from progressing with the journey.

![Screenshot 2023-02-13 at 12 01 19](https://user-images.githubusercontent.com/70764326/218452699-a22e9b09-0121-4e70-98d9-40938f130e17.png)

b. Collection details screen:

![Screenshot 2023-02-13 at 09 08 37](https://user-images.githubusercontent.com/70764326/218417587-30dddea2-188c-45ee-8204-f05cacbe00a9.png)

On this screen what needs to be tested is the Edit click button functionality. If an error is returned by the `dataset-api` when checking the dataset type you should see the below message and you shouldn't be able to progress the journey.

![Screenshot 2023-02-13 at 12 07 30](https://user-images.githubusercontent.com/70764326/218454584-b0dabbb9-0095-4f0b-ac2d-e5d852ece7b7.png)

c. Dataset preview screen:

![Screenshot 2023-02-13 at 12 09 50](https://user-images.githubusercontent.com/70764326/218454326-8ddbe08c-83ef-49f6-975c-c11271f6edd5.png)

On the preview screen what is to be tested is the back button functionality. If an error is returned by the dataset-api when checking the dataset type you should see the same error message and again, you shouldn't be able to progress the journey.

![Screenshot 2023-02-13 at 12 09 32](https://user-images.githubusercontent.com/70764326/218454444-da5734d8-cf1f-4c45-a308-2c4740818305.png)

To test the `cantabular-metadata-extractor-api` error handling, you just need to stop the service so that when you land on the cantabular metadata form you can check to see if the below error message is displayed.

![Screenshot 2023-02-13 at 11 57 48](https://user-images.githubusercontent.com/70764326/218452052-493772d8-a186-4a4f-ba2f-a38e25de3e10.png)

### Who can review

Anyone
