### PR TITLE
Task/audit fix core-js

### DIFF
--- a/src/audit-allowlist.json
+++ b/src/audit-allowlist.json
@@ -43,6 +43,10 @@
         {
             "id" : "CVE-2022-38900",
             "reason" : "decode-uri-component is a dependency of css, of which we are using the latest version."
+        },
+        {
+            "id" : "sonatype-2023-0962",
+            "reason" : "core-js@2.6.12 is a dependency of the table-builder-ui library , of which we are using the latest version. It requires upgrading core-js to 3.28.0. See https://trello.com/c/KNIkvvRc/1429-florence-audit-failurecore-js2612"
         }
     ]
 }


### PR DESCRIPTION
### What

`core-js@2.6.12` is a dependency of  `dp-table-builder-ui` library and at the time of writing the current used version of the `dp-table-builder-ui` is `v1.1.1` which is also the latest version and does not address the current vulnerability. So until this gets fixed the vulnerability has been added to the audit allowlist. 

### How to review

Sense check

### Who can review

Anyone
