### PR TITLE
Fix notification dismiss

### DIFF
--- a/src/app/utilities/notifications.js
+++ b/src/app/utilities/notifications.js
@@ -25,8 +25,8 @@ export default class notifications {
             return;
         }
 
-        const { notifications = [] } = store.getState().state || {};
-        const isDuplicate = notifications.some(n => n.message === notification.message);
+        const currentNotifications = store.getState().state.notifications || [];
+        const isDuplicate = currentNotifications.some(n => n.message === notification.message);
         if (isDuplicate) {
             return;
         }


### PR DESCRIPTION
### What

Fixed issue with notifications class being overridden, causing them not to be able to dismiss. 

### How to review

Run Florence (`make debug && make watch-src`) - access /florence/collections to trigger notifications. Observe they are now dismissable. 

### Who can review

Not me. 