### PR TITLE
Feature/migrate identity api proxy to use api router proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ The following environment variables are available when running the Go server.
 
 | Environment variable         | Default                           | Description
 |------------------------------|-----------------------------------|------------
+| API_ROUTER_URL               | <http://localhost:23200> | The URL of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)  
 | BIND_ADDR                    | :8080                             | Host and port to bind to. **Note**: running `make debug` will run Florence on `:8081`
 | ROUTER_URL                   | http://localhost:20000            | URL that the [frontend router](https://github.com/ONSdigital/dp-frontend-router) can be accessed on
 | ZEBEDEE_URL                  | http://localhost:8082             | URL that [Zebedee](https://github.com/ONSdigital/zebedee) can be accessed on
@@ -116,6 +117,7 @@ The following envrionment variables are available when running the Go server and
 | Environment variable      | Default | Description
 |---------------------------|---------|------------
 | ALLOWED_EXTERNAL_PATHS    | []string| Permitted external primary path and subpath from Florence e.g. primary path `/data-admin` allows `/data-admin/*`
+| API_ROUTER_VERSION        | v1      | The version of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)
 | ENABLE_NEW_UPLOAD         | false   | Enables the image upload functionality via static files service
 | ENABLE_PERMISSION_API     | false   |
 | ENABLE_CANTABULAR_JOURNEY | false   | Enables the cantabular journey

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The following environment variables are available when running the Go server.
 
 | Environment variable         | Default                           | Description
 |------------------------------|-----------------------------------|------------
-| API_ROUTER_URL               | <http://localhost:23200> | The URL of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)  
+| API_ROUTER_URL               | <http://localhost:23200>          | The URL of the [dp-api-router](https://github.com/ONSdigital/dp-api-router)  
 | BIND_ADDR                    | :8080                             | Host and port to bind to. **Note**: running `make debug` will run Florence on `:8081`
 | ROUTER_URL                   | http://localhost:20000            | URL that the [frontend router](https://github.com/ONSdigital/dp-frontend-router) can be accessed on
 | ZEBEDEE_URL                  | http://localhost:8082             | URL that [Zebedee](https://github.com/ONSdigital/zebedee) can be accessed on

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ type Config struct {
 // SharedConfig represents the configuration made available to the client-side application from the server
 type SharedConfig struct {
 	AllowedExternalPaths    []string `envconfig:"ALLOWED_EXTERNAL_PATHS" json:"allowedExternalPaths"`
+	APIRouterVersion        string   `envconfig:"API_ROUTER_VERSION" json:"apiRouterVersion"`
 	EnableNewUpload         bool     `envconfig:"ENABLE_NEW_UPLOAD" json:"enableNewUpload"`
 	EnablePermissionsAPI    bool     `envconfig:"ENABLE_PERMISSION_API" json:"enablePermissionsAPI"`
 	EnableCantabularJourney bool     `envconfig:"ENABLE_CANTABULAR_JOURNEY" json:"enableCantabularJourney"`
@@ -52,6 +53,7 @@ func Get() (*Config, error) {
 		EnableWagtailProxy:   false,
 		SharedConfig: SharedConfig{
 			AllowedExternalPaths:    []string{},
+			APIRouterVersion:        "v1",
 			EnableNewUpload:         false,
 			EnablePermissionsAPI:    false,
 			EnableCantabularJourney: false,

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,6 @@ import (
 type Config struct {
 	BindAddr                   string        `envconfig:"BIND_ADDR"`
 	APIRouterURL               string        `envconfig:"API_ROUTER_URL"`
-	APIRouterVersion           string        `envconfig:"API_ROUTER_VERSION"`
 	FrontendRouterURL          string        `envconfig:"ROUTER_URL"`
 	DatasetControllerURL       string        `envconfig:"DATASET_CONTROLLER_URL"`
 	TableRendererURL           string        `envconfig:"TABLE_RENDERER_URL"`
@@ -44,7 +43,6 @@ func Get() (*Config, error) {
 	cfg = &Config{
 		BindAddr:             ":8080",
 		APIRouterURL:         "http://localhost:23200",
-		APIRouterVersion:     "v1",
 		FrontendRouterURL:    "http://localhost:20000",
 		DatasetControllerURL: "http://localhost:24000",
 		TableRendererURL:     "http://localhost:23300",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,7 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 				EnableNewUpload:         false,
 				EnableCantabularJourney: false,
 				EnableDataAdmin:         true,
+				APIRouterVersion:        "v1",
 			},
 			GracefulShutdownTimeout:    10 * time.Second,
 			HealthCheckInterval:        30 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,7 +17,6 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 		So(configuration, ShouldResemble, &Config{
 			BindAddr:             ":8080",
 			APIRouterURL:         "http://localhost:23200",
-			APIRouterVersion:     "v1",
 			FrontendRouterURL:    "http://localhost:20000",
 			DatasetControllerURL: "http://localhost:24000",
 			TableRendererURL:     "http://localhost:23300",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,10 +26,10 @@ func TestGetRetrunsDefaultValues(t *testing.T) {
 			EnableWagtailProxy:   false,
 			SharedConfig: SharedConfig{
 				AllowedExternalPaths:    []string{},
+				APIRouterVersion:        "v1",
 				EnableNewUpload:         false,
 				EnableCantabularJourney: false,
 				EnableDataAdmin:         true,
-				APIRouterVersion:        "v1",
 			},
 			GracefulShutdownTimeout:    10 * time.Second,
 			HealthCheckInterval:        30 * time.Second,

--- a/directors/directors.go
+++ b/directors/directors.go
@@ -73,7 +73,7 @@ func setHeaders(req *http.Request) {
 		}
 	}
 
-	if req.URL.Path == "/groups-report" {
+	if req.URL.Path == "/api/v1/groups-report" {
 		if err := headers.SetAccept(req, "text/csv"); err != nil {
 			log.Event(req.Context(), "unable to set accept header", log.Error(err), log.ERROR)
 		}

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -242,7 +242,7 @@ func TestIndexFile(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":["/test/path","/another/test/path"],"apiRouterVersion":'v1',"enableNewUpload":true,"enablePermissionsAPI":true,"enableCantabularJourney":true,"enableDataAdmin":true}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":["/test/path","/another/test/path"],"apiRouterVersion":"v1","enableNewUpload":true,"enablePermissionsAPI":true,"enableCantabularJourney":true,"enableDataAdmin":true}`), ShouldBeTrue)
 		})
 
 		Convey("Shared config written into refactored HTML contains the correct config", func() {
@@ -271,7 +271,7 @@ func TestIndexFile(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"apiRouterVersion":'v1',"enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"apiRouterVersion":"","enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
 
 		})
 
@@ -282,7 +282,7 @@ func TestIndexFile(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"apiRouterVersion":'v1',"enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"apiRouterVersion":"","enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
 		})
 
 	})

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -219,6 +219,7 @@ func TestIndexFile(t *testing.T) {
 					"/test/path",
 					"/another/test/path",
 				},
+				APIRouterVersion:        "v1",
 				EnableNewUpload:         true,
 				EnablePermissionsAPI:    true,
 				EnableCantabularJourney: true,
@@ -241,7 +242,7 @@ func TestIndexFile(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":["/test/path","/another/test/path"],"enableNewUpload":true,"enablePermissionsAPI":true,"enableCantabularJourney":true,"enableDataAdmin":true}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":["/test/path","/another/test/path"],"apiRouterVersion":'v1',"enableNewUpload":true,"enablePermissionsAPI":true,"enableCantabularJourney":true,"enableDataAdmin":true}`), ShouldBeTrue)
 		})
 
 		Convey("Shared config written into refactored HTML contains the correct config", func() {
@@ -270,7 +271,7 @@ func TestIndexFile(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"apiRouterVersion":'v1',"enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
 
 		})
 
@@ -281,7 +282,7 @@ func TestIndexFile(t *testing.T) {
 			So(err, ShouldBeNil)
 			html := string(body)
 			So(strings.Contains(html, "/* environment variables placeholder */"), ShouldBeFalse)
-			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
+			So(strings.Contains(html, `/* server generated shared config */ {"allowedExternalPaths":null,"apiRouterVersion":'v1',"enableNewUpload":false,"enablePermissionsAPI":false,"enableCantabularJourney":false,"enableDataAdmin":false}`), ShouldBeTrue)
 		})
 
 	})

--- a/service/modifiers/identity_test.go
+++ b/service/modifiers/identity_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIdentityResponseModifier(t *testing.T) {
-
+	const apiRouterVersion = "v1"
 	Convey("Given a response that was successful and all headers are present, all 'set-cookie' headers should"+
 		" be set", t, func() {
 		initialHeaders := http.Header{
@@ -27,11 +27,11 @@ func TestIdentityResponseModifier(t *testing.T) {
 			Request: &http.Request{
 				Method: http.MethodPut,
 				URL: &url.URL{
-					Path: "/tokens/self",
+					Path: "/api/v1/tokens/self",
 				},
 			},
 		}
-		err := modifiers.IdentityResponseModifier(inBoundResponse)
+		err := modifiers.IdentityResponseModifier(apiRouterVersion)(inBoundResponse)
 		cookieValues := inBoundResponse.Header.Values("Set-Cookie")
 		var refreshTokenHeader string
 		var idTokenHeader string
@@ -51,7 +51,7 @@ func TestIdentityResponseModifier(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(userAuthTokenHeader, ShouldEqual, "access_token=foo; Path=/; HttpOnly; Secure; SameSite=Strict")
 		So(idTokenHeader, ShouldEqual, "id_token=bar; Path=/; Secure; SameSite=Lax")
-		So(refreshTokenHeader, ShouldEqual, "refresh_token=baz; Path=/tokens/self; HttpOnly; Secure; SameSite=Strict")
+		So(refreshTokenHeader, ShouldEqual, "refresh_token=baz; Path=/api/v1/tokens/self; HttpOnly; Secure; SameSite=Strict")
 	})
 	Convey("Given a response that was unsuccessful do not set the set-cookie headers", t, func() {
 		initialHeaders := http.Header{
@@ -66,11 +66,11 @@ func TestIdentityResponseModifier(t *testing.T) {
 			Request: &http.Request{
 				Method: http.MethodPut,
 				URL: &url.URL{
-					Path: "/tokens/self",
+					Path: "/api/v1/tokens/self",
 				},
 			},
 		}
-		err := modifiers.IdentityResponseModifier(inBoundResponse)
+		err := modifiers.IdentityResponseModifier(apiRouterVersion)(inBoundResponse)
 		cookieValues := inBoundResponse.Header.Values("Set-Cookie")
 		So(err, ShouldBeNil)
 		So(cookieValues, ShouldBeNil)

--- a/service/service.go
+++ b/service/service.go
@@ -118,7 +118,7 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	}
 
 	frontendRouterProxy := reverseproxy.Create(frontendRouterURL, directors.Director(""), nil)
-	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), modifiers.IdentityResponseModifier)
+	apiRouterProxy := reverseproxy.Create(apiRouterURL, directors.Director("/api"), modifiers.IdentityResponseModifier(cfg.SharedConfig.APIRouterVersion))
 	tableProxy := reverseproxy.Create(tableURL, directors.Director("/table"), nil)
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, directors.Director("/dataset-controller"), nil)
 	dataAdminProxy := reverseproxy.Create(dataAdminURL, directors.Director("/data-admin"), nil)
@@ -135,7 +135,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	uploadServiceAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
 	filesAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
 	downloadServiceProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
-	identityAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), modifiers.IdentityResponseModifier)
 	// End of deprecated proxies
 
 	router = mux.NewRouter()
@@ -159,17 +158,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	if cfg.SharedConfig.EnableCantabularJourney {
 		router.Handle("/cantabular-metadata/{uri:.*}", cantabularMetadataExtractorAPIProxy)
 	}
-
-	// auth endpoints
-	router.Handle("/tokens", identityAPIProxy)
-	router.Handle("/tokens/{uri:.*}", identityAPIProxy)
-	router.Handle("/users", identityAPIProxy)
-	router.Handle("/users/{uri:.*}", identityAPIProxy)
-	router.Handle("/groups/{uri:.*}", identityAPIProxy)
-	router.Handle("/groups", identityAPIProxy)
-	router.Handle("/groups-report", identityAPIProxy)
-	router.Handle("/password-reset", identityAPIProxy)
-	router.Handle("/password-reset/{uri:.*}", identityAPIProxy)
 
 	router.Handle("/image/{uri:.*}", imageAPIProxy)
 	router.Handle("/zebedee{uri:/.*}", zebedeeProxy)

--- a/service/service.go
+++ b/service/service.go
@@ -123,18 +123,18 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	datasetControllerProxy := reverseproxy.Create(datasetControllerURL, directors.Director("/dataset-controller"), nil)
 	dataAdminProxy := reverseproxy.Create(dataAdminURL, directors.Director("/data-admin"), nil)
 	wagtailProxy := reverseproxy.Create(wagtailURL, directors.Director("/wagtail"), nil)
-	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
+	cantabularMetadataExtractorAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
 
 	// The following proxies and their associated routes are deprecated and should be removed once the client side code has been updated to match
 	zebedeeProxy := reverseproxy.Create(apiRouterURL, directors.Director("/zebedee"), nil)
-	importAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, "/import"), nil)
-	datasetAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, "/dataset"), nil)
-	recipeAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
-	topicsProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
-	imageAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, "/image"), nil)
-	uploadServiceAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
-	filesAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
-	downloadServiceProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.APIRouterVersion, ""), nil)
+	importAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/import"), nil)
+	datasetAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/dataset"), nil)
+	recipeAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
+	topicsProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
+	imageAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/image"), nil)
+	uploadServiceAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
+	filesAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
+	downloadServiceProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
 	// End of deprecated proxies
 
 	router = mux.NewRouter()

--- a/src/app/config/initialState.js
+++ b/src/app/config/initialState.js
@@ -8,6 +8,7 @@ export const initialState = {
     },
     config: {
         allowedExternalPaths: [],
+        apiRouterVersion: "v1",
         enableNewUpload: false,
         enablePermissionsAPI: false,
         enableCantabularJourney: false,

--- a/src/app/utilities/api-clients/teams.js
+++ b/src/app/utilities/api-clients/teams.js
@@ -1,5 +1,7 @@
 import http from "../http";
 
+const API_PROXY_PATH = `/api/${window.getEnv().apiRouterVersion}`;
+
 export default class teams {
     static getAll() {
         return http.get(`/zebedee/teams`).then(response => {
@@ -40,61 +42,61 @@ export default class teams {
     // TODO: new auth work
 
     static createTeam(body) {
-        return http.post(`/groups`, body).then(response => {
+        return http.post(`${API_PROXY_PATH}/groups`, body).then(response => {
             return response;
         });
     }
 
     static addMemberToTeam(id, userID) {
-        return http.post(`/groups/${id}/members`, { user_id: userID }).then(response => {
+        return http.post(`${API_PROXY_PATH}/groups/${id}/members`, { user_id: userID }).then(response => {
             return response;
         });
     }
 
     static deleteMemberFromTeam(id, body) {
-        return http.post(`/groups/${id}/members`, body).then(response => {
+        return http.post(`${API_PROXY_PATH}/groups/${id}/members`, body).then(response => {
             return response;
         });
     }
 
     static getGroups() {
-        return http.get(`/groups?sort=name:asc`).then(response => {
+        return http.get(`${API_PROXY_PATH}/groups?sort=name:asc`).then(response => {
             return response;
         });
     }
 
     static getGroup(id) {
-        return http.get(`/groups/${id}`).then(response => {
+        return http.get(`${API_PROXY_PATH}/groups/${id}`).then(response => {
             return response;
         });
     }
 
     static updateGroup(id, body) {
-        return http.put(`/groups/${id}`, body).then(response => {
+        return http.put(`${API_PROXY_PATH}/groups/${id}`, body).then(response => {
             return response;
         });
     }
 
     static updateGroupMembers(id, body) {
-        return http.put(`/groups/${id}/members`, body).then(response => {
+        return http.put(`${API_PROXY_PATH}/groups/${id}/members`, body).then(response => {
             return response;
         });
     }
 
     static deleteGroup(id) {
-        return http.delete(`/groups/${id}`).then(response => {
+        return http.delete(`${API_PROXY_PATH}/groups/${id}`).then(response => {
             return response;
         });
     }
 
     static getGroupMembers(id) {
-        return http.get(`/groups/${id}/members?sort=forename:asc`).then(response => {
+        return http.get(`${API_PROXY_PATH}/groups/${id}/members?sort=forename:asc`).then(response => {
             return response;
         });
     }
 
     static addGroupsToUser(name, body) {
-        return http.post(`/groups/${name}`, body).then(response => {
+        return http.post(`${API_PROXY_PATH}/groups/${name}`, body).then(response => {
             return response;
         });
     }

--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -9,6 +9,8 @@ import SessionManagement from "dis-authorisation-client-js";
 import { errCodes as errorCodes, errCodes } from "../errorCodes";
 import { removeAuthState, setAuthState } from "../auth";
 
+const API_PROXY_PATH = `/api/${window.getEnv().apiRouterVersion}`;
+
 export default class user {
     static get(email) {
         return http.get(`/zebedee/users?email=${email}`);
@@ -25,7 +27,7 @@ export default class user {
             queryString = queryString ? `${queryString}&${key}=${params[key]}` : `?${key}=${params[key]}`;
         });
         try {
-            return await http.get(`/users${queryString}`);
+            return await http.get(`${API_PROXY_PATH}/users${queryString}`);
         } catch (error) {
             if (error.status) {
                 if (error.status >= 400 && error.status < 500) {
@@ -79,34 +81,34 @@ export default class user {
     };
 
     static create(body) {
-        return http.post(`/zebedee/users`, body);
+        return http.post(`${API_PROXY_PATH}/users`, body);
     }
 
     // TODO: new auth work
     static getUsers() {
-        return http.get(`/users?sort=forename:asc`);
+        return http.get(`${API_PROXY_PATH}/users?sort=forename:asc`);
     }
 
     // TODO: new auth work
     static createNewUser(body) {
-        return http.post(`/users`, body);
+        return http.post(`${API_PROXY_PATH}/users`, body);
     }
 
     static getUser(id) {
-        return http.get(`/users/${id}`);
+        return http.get(`${API_PROXY_PATH}/users/${id}`);
     }
 
     // TODO: new auth work
     static updateUser(id, body) {
-        return http.put(`/users/${id}`, body);
+        return http.put(`${API_PROXY_PATH}/users/${id}`, body);
     }
 
     static getUserGroups(id) {
-        return http.get(`/users/${id}/groups`);
+        return http.get(`${API_PROXY_PATH}/users/${id}/groups`);
     }
 
     static remove(email) {
-        return http.delete(`/zebedee/users?email=" + ${email}`);
+        return http.delete(`${API_PROXY_PATH}/users?email=" + ${email}`);
     }
 
     static setPassword(body) {
@@ -149,7 +151,7 @@ export default class user {
     }
 
     static setForgottenPassword(body) {
-        return http.put("/users/self/password", body, true, true);
+        return http.put(`${API_PROXY_PATH}/users/self/password`, body, true, true);
     }
 
     static renewSession(body) {

--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -142,12 +142,12 @@ export default class user {
     }
 
     static signIn(body) {
-        return http.post("/tokens", body, true, true, true);
+        return http.post(`${API_PROXY_PATH}/tokens`, body, true, true, true);
     }
 
     // TODO: new auth work
     static deleteTokens() {
-        return http.delete("/tokens");
+        return http.delete(`${API_PROXY_PATH}/tokens`);
     }
 
     static setForgottenPassword(body) {
@@ -155,11 +155,11 @@ export default class user {
     }
 
     static renewSession(body) {
-        return http.put("/tokens/self", body, true, false);
+        return http.put(`${API_PROXY_PATH}/tokens/self`, body, true, false);
     }
 
     static expireSession() {
-        return http.delete("/tokens/self", true, true);
+        return http.delete(`${API_PROXY_PATH}/tokens/self`, true, true);
     }
 
     // This is a temporary fix for 925: Login fails after going from new login to old login

--- a/src/app/views/groups/Groups.jsx
+++ b/src/app/views/groups/Groups.jsx
@@ -13,6 +13,7 @@ const Groups = props => {
     const { groups, isLoading, loadTeams } = props;
     const [search, setSearch] = useInput("");
     const isAdmin = props.loggedInUser.isAdmin || false;
+    const API_PROXY_PATH = `/api/${window.getEnv().apiRouterVersion}`;
 
     useEffect(() => {
         loadTeams();
@@ -51,7 +52,7 @@ const Groups = props => {
                                 <a
                                     class="btn btn--positive"
                                     download={`${date.format(Date.now(), "yyyymmdd-HHMM")}-groups-report`}
-                                    href="/groups-report"
+                                    href={`${API_PROXY_PATH}/groups-report`}
                                 >
                                     Export teams report
                                 </a>{" "}

--- a/src/app/views/groups/__snapshots__/Groups.test.jsx.snap
+++ b/src/app/views/groups/__snapshots__/Groups.test.jsx.snap
@@ -74,7 +74,7 @@ exports[`Groups matches the snapshot with empty props 1`] = `
         <a
           class="btn btn--positive"
           download="20171006-1445-groups-report"
-          href="/groups-report"
+          href="/api/v1/groups-report"
         >
           Export teams report
         </a>
@@ -168,7 +168,7 @@ exports[`Groups matches the snapshot with groups props 1`] = `
         <a
           class="btn btn--positive"
           download="20171006-1445-groups-report"
-          href="/groups-report"
+          href="/api/v1/groups-report"
         >
           Export teams report
         </a>

--- a/src/app/views/new-password/forgottenPasswordController.jsx
+++ b/src/app/views/new-password/forgottenPasswordController.jsx
@@ -10,6 +10,8 @@ const propTypes = {
     // dispatch: PropTypes.func.isRequired, // not used, can we remove?
 };
 
+const API_PROXY_PATH = `/api/${window.getEnv().apiRouterVersion}`;
+
 export class ForgottenPasswordController extends Component {
     constructor(props) {
         super(props);
@@ -102,7 +104,7 @@ export class ForgottenPasswordController extends Component {
     }
 
     postResetPassword(body) {
-        return http.post("/password-reset", body, true, true);
+        return http.post(`${API_PROXY_PATH}/password-reset`, body, true, true);
     }
 
     requestEmailChange(email) {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -19,7 +19,7 @@
         "jest-snapshot": "^27.4.2",
         "path": "^0.12.7",
         "react-select": "^5.4.0",
-        "dis-authorisation-client-js": "^0.2.0",
+        "dis-authorisation-client-js": "^1.0.0",
         "moment": "^2.29.1",
         "uuid": "^3.4.0",
         "react-dom": "^17.0.2",
@@ -18856,9 +18856,9 @@
       "dev": true
     },
     "node_modules/dis-authorisation-client-js": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/dis-authorisation-client-js/-/dis-authorisation-client-js-0.2.0.tgz",
-      "integrity": "sha512-7otG00NGebTfhgnb7Z1jv11QCvNDllqzcrmGnf9Z+ffzIeJnxkY/3D19hV5C0dwFm/S5a1W45WUgkqGsTYtjWg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dis-authorisation-client-js/-/dis-authorisation-client-js-1.0.0.tgz",
+      "integrity": "sha512-9vEul1cunTYuzxK0Zf9IttTSSZ+L67FzVJTzbKciU2mG3ss/3jxBWoCdkoQrW1gUIJnUSV17dNLIAcBVhdLO/A==",
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21"

--- a/src/package.json
+++ b/src/package.json
@@ -100,7 +100,7 @@
     "acorn": "^8.4.1",
     "auditjs": "^4.0.37",
     "dateformat": "^2.0.0",
-    "dis-authorisation-client-js": "^0.2.0",
+    "dis-authorisation-client-js": "^1.0.0",
     "dp-table-builder-ui": "^1.1.2",
     "is-empty-object": "^1.1.1",
     "jest-snapshot": "^27.4.2",

--- a/src/setupJest.js
+++ b/src/setupJest.js
@@ -24,5 +24,7 @@ Object.defineProperty(document, 'getElementById', {
 
 Object.defineProperty(window, 'getEnv', {
     writable: true,
-    value: jest.fn().mockImplementation(() => { }),
+    value: jest.fn().mockImplementation(() => ({
+        apiRouterVersion: "v1",
+    })),
 });


### PR DESCRIPTION
### What

[This](https://jira.ons.gov.uk/browse/DIS-2549) is to migrate identity API proxy to use API router proxy

### How to review

Run florence

- port forward to the api router - dp ssh sandbox publishing 2 -p 23200:localhost:10800
- make dev in florence

Sense check.
Tests pass.

Did I miss any endpoints?

- /tokens
- /tokens/self
- /users
- /users/{id}
- /users/{id}/groups
- /users/self/password
- /groups
- /groups/{id}
- /groups/{id}/members
- /groups/{id}/members/{user_id}
- /groups-report
- /password-reset

### Who can review

Not me
