### PR TITLE
setting cookie for collection when clicked on preview button.

### DIFF
--- a/src/legacy/js/functions/_viewPublishDetails.js
+++ b/src/legacy/js/functions/_viewPublishDetails.js
@@ -1,132 +1,152 @@
 function viewPublishDetails(collections) {
+  var manual = "[manual collection]";
+  var result = {
+    date: Florence.collectionToPublish.publishDate,
+    subtitle: "",
+    collectionDetails: [],
+    pendingDeletes: [],
+  };
+  var pageDataRequests = []; // list of promises - one for each ajax request to load page data.
+  var onlyOne = 0;
 
-    var manual = '[manual collection]';
-    var result = {
-        date: Florence.collectionToPublish.publishDate,
-        subtitle: '',
-        collectionDetails: [],
-        pendingDeletes: []
-    };
-    var pageDataRequests = []; // list of promises - one for each ajax request to load page data.
-    var onlyOne = 0;
+  $.each(collections, function (i, collectionId) {
+    onlyOne += 1;
+    pageDataRequests.push(
+      getCollectionDetails(
+        collectionId,
+        (success = function (response) {
+          if (result.date === manual) {
+            result.collectionDetails.push({
+              id: response.id,
+              name: response.name,
+              pageDetails: response.reviewed,
+              datasets: response.datasets,
+              datasetVersions: response.datasetVersions,
+              pageType: "manual",
+              pendingDeletes: response.pendingDeletes,
+              interactives: response.interactives,
+            });
+          } else {
+            result.collectionDetails.push({
+              id: response.id,
+              name: response.name,
+              pageDetails: response.reviewed,
+              datasets: response.datasets,
+              datasetVersions: response.datasetVersions,
+              interactives: response.interactives,
+            });
+          }
+        }),
+        (error = function () {
+          result.collectionDetails.push({
+            id: getCollectionIDWithoutUUID(collectionId),
+            error: true,
+            pageType: result.date === manual ? "manual" : "",
+          });
+        })
+      )
+    );
+  });
 
-    $.each(collections, function (i, collectionId) {
-        onlyOne += 1;
-        pageDataRequests.push(
-            getCollectionDetails(collectionId,
-                success = function (response) {
-                    if (result.date === manual) {
-                        result.collectionDetails.push({
-                            id: response.id,
-                            name: response.name,
-                            pageDetails: response.reviewed,
-                            datasets: response.datasets,
-                            datasetVersions: response.datasetVersions,
-                            pageType: 'manual',
-                            pendingDeletes: response.pendingDeletes,
-                            interactives: response.interactives
-                        });
-                    } else {
-                        result.collectionDetails.push({
-                            id: response.id,
-                            name: response.name,
-                            pageDetails: response.reviewed,
-                            datasets: response.datasets,
-                            datasetVersions: response.datasetVersions,
-                            interactives: response.interactives
-                        });
-                    }
-                },
-                error = function () {
-                    result.collectionDetails.push({
-                        id: getCollectionIDWithoutUUID(collectionId),
-                        error: true,
-                        pageType: result.date === manual ? "manual" : ""
-                    })
-                }
-            )
-        );
+  if (onlyOne < 2) {
+    result.subtitle = "The following collection has been approved";
+  } else {
+    result.subtitle = "The following collections have been approved";
+  }
+
+  Promise.allSettled(pageDataRequests)
+    .then(() => {
+      displayPublishDetailsPanel();
+    })
+    .catch((err) => {
+      handleApiError(err);
     });
 
-    if (onlyOne < 2) {
-        result.subtitle = 'The following collection has been approved';
-    } else {
-        result.subtitle = 'The following collections have been approved';
-    }
+  function displayPublishDetailsPanel() {
+    var publishDetails = templates.publishDetails(result);
+    $(".panel--off-canvas").html(publishDetails);
+    bindAccordions();
 
-    Promise.allSettled(pageDataRequests).then(() => {
-        displayPublishDetailsPanel()
-    }).catch(err => {
-        handleApiError(err);
-    })
+    $(".btn-collection-publish").click(function () {
+      var collection = $(this)
+        .closest(".js-accordion")
+        .find(".collection-name")
+        .attr("data-id");
+      publish(collection);
+    });
 
-    function displayPublishDetailsPanel() {
-        var publishDetails = templates.publishDetails(result);
-        $('.panel--off-canvas').html(publishDetails);
-        bindAccordions();
+    $(".btn-collection-unlock").click(function () {
+      var collection = $(this)
+        .closest(".js-accordion")
+        .find(".collection-name")
+        .attr("data-id");
 
-        $('.btn-collection-publish').click(function () {
-            var collection = $(this).closest('.js-accordion').find('.collection-name').attr('data-id');
-            publish(collection);
-        });
+      if (result.date !== manual) {
+        swal(
+          {
+            title: "Are you sure?",
+            text:
+              "If unlocked, this collection will not be published on " +
+              result.date +
+              " unless it is approved" +
+              " again",
+            type: "warning",
+            showCancelButton: true,
+            confirmButtonColor: "#6d272b",
+            confirmButtonText: "Yes, unlock it!",
+            closeOnConfirm: false,
+          },
+          function () {
+            unlock(collection);
+          }
+        );
+      } else {
+        unlock(collection);
+      }
+    });
 
-        $('.btn-collection-unlock').click(function () {
-            var collection = $(this).closest('.js-accordion').find('.collection-name').attr('data-id');
+    $(".btn-collection-preview").click(function () {
+      var collection = $(this)
+        .closest(".js-accordion")
+        .find(".collection-name")
+        .attr("data-id");
+      document.cookie = "collection=" + collection + ";path=/";
+      window.location = `/florence/collections/${collection}/preview`;
+    });
 
-            if (result.date !== manual) {
-                swal({
-                        title: "Are you sure?",
-                        text: "If unlocked, this collection will not be published on " + result.date + " unless it is approved" +
-                        " again",
-                        type: "warning",
-                        showCancelButton: true,
-                        confirmButtonColor: "#6d272b",
-                        confirmButtonText: "Yes, unlock it!",
-                        closeOnConfirm: false
-                    },
-                    function () {
-                        unlock(collection);
-                    });
-            } else {
-                unlock(collection);
-            }
-        });
+    //page-list
+    $(".page__item:not(.delete-child)").click(function () {
+      $(".page-list li").removeClass("selected");
+      $(".page__buttons").hide();
+      $(".page__children").hide();
 
-        $('.btn-collection-preview').click(function () {
-            var collection = $(this).closest('.js-accordion').find('.collection-name').attr('data-id');
-            window.location = `/florence/collections/${collection}/preview`
-        });
+      // $(this).parent('li').addClass('selected');
+      // $(this).next('.page__buttons').show();
 
-        //page-list
-        $('.page__item:not(.delete-child)').click(function () {
-            $('.page-list li').removeClass('selected');
-            $('.page__buttons').hide();
-            $('.page__children').hide();
+      var $this = $(this),
+        $buttons = $this.next(".page__buttons"),
+        $childrenPages =
+          $buttons.length > 0
+            ? $buttons.next(".page__children")
+            : $this.next(".page__children");
 
-            // $(this).parent('li').addClass('selected');
-            // $(this).next('.page__buttons').show();
+      $this.parent("li").addClass("selected");
+      $buttons.show();
+      $childrenPages.show();
+    });
 
-            var $this = $(this),
-                $buttons = $this.next('.page__buttons'),
-                $childrenPages = $buttons.length > 0 ? $buttons.next('.page__children') : $this.next('.page__children');
+    $(".btn-collection-cancel").click(function () {
+      var hidePanelOptions = {
+        onHide: false,
+        moveCenteredPanel: true,
+      };
 
-            $this.parent('li').addClass('selected');
-            $buttons.show();
-            $childrenPages.show();
-        });
+      hidePanel(hidePanelOptions);
+    });
+  }
 
-        $('.btn-collection-cancel').click(function () {
-            var hidePanelOptions = {
-                onHide: false,
-                moveCenteredPanel: true
-            };
-
-            hidePanel(hidePanelOptions);
-        });
-    }
-
-    // return collection id without unique identifier on the end
-    function getCollectionIDWithoutUUID(collectionID) {
-        return collectionID.split("-")[0]
-    }
+  // return collection id without unique identifier on the end
+  function getCollectionIDWithoutUUID(collectionID) {
+    return collectionID.split("-")[0];
+  }
 }


### PR DESCRIPTION
### What

Previewing an approved collection in Florence only works for the first previewed collection per session.

### How to review

Create/ensure two different collections ('A' &' B') with some edited content are in an ‘approved’ state (ie. they appear in the publishing queue).
Sign out of Florence then back in again (clear session)
Go to "Publishing queue" -> [date]/[manual collection] -> [collection 'A'] -> "Preview" and observe that the edited content CAN be previewed (expected collection changes are visible)
Go to "Publishing queue" -> [date]/[manual collection] -> [collection ‘B'] -> "Preview" and observe that the content changed in collection ‘B’ CAN NOT be previewed (only the content in the published master is viewable). However, note that the content modified in collection 'A’ is still being overlaid and shows the modified content rather than the master as it should do.
Sign out of Florence then back in again (clear session)
Go to "Publishing queue" -> [date]/[manual collection] -> [collection 'B'] -> "Preview" and observe that the edited content nowCAN be previewed (expected collection changes are visible) as it is now the first collection previewed in this session.

### Who can review

FD