### PR TITLE
Add nvm to makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 BIND_ADDR ?= :8081
 BINPATH ?= build
+NVM_SOURCE_PATH ?= $(HOME)/.nvm/nvm.sh
+
+ifneq ("$(wildcard $(NVM_SOURCE_PATH))","")
+	NVM_EXEC = source $(NVM_SOURCE_PATH) && nvm exec --
+endif
+NPM = $(NVM_EXEC) npm
 
 BUILD_TIME=$(shell date +%s)
 GIT_COMMIT=$(shell git rev-parse HEAD)
@@ -10,8 +16,8 @@ LDFLAGS=-ldflags "-w -s -X 'main.Version=${VERSION}' -X 'main.BuildTime=$(BUILD_
 .PHONY: audit
 audit: node-modules
 	go list -m all | nancy sleuth
-	cd src; npm run audit
-	cd src/legacy; npm run audit
+	cd src; $(NPM) run audit
+	cd src/legacy; $(NPM) run audit
 
 .PHONY: build
 build: node-modules generate-go-prod
@@ -59,27 +65,27 @@ test-go:
 
 .PHONY: test-npm
 test-npm: node-modules-react
-	cd src; npm run test
+	cd src; $(NPM) run test
 
 .PHONY: test-pretty
 test-pretty: node-modules-react
-	cd src; npm run prettier-test
+	cd src; $(NPM) run prettier-test
 
 .PHONY: node-modules
 node-modules: node-modules-react node-modules-legacy
 
 .PHONY: node-modules-react
 node-modules-react:
-	cd src; npm install --unsafe-perm --legacy-peer-deps
+	cd src; $(NPM) install --unsafe-perm --legacy-peer-deps
 
 .PHONY: node-modules-legacy
 node-modules-legacy:
-	cd src/legacy; npm install --unsafe-perm --legacy-peer-deps
+	cd src/legacy; $(NPM) install --unsafe-perm --legacy-peer-deps
 
 .PHONY: watch-src
 watch-src:
 	make node-modules
-	cd src; npm run watch
+	cd src; $(NPM) run watch
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,27 @@ The publishing platform used for the [ONS website](https://www.ons.gov.uk).
 
 ## Getting started
 
-To run Florence you must have [Golang](https://golang.org/) installed on a UNIX machine.
+To run Florence you must have:
+
+1. [Golang](https://golang.org/) installed:
+
+   ```shell
+   brew install go
+   ```
+
+1. [nvm](https://github.com/nvm-sh/nvm) installed:
+
+   ```shell
+   brew install nvm
+   ```
+
+   :warning: Make sure to follow the instructions provided at the end of the install to configure up your shell profile.
+
+1. The node version specified in [`.nvmrc`](./.nvmrc) installed through nvm:
+
+   ```shell
+   nvm install
+   ```
 
 Once you have installed those dependencies and cloned this repo you need to run the following:
 
@@ -68,7 +88,7 @@ There are other ONS digital applications that you'll need to run to allow Floren
 - Update JS, CSS and other source file changes
 
    ```shell
-   make node-modules 
+   make node-modules
    ```
 
 ### Configuration


### PR DESCRIPTION
### What

Add nvm to makefile targets to remove the need to remember to run `nvm use` everytime you switch to the repo. This also makes it quicker and easier to switch between working on different applications with differing node version.

Update the readme to highlight the steps to install nvm.

### How to review

Ensure all make targets work correctly and that the correct node version is used (nvm outputs version used to stdout).
Review the README changes.

### Who can review

!me