### PR TITLE
Fix asset loading/resolving

### DIFF
--- a/src/webpack.config.js
+++ b/src/webpack.config.js
@@ -50,15 +50,7 @@ module.exports = {
             {
                 test: /\.scss$/i,
                 use: [MiniCssExtractPlugin.loader, "css-loader", "sass-loader"],
-        },
-        {
-            test: /\.(jpg|jpeg|png|gif|mp3|svg)$/i,
-            use: [{
-                loader: 'url-loader',
-                options: { limit: 100000,},
-            },
-            ],
-        },
+        }
     ]},
     plugins: [
         new CopyWebpackPlugin({


### PR DESCRIPTION
### What

Remove `url-loader` module. From the docs: 

> url-loader lets you import arbitrary files, like images. If you import a .png file, url-loader will ensure that import resolves to a Base64 string representing the contents of the file.

When we use `url-loader` the assets seem broken and don't load properly in browsers. Removed this for now as attempted fixes didn't work and this is depreciated as of v5 so maybe worth moving away from it anyways

Before fix:
<img width="217" alt="image" src="https://user-images.githubusercontent.com/12159136/226456887-9a6590ff-1f74-4522-ae54-9eab039564ff.png">

After fix:
<img width="664" alt="image" src="https://user-images.githubusercontent.com/12159136/226456972-58ce5d27-f63f-4a1d-980b-9b8a911c7485.png">


### Who can review

Anyone
