### PR TITLE
Remove warnings for unauthenticated signout

### DIFF
--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -232,24 +232,10 @@ export default class user {
             user.expireSession()
                 .catch(error => {
                     if (error.status === 400) {
-                        const notification = {
-                            type: "warning",
-                            message: "An error occurred during sign out 'InvalidToken', please contact a system administrator",
-                            isDismissable: true,
-                            autoDismiss: 20000,
-                        };
-                        notifications.add(notification);
-                        console.error("Error occurred sending DELETE to /tokens/self - InvalidToken");
+                        console.warning("Error occurred sending DELETE to /tokens/self - InvalidToken");
                         log.event("error on sign out sending delete to /tokens/self failed with an invalid token", log.error(error));
                     } else {
-                        const notification = {
-                            type: "warning",
-                            message: "Unexpected error occurred during sign out",
-                            isDismissable: true,
-                            autoDismiss: 20000,
-                        };
-                        notifications.add(notification);
-                        console.error("Error occurred sending DELETE to /tokens/self");
+                        console.warning("Error occurred sending DELETE to /tokens/self");
                         log.event("error on sign out sending delete to /tokens/self failed with an unexpected error", log.error(error));
                     }
                     clearCookies();

--- a/src/legacy/js/functions/_logout.js
+++ b/src/legacy/js/functions/_logout.js
@@ -10,11 +10,9 @@ async function logout(currentPath) {
             }
         })
         if (res.status === 400) {
-            sweetAlert("An error occurred during sign out 'InvalidToken', please contact a system administrator");
-            console.error("Error occurred sending DELETE to /tokens/self - InvalidToken");
+            console.warning("Error occurred sending DELETE to /tokens/self - InvalidToken");
         } else if (res.status !== 204) {
-            sweetAlert("Unexpected error occurred during sign out");
-            console.error("Error occurred sending DELETE to /tokens/self");
+            console.warning("Error occurred sending DELETE to /tokens/self");
         }
     } else {
         delete_cookie('access_token');


### PR DESCRIPTION
### What

Removed warnings and console errors for unauthenticated timeout.

### How to review

Port forward to api router in sandbox publishing.
Run florence with enableNewSignIn: true
Login
Wait for 1h16m ensuring your tunnel remains open.
Click a button in Florence.
Observe logout now doesn't throw hundreds of errors.

### Who can review

Florence dev. 