### PR TITLE
fix/session expired check

### DIFF
--- a/src/app/config/user/userHooks.js
+++ b/src/app/config/user/userHooks.js
@@ -30,23 +30,27 @@ export const useGetPermissions = (props, authState, setShouldUpdateAccessToken) 
 
 export const useUpdateTimers = (props, sessionTimerIsActive, dispatch) => {
     useEffect(() => {
-        if (!nonAuthRoutes.includes(props.location.pathname) && !sessionTimerIsActive) {
-            if (isSessionExpired()) {
-                console.debug("Timers : requesting a new access_token");
-                user.renewSession()
-                    .then(res => {
-                        // update the authState, start the session timer with the nest session response value
-                        // & restart the refresh timer with the existing refresh value.
-                        const expirationTime = fp.get("expirationTime")(res);
-                        SessionManagement.initialiseSessionExpiryTimers(expirationTime);
-                    })
-                    .catch(err => console.error(err));
-            } else {
-                console.debug("[FLORENCE] Timers: starting timers");
-                // The user has refreshed the page but the session is not expired, so just restart the timers
-                // for both refresh & session.
-                SessionManagement.initialiseSessionExpiryTimers();
+        const updateTimers = async () => {
+            if (!nonAuthRoutes.includes(props.location.pathname) && !sessionTimerIsActive) {
+                if (await isSessionExpired()) {
+                    console.debug("[FLORENCE] Timers : requesting a new access_token");
+                    user.renewSession()
+                        .then(res => {
+                            // update the authState, start the session timer with the new session response value
+                            // & restart the refresh timer with the existing refresh value.
+                            const expirationTime = fp.get("expirationTime")(res);
+                            SessionManagement.initialiseSessionExpiryTimers(expirationTime);
+                        })
+                        .catch(err => console.error(err));
+                } else {
+                    console.debug("[FLORENCE] Timers: starting timers");
+                    // The user has refreshed the page but the session is not expired, so just restart the timers
+                    // for both refresh & session.
+                    SessionManagement.initialiseSessionExpiryTimers();
+                }
             }
-        }
+        };
+
+        updateTimers();
     }, [sessionTimerIsActive]);
 };


### PR DESCRIPTION
### What

This fixes an issue when moving from legacy and isSessionExpired not acting as expected.

### How to review

Run florence

- port forward to the api router - `dp ssh sandbox publishing 2 -p 23200:localhost:10800`
- `make dev` in florence

Check console logs
Click "Publishing queue" button
Click "Collections"
In logs you should see "Session is not expired."

![image](https://github.com/user-attachments/assets/1aad2368-6576-4389-a406-fdb42505fcc8)


### Who can review

Not me
