### PR TITLE
feature/login redirect

### DIFF
--- a/src/app/utilities/redirect.js
+++ b/src/app/utilities/redirect.js
@@ -18,9 +18,12 @@ export default function redirectToMainScreen(screen) {
     }
 
     if (
-        screen.startsWith(`${rootPath}/teams`) ||
-        screen.startsWith(`${rootPath}/datasets`) ||
         screen.startsWith(`${rootPath}/collections`) ||
+        screen.startsWith(`${rootPath}/datasets`) ||
+        screen.startsWith(`${rootPath}/groups`) ||
+        screen.startsWith(`${rootPath}/security`) ||
+        screen.startsWith(`${rootPath}/teams`) ||
+        screen.startsWith(`${rootPath}/uploads`) ||
         screen.startsWith(`${rootPath}/users`)
     ) {
         browserHistory.push(screen);

--- a/src/index.js
+++ b/src/index.js
@@ -231,6 +231,11 @@ const Index = () => {
                     {config.enableNewSignIn && <Route path={`${rootPath}/security`} exact component={userIsAuthenticated(userIsAdmin(Security))}/>}
                     {config.enableNewSignIn && <Route path={`${rootPath}/groups/create`} exact component={userIsAuthenticated(userIsAdmin(CreateTeam))}/>}
                     {config.enableNewSignIn && <Route path={`${rootPath}/groups/:id`} component={userIsAuthenticated(EditGroup)}/>}
+                    {/* legacy paths, stops the "not found" view from showing when loading */}
+                    <Route path={`${rootPath}/publishing-queue`} component={<></>} />
+                    <Route path={`${rootPath}/reports`} component={<></>} />
+                    <Route path={`${rootPath}/workspace`} component={<></>} />
+                    
                     <Route path="*" component={NotFound} />
                 </Route>
             </Router>


### PR DESCRIPTION
### What

This [ticket](https://jira.ons.gov.uk/browse/DIS-1672) was to investigate not all login redirects working correctly.

**Notes:**
- `/publishing-queue`, `/reports`, and `/workspace` all use a legacy. method to serve their html, and so render slightly different to the others. The legacy method causes a full page reload, so behaviour looks different to the others.
    - ~With some experimenting, it looks like you could potentially update these legacy pages.~
    - Added routes for legacy pages, should stop `not found` popping up on redirects. Was unable to reproduce this locally though, and could only see it in sandbox - https://publishing.dp.aws.onsdigital.uk/florence/login?redirect=/florence/publishing-queue
- For future potential integration with Wagtail and Discoverable Datasets, we could add something to `redirect.js` like the below to allow for external paths, outside Florence.
```
if (!screen.startsWith(`${rootPath}`)) {
    browserHistory.push(screen);
    return;
}
```

### How to review

Sense check.
Run florence

- http://localhost:8081/florence/login?redirect=/florence/uploads/data
- http://localhost:8081/florence/login?redirect=/florence/groups
- http://localhost:8081/florence/login?redirect=/florence/security
- http://localhost:8081/florence/login?redirect=/florence/testing123 - will take you to /collections

Did I miss any pages?

### Who can review

Anyone
