### PR TITLE
Integrates the new PUT metadata endpoint

### DIFF
--- a/src/app/utilities/api-clients/datasets.js
+++ b/src/app/utilities/api-clients/datasets.js
@@ -217,6 +217,10 @@ export default class datasets {
             });
     }
 
+    static putMetadata(datasetID, editionID, versionID, body) {
+        return http.put(`${publishingDatasetControllerURL}/datasets/${datasetID}/editions/${editionID}/versions/${versionID}/metadata`, body, true);
+    }
+
     static getVersionsList(datasetID, editionID) {
         return http.get(`${publishingDatasetControllerURL}/datasets/${datasetID}/editions/${editionID}/versions`).then(response => {
             return response;

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -941,7 +941,9 @@ export class CantabularMetadataController extends Component {
         if (this.state.collectionState === "") {
             return datasets
                 .putEditMetadata(datasetID, editionID, versionID, body)
-                .then(() => {
+                .then(async () => {
+                    await this.sleep(3000);
+                    await this.retrieveDatasetMetadata();
                     this.setState(() => {
                         return { isSaving: false, allowPreview: true, disableCancel: true };
                     });
@@ -1098,6 +1100,12 @@ export class CantabularMetadataController extends Component {
                 .then(this.retrieveDatasetMetadata)
                 .catch(error => error);
         }
+    };
+
+    sleep = async milliseconds => {
+        await new Promise(resolve => {
+            return setTimeout(resolve, milliseconds);
+        });
     };
 
     handleRedirectOnReject = isCancellingPublication => {

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -213,31 +213,31 @@ export class CantabularMetadataController extends Component {
                 contacts:
                     "contacts" in datasetMetadata.dataset
                         ? [
-                            {
-                                name: datasetMetadata.dataset.contacts?.[0].name || "",
-                                email: datasetMetadata.dataset.contacts?.[0].email || "",
-                                telephone: datasetMetadata.dataset.contacts?.[0].telephone || "",
-                            },
-                        ]
+                              {
+                                  name: datasetMetadata.dataset.contacts?.[0].name || "",
+                                  email: datasetMetadata.dataset.contacts?.[0].email || "",
+                                  telephone: datasetMetadata.dataset.contacts?.[0].telephone || "",
+                              },
+                          ]
                         : [
-                            {
-                                name: "",
-                                email: "",
-                                telephone: "",
-                            },
-                        ],
+                              {
+                                  name: "",
+                                  email: "",
+                                  telephone: "",
+                              },
+                          ],
             },
             version: {
                 dimensions:
                     "dimensions" in datasetMetadata.version
                         ? datasetMetadata.version.dimensions.map(dimension => ({
-                            id: "id" in dimension ? dimension.id : "",
-                            name: "name" in dimension ? dimension.name : "",
-                            description: "description" in dimension ? dimension.description : "",
-                            label: "label" in dimension ? dimension.label : "",
-                            quality_statement_text: "quality_statement_text" in dimension ? dimension.quality_statement_text : "",
-                            quality_statement_url: "quality_statement_url" in dimension ? dimension.quality_statement_url : "",
-                        }))
+                              id: "id" in dimension ? dimension.id : "",
+                              name: "name" in dimension ? dimension.name : "",
+                              description: "description" in dimension ? dimension.description : "",
+                              label: "label" in dimension ? dimension.label : "",
+                              quality_statement_text: "quality_statement_text" in dimension ? dimension.quality_statement_text : "",
+                              quality_statement_url: "quality_statement_url" in dimension ? dimension.quality_statement_url : "",
+                          }))
                         : [],
             },
         };

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.jsx
@@ -466,7 +466,7 @@ export class CantabularMetadataController extends Component {
                 versionIsPublished: version.state === "published",
                 state: dataset.state,
                 collectionState: collectionState,
-                versionEtag: version.e_tag || "",
+                versionEtag: nonCantDatasetMetadata.version_etag || "",
             };
         } catch (error) {
             log.event("error mapping metadata to to state", log.data({ datasetID: dataset.id, versionID: version.id }), log.error(error));
@@ -903,11 +903,11 @@ export class CantabularMetadataController extends Component {
                         ? this.state.metadata.latestChanges.map(latestChange => ({ ...latestChange, name: latestChange.title }))
                         : [],
                 dimensions: [...this.state.metadata.dimensions],
-                e_tag: this.state.versionEtag,
             },
             dimensions: [...this.state.metadata.dimensions],
             collection_id: this.props.params.collectionID,
             collection_state: this.mapCollectionState(isSubmittingForReview, isMarkingAsReviewed),
+            version_etag: this.state.versionEtag,
         };
     };
 

--- a/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
+++ b/src/app/views/datasets-new/edit-metadata-cantabular/CantabularMetadataController.test.js
@@ -6,19 +6,19 @@ import cookies from "../../../utilities/cookies";
 import log from "../../../utilities/logging/log";
 import topics from "../../../utilities/api-clients/topics";
 
-console.error = () => { };
+console.error = () => {};
 
 jest.mock("../../../utilities/logging/log", () => {
     return {
-        event: function () { },
-        data: function () { },
+        event: function () {},
+        data: function () {},
         error: jest.fn(),
     };
 });
 
 jest.mock("../../../utilities/log", () => {
     return {
-        add: function () { },
+        add: function () {},
         eventTypes: {},
     };
 });
@@ -28,7 +28,7 @@ jest.mock("../../../utilities/notifications", () => {
         add: jest.fn(notification => {
             mockedNotifications.push(notification);
         }),
-        remove: () => { },
+        remove: () => {},
     };
 });
 


### PR DESCRIPTION
### What

- uses the new PUT metadata endpoint (see [ONSdigital/dp-publishing-dataset-controller#51](https://github.com/ONSdigital/dp-publishing-dataset-controller/pull/51)) once the dataset has been associated to a collection and the collection state is not an empty string anymore
- reads and writes the `versionEtag` to the payload so that the put metadata request to be successful 
- retrieves the latest metadata, before every `putMetadata` call is made to make sure the latest `versionEtag` is passed down in the payload 

**NOTE - this PR to be merged only after the following two PRs have been merged:**

1.  [ ONSdigital/dp-dataset-api#415](https://github.com/ONSdigital/dp-dataset-api/pull/415) 
2. [ONSdigital/dp-publishing-dataset-controller#51](https://github.com/ONSdigital/dp-publishing-dataset-controller/pull/51)

### How to review

Read the code, run the tests and set up your local environment following these [instructions](https://github.com/ONSdigital/dp-cantabular-metadata-extractor-api/blob/develop/devstack/README.md) to locally test the changes in florence .

Make sure the changes are not affecting any part of the cantabular metadata journey.

### Who can review

Anyone