### PR TITLE
Stop whitescreen on no session expiry

### DIFF
--- a/src/app/utilities/sessionManagement.js
+++ b/src/app/utilities/sessionManagement.js
@@ -202,11 +202,16 @@ export default class sessionManagement {
      *  @returns true if session has expired
      *  */
     static isSessionExpired(sessionExpiryTime) {
+        if (sessionExpiryTime == null) {
+            return true;
+        }
         const now = new Date();
         const nowUTCInMS = now.getTime() + now.getTimezoneOffset() * 60000;
         const nowInUTC = new Date(nowUTCInMS);
+
         // Get the time difference between now and the expiry time minus the timer offset
         const timerInterval = new Date(sessionExpiryTime) - nowInUTC;
+
         let diffInSeconds = Math.round(timerInterval / 1000);
         if (isNaN(diffInSeconds)) {
             throw new Error("encounted an error checking time interval: diffInSeconds is NaN");

--- a/src/app/utilities/sessionManagement.test.js
+++ b/src/app/utilities/sessionManagement.test.js
@@ -138,4 +138,10 @@ describe("#isSessionExpired()", () => {
         const expected = false;
         expect(actual).toEqual(expected);
     });
+    it("should return true if session time does not exist", () => {
+        const sessionExpiryTime = null;
+        const actual = sessionManagement.isSessionExpired(sessionExpiryTime);
+        const expected = true;
+        expect(actual).toEqual(expected);
+    });
 });


### PR DESCRIPTION
### What

If you deeplink to a page in florence, e.g. /florence/users, and you haven't signed in it tries to redirect you to the login, but there is no session expiry time. This causes a NaN error leading to a white screen. 

### How to review

Run Florence.
Go to /florence/users without signing in
Observe how it redirects you to the login screen

### Who can review

React/JS Dev.