### PR TITLE
Fix removal of access_token cookie

### DIFF
--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -205,16 +205,16 @@ export default class user {
 
     static logOut() {
         function clearCookies() {
-            const accessTokenCookieRemoved = cookies.remove("access_token");
-            if (!accessTokenCookieRemoved) {
-                if (!config.enableNewSignIn) {
+            if (!config.enableNewSignIn) {
+                const accessTokenCookieRemoved = cookies.remove("access_token");
+                if (!accessTokenCookieRemoved) {
+                    console.warn(`Error trying to remove 'access_token' cookie`);
                     user.deleteCookies()
                         .then(function () {
                             console.debug("[FLORENCE] Deleted HTTP Cookies");
                         })
                         .catch(err => console.error(err));
                 }
-                console.warn(`Error trying to remove 'access_token' cookie`);
             }
             if (cookies.get("collection")) {
                 cookies.remove("collection");

--- a/src/legacy/js/functions/_logout.js
+++ b/src/legacy/js/functions/_logout.js
@@ -16,8 +16,9 @@ async function logout(currentPath) {
             sweetAlert("Unexpected error occurred during sign out");
             console.error("Error occurred sending DELETE to /tokens/self");
         }
+    } else {
+        delete_cookie('access_token');
     }
-    delete_cookie('access_token');
     delete_cookie('collection');
     removeAuthState();
 


### PR DESCRIPTION
### What

Stopped JS trying to remove access_token as HttpOnly. Clears errors and ensures tokens removed on logout. 

### How to review

Run Florence in NewSignIn mode and port forward to sandbox api router. 
Sign in, observe cookies, sign out. Check access_token is gone. Do the same from old Florence too. 

### Who can review

Florence dev. 