### PR TITLE
Fix "Preview teams" navbar tab logic

### DIFF
--- a/src/legacy/js/functions/_viewController.js
+++ b/src/legacy/js/functions/_viewController.js
@@ -48,9 +48,9 @@ function viewController(view) {
         else if (view === 'teams') {
             if (Florence.globalVars.config.enableNewSignIn) {
                 window.location.pathname = "/florence/groups";
-                return;
+            } else {
+                window.location.pathname = "/florence/teams";
             }
-            window.location.pathname = "/florence/teams";
         }
         else if (view === 'login') {
             window.location.pathname = "/florence/login";


### PR DESCRIPTION
### What

Fix "Preview teams" navbar tab logic so that it goes to `/groups` OR `/teams` depending on feature flag

### Who can review

Anyone
