### PR TITLE
Feature/remove duplicate notifications

### DIFF
--- a/src/app/utilities/notifications.js
+++ b/src/app/utilities/notifications.js
@@ -25,6 +25,12 @@ export default class notifications {
             return;
         }
 
+        const { notifications = [] } = store.getState().state || {};
+        const isDuplicate = notifications.some(n => n.message === notification.message);
+        if (isDuplicate) {
+            return;
+        }
+
         const config = {
             type: notification.type || "neutral",
             message: notification.message || "",

--- a/src/app/utilities/notifications.test.js
+++ b/src/app/utilities/notifications.test.js
@@ -126,3 +126,17 @@ fit("Does not add duplicate notifications", () => {
 
     mockNotificationsState = [];
 });
+
+test("Remove notification by ID works as expected", () => {
+    const mockNotification = {
+        message: "Remove me",
+    };
+
+    const id = notifications.add(mockNotification);
+    expect(mockNotificationsState.length).toBe(1);
+
+    notifications.remove(id);
+    expect(mockNotificationsState.length).toBe(0);
+
+    mockNotificationsState = [];
+});

--- a/src/app/utilities/notifications.test.js
+++ b/src/app/utilities/notifications.test.js
@@ -78,7 +78,7 @@ test("Button to dismiss notification is added to config correctly and included b
             isDismissable: false,
         },
         {
-            message: "Message 2",
+            message: "Message 3",
             isDismissable: true,
         },
     ];
@@ -111,6 +111,18 @@ test("Click 'dismiss' button removes that notfication from state", () => {
     }, 1000);
 
     jest.runAllTimers();
+
+    mockNotificationsState = [];
+});
+
+fit("Does not add duplicate notifications", () => {
+    const mockNotification = {
+        message: "Duplicate message",
+    };
+
+    notifications.add(mockNotification);
+    notifications.add(mockNotification);
+    expect(mockNotificationsState.length).toBe(1);
 
     mockNotificationsState = [];
 });


### PR DESCRIPTION
### What

This stops duplicate notifications from appearing.

### How to review

Best way I found to force duplicates was to (run on dev branch to see dupes):

- port forward to the api router - `dp ssh sandbox publishing 2 -p 23200:localhost:10800`
- `make dev` in florence
- login to florence
- stop port forwarding
- jump between the same tabs, 'Collections' and 'Datasets' will do
- Duplicate notifications shouldn't appear
- To get dupes to appear, redo steps from dev branch

**Media**
_Before_
![image](https://github.com/user-attachments/assets/8e1c23bc-88b3-44ad-ab01-eb5d3f96bc93)

_After_
![image](https://github.com/user-attachments/assets/bc572974-3ab7-4079-908e-b069d96de345)


### Who can review

Not me
