### PR TITLE
Fix/calendar entry publish date

### DIFF
--- a/src/app/views/collections/schedule-by-release/ScheduleByRelease.jsx
+++ b/src/app/views/collections/schedule-by-release/ScheduleByRelease.jsx
@@ -104,10 +104,10 @@ export class ScheduleByRelease extends Component {
 
                 return {
                     id: release.uri,
-                    columnValues: [title, date.format(release.description.releaseDate, "dddd, dd/mm/yyyy h:MMTT")],
+                    columnValues: [title, date.format(release.description.release_date, "dddd, dd/mm/yyyy h:MMTT")],
                     returnValue: {
                         uri: release.uri,
-                        releaseDate: release.description.releaseDate,
+                        releaseDate: release.description.release_date,
                         title,
                         isProvisional: !release.description.finalised,
                     },

--- a/src/app/views/collections/schedule-by-release/ScheduleByRelease.jsx
+++ b/src/app/views/collections/schedule-by-release/ScheduleByRelease.jsx
@@ -101,13 +101,15 @@ export class ScheduleByRelease extends Component {
                 //TODO check whether the release is already associated to a collection
 
                 const title = release.description.title.replace(/<\/?[^>]+(>|$)/g, ""); // remove any <strong> tags added on by Babbage's response
+                const releaseDate = release.description.release_date;
+                const formattedDate = releaseDate ? date.format(releaseDate, "dddd, dd/mm/yyyy h:MMTT") : "";
 
                 return {
                     id: release.uri,
-                    columnValues: [title, date.format(release.description.release_date, "dddd, dd/mm/yyyy h:MMTT")],
+                    columnValues: [title, formattedDate],
                     returnValue: {
                         uri: release.uri,
-                        releaseDate: release.description.release_date,
+                        releaseDate: releaseDate,
                         title,
                         isProvisional: !release.description.finalised,
                     },

--- a/src/app/views/collections/schedule-by-release/ScheduleByRelease.test.js
+++ b/src/app/views/collections/schedule-by-release/ScheduleByRelease.test.js
@@ -21,7 +21,7 @@ jest.mock("../../../utilities/api-clients/releases", () => ({
                     uri: "/releases/my-release",
                     description: {
                         title: "My release",
-                        releaseDate: "2018-05-17T09:30:54.928Z",
+                        release_date: "2018-05-17T09:30:54.928Z",
                         finalised: true,
                     },
                 },
@@ -29,7 +29,7 @@ jest.mock("../../../utilities/api-clients/releases", () => ({
                     uri: "/releases/my-second-release",
                     description: {
                         title: "My second release",
-                        releaseDate: "2018-05-20T09:30:54.928Z",
+                        release_date: "2018-05-20T09:30:54.928Z",
                         finalised: true,
                     },
                 },
@@ -37,7 +37,7 @@ jest.mock("../../../utilities/api-clients/releases", () => ({
                     uri: "/releases/my-third-release",
                     description: {
                         title: "My third release",
-                        releaseDate: "2018-05-21T09:30:54.928Z",
+                        release_date: "2018-05-21T09:30:54.928Z",
                         finalised: true,
                     },
                 },
@@ -59,7 +59,7 @@ const mockedReleases = [
         uri: "/releases/my-release",
         description: {
             title: "My release",
-            releaseDate: "2018-05-17T09:30:54.928Z",
+            release_date: "2018-05-17T09:30:54.928Z",
             finalised: true,
         },
     },
@@ -67,7 +67,7 @@ const mockedReleases = [
         uri: "/releases/my-second-release",
         description: {
             title: "My second release",
-            releaseDate: "2018-05-20T09:30:54.928Z",
+            release_date: "2018-05-20T09:30:54.928Z",
             finalised: true,
         },
     },
@@ -75,7 +75,7 @@ const mockedReleases = [
         uri: "/releases/my-third-release",
         description: {
             title: "My third release",
-            releaseDate: "2018-05-21T09:30:54.928Z",
+            release_date: "2018-05-21T09:30:54.928Z",
             finalised: true,
         },
     },
@@ -256,7 +256,7 @@ describe("Loading more releases", () => {
                         uri: "/releases/my-fourth-release",
                         description: {
                             title: "My fourth release",
-                            releaseDate: "2018-05-17T09:30:54.928Z",
+                            release_date: "2018-05-17T09:30:54.928Z",
                             finalised: true,
                         },
                     },
@@ -264,7 +264,7 @@ describe("Loading more releases", () => {
                         uri: "/releases/my-fifth-release",
                         description: {
                             title: "My fifth release",
-                            releaseDate: "2018-05-17T09:30:54.928Z",
+                            release_date: "2018-05-17T09:30:54.928Z",
                             finalised: true,
                         },
                     },
@@ -272,7 +272,7 @@ describe("Loading more releases", () => {
                         uri: "/releases/my-sixth-release",
                         description: {
                             title: "My sixth release",
-                            releaseDate: "2018-05-17T09:30:54.928Z",
+                            release_date: "2018-05-17T09:30:54.928Z",
                             finalised: true,
                         },
                     },

--- a/src/app/views/collections/schedule-by-release/ScheduleByRelease.test.js
+++ b/src/app/views/collections/schedule-by-release/ScheduleByRelease.test.js
@@ -189,21 +189,6 @@ describe("Mapping releases response to table", () => {
         expect(component.instance().mapReleasesToTableRows(releasesWithHTMLTags)[0].returnValue.title).toBe("My tagged release");
     });
 
-    it("handles blank dates", () => {
-        const releasesWithBlankDates = [
-            {
-                uri: "/releases/my-release-with-blank-date",
-                description: {
-                    title: "My release with blank date",
-                    release_date: "",
-                    finalised: true,
-                },
-            },
-        ];
-
-        expect(component.instance().mapReleasesToTableRows(releasesWithBlankDates)[0].columnValues[1]).toBe("");
-    });
-
     it("handles no dates", () => {
         const releasesWithoutReleaseDate = [
             {
@@ -215,7 +200,7 @@ describe("Mapping releases response to table", () => {
             },
         ];
 
-        expect(component.instance().mapReleasesToTableRows(releasesWithoutReleaseDate)[0].returnValue.releaseDate).toBe("");
+        expect(component.instance().mapReleasesToTableRows(releasesWithoutReleaseDate)[0].columnValues[1]).toBe("");
     });
 });
 

--- a/src/app/views/collections/schedule-by-release/ScheduleByRelease.test.js
+++ b/src/app/views/collections/schedule-by-release/ScheduleByRelease.test.js
@@ -188,6 +188,35 @@ describe("Mapping releases response to table", () => {
 
         expect(component.instance().mapReleasesToTableRows(releasesWithHTMLTags)[0].returnValue.title).toBe("My tagged release");
     });
+
+    it("handles blank dates", () => {
+        const releasesWithBlankDates = [
+            {
+                uri: "/releases/my-release-with-blank-date",
+                description: {
+                    title: "My release with blank date",
+                    release_date: "",
+                    finalised: true,
+                },
+            },
+        ];
+
+        expect(component.instance().mapReleasesToTableRows(releasesWithBlankDates)[0].columnValues[1]).toBe("");
+    });
+
+    it("handles no dates", () => {
+        const releasesWithoutReleaseDate = [
+            {
+                uri: "/releases/my-release-without-date",
+                description: {
+                    title: "My release without date",
+                    finalised: true,
+                },
+            },
+        ];
+
+        expect(component.instance().mapReleasesToTableRows(releasesWithoutReleaseDate)[0].returnValue.releaseDate).toBe("");
+    });
 });
 
 describe("Searching releases", () => {


### PR DESCRIPTION
### What

This fixes an issue with calendar entries showing the incorrect date. The issue was from this previous [pr](https://github.com/ONSdigital/florence/pull/1037).
This also handles no date to default to a blank date now.

### How to review

- Grab this branch
- Run the search stack
- Run florence
- Login
- Check "Calendar entry schedule"
- Dates should be showing correctly and not just todays date.

**Before**
![image](https://github.com/user-attachments/assets/25c43227-cb93-40fc-8ab2-8c5223f363ee)

**After**
![image](https://github.com/user-attachments/assets/a124a679-2103-4c79-84ff-d84f107a4cae)


### Who can review

Florence dev
