### PR TITLE
Feature/add next query param

### DIFF
--- a/src/app/utilities/redirect.js
+++ b/src/app/utilities/redirect.js
@@ -1,23 +1,54 @@
 import { browserHistory } from "react-router";
 import { store } from "../config/store";
-/**
- * Redirects to one of the main views in Florence - chooses whether it needs to redirect to old Florence or route within the new application
- *
- * @param {string} - The path of the view that we want to redirect to
- */
 
-export default function handleRedirect(redirectPath) {
-    if (!redirectPath) {
-        return internalRedirect();
+export default class redirect {
+    /**
+     * handle - chooses whether to redirect internally within Florence or to an external path
+     *
+     * @param {string} string path of the redirect
+     *
+     * @returns {action} performs either an internal or external redirect
+     */
+    static handle(redirectPath) {
+        if (!redirectPath) {
+            return internalRedirect();
+        }
+
+        const config = window.getEnv();
+        const allowedExternalPaths = config.allowedExternalPaths;
+        if (allowedExternalPaths.some(path => redirectPath.startsWith(path))) {
+            return externalRedirect(redirectPath);
+        }
+
+        return internalRedirect(redirectPath);
     }
 
-    const config = window.getEnv();
-    const allowedExternalPaths = config.allowedExternalPaths;
-    if (allowedExternalPaths.some(path => redirectPath.startsWith(path))) {
-        return externalRedirect(redirectPath);
-    }
+    /**
+     * getPath returns the redirect path from the query string with the key 'redirect' or 'next'
+     *
+     * @param {object} query string object
+     *
+     * @returns {string} redirect path
+     */
+    static getPath(queryStr) {
+        if (!queryStr) {
+            return "";
+        }
 
-    return internalRedirect(redirectPath);
+        if (queryStr.redirect && queryStr.next) {
+            return "";
+        }
+
+        if (queryStr.redirect) {
+            return queryStr.redirect;
+        }
+
+        if (queryStr.next) {
+            return queryStr.next;
+        }
+
+        return "";
+    }
 }
 
 function internalRedirect(redirectPath) {

--- a/src/app/utilities/redirect.test.js
+++ b/src/app/utilities/redirect.test.js
@@ -1,4 +1,4 @@
-import handleRedirect from "./redirect";
+import redirect from "./redirect";
 import { browserHistory } from "react-router";
 import { store } from "../config/store";
 
@@ -27,7 +27,7 @@ describe("given call to handleRedirect", () => {
     });
 
     it("when no redirect parameter provided then the default /florence/collections path is returned", () => {
-        handleRedirect();
+        redirect.handle();
         expect(browserHistory.push).toHaveBeenCalledWith(defaultPath);
     });
 
@@ -35,25 +35,25 @@ describe("given call to handleRedirect", () => {
         const redirectPath = "/external/path";
         delete window.location;
         window.location = { pathname: "" };
-        handleRedirect(redirectPath);
+        redirect.handle(redirectPath);
         expect(window.location.pathname).toBe(redirectPath);
     });
 
     it("when the redirect parameter is an unknown external path then the default /florence/collections path is returned", () => {
         const redirectPath = "/test/path";
-        handleRedirect(redirectPath);
+        redirect.handle(redirectPath);
         expect(browserHistory.push).toHaveBeenCalledWith(defaultPath);
     });
 
     it("when the redirect parameter has a known internal path then the given internal path is returned", () => {
         const redirectPath = "/florence/users";
-        handleRedirect(redirectPath);
+        redirect.handle(redirectPath);
         expect(browserHistory.push).toHaveBeenCalledWith(redirectPath);
     });
 
     it("when the redirect parameter has a unknown internal path then the default /florence/collections path is returned", () => {
         const redirectPath = "/florence/badpath";
-        handleRedirect(redirectPath);
+        redirect.handle(redirectPath);
         expect(browserHistory.push).toHaveBeenCalledWith(defaultPath);
     });
 });

--- a/src/app/utilities/redirect.test.js
+++ b/src/app/utilities/redirect.test.js
@@ -14,7 +14,7 @@ jest.mock("../config/store", () => ({
     },
 }));
 
-describe("given call to handleRedirect", () => {
+describe("redirect.handle", () => {
     const defaultPath = "/florence/collections";
     beforeEach(() => {
         jest.clearAllMocks();
@@ -26,12 +26,12 @@ describe("given call to handleRedirect", () => {
         });
     });
 
-    it("when no redirect parameter provided then the default /florence/collections path is returned", () => {
+    it("returns the default /florence/collections path when no redirect parameter provided", () => {
         redirect.handle();
         expect(browserHistory.push).toHaveBeenCalledWith(defaultPath);
     });
 
-    it("when the redirect parameter is in allowedExternalPaths then the given external path is returned", () => {
+    it("returns the external path when the redirect parameter is in allowedExternalPaths", () => {
         const redirectPath = "/external/path";
         delete window.location;
         window.location = { pathname: "" };
@@ -39,21 +39,52 @@ describe("given call to handleRedirect", () => {
         expect(window.location.pathname).toBe(redirectPath);
     });
 
-    it("when the redirect parameter is an unknown external path then the default /florence/collections path is returned", () => {
+    it("returns the default /florence/collections path when the redirect parameter is an unknown external path", () => {
         const redirectPath = "/test/path";
         redirect.handle(redirectPath);
         expect(browserHistory.push).toHaveBeenCalledWith(defaultPath);
     });
 
-    it("when the redirect parameter has a known internal path then the given internal path is returned", () => {
+    it("returns the given internal path when the redirect parameter is a known internal path", () => {
         const redirectPath = "/florence/users";
         redirect.handle(redirectPath);
         expect(browserHistory.push).toHaveBeenCalledWith(redirectPath);
     });
 
-    it("when the redirect parameter has a unknown internal path then the default /florence/collections path is returned", () => {
+    it("returns the default /florence/collections path when the redirect parameter is an unknown internal path", () => {
         const redirectPath = "/florence/badpath";
         redirect.handle(redirectPath);
         expect(browserHistory.push).toHaveBeenCalledWith(defaultPath);
+    });
+});
+
+describe("redirect.getPath", () => {
+    it("should return a blank path when no query string parameters are provided", () => {
+        expect(redirect.getPath(null)).toBe("");
+        expect(redirect.getPath(undefined)).toBe("");
+    });
+
+    it("should return a blank path when an empty object is provided", () => {
+        expect(redirect.getPath({})).toBe("");
+    });
+
+    it("should return an empty string if both redirect and next keys have values", () => {
+        const queryStr = { redirect: "/florence/users", next: "/wagtail/admin" };
+        expect(redirect.getPath(queryStr)).toBe("");
+    });
+
+    it("should return the redirect string if the redirect key has a value", () => {
+        const queryStr = { redirect: "/florence/uploads/data" };
+        expect(redirect.getPath(queryStr)).toBe("/florence/uploads/data");
+    });
+
+    it("should return the redirect string if the next key has a value", () => {
+        const queryStr = { next: "/wagtail" };
+        expect(redirect.getPath(queryStr)).toBe("/wagtail");
+    });
+
+    it("should return an empty string if an unexpected redirect key is provided", () => {
+        const queryStr = { otherParam: "value" };
+        expect(redirect.getPath(queryStr)).toBe("");
     });
 });

--- a/src/app/views/login/SignIn.jsx
+++ b/src/app/views/login/SignIn.jsx
@@ -13,7 +13,7 @@ import SessionManagement from "dis-authorisation-client-js";
 import { status } from "../../constants/Authentication";
 import { setAuthState } from "../../utilities/auth";
 import fp from "lodash/fp";
-import handleRedirect from "../../utilities/redirect";
+import redirect from "../../utilities/redirect";
 
 const propTypes = {
     dispatch: PropTypes.func.isRequired,
@@ -172,7 +172,8 @@ export class LoginController extends Component {
             .then(userType => {
                 setAuthState(userType);
                 user.setUserState(userType);
-                handleRedirect(this.props.location.query.redirect);
+                const redirectPath = redirect.getPath(this.props.location.query);
+                redirect.handle(redirectPath);
             })
             .catch(error => {
                 notifications.add({

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,6 @@ import CollectionRoutesWrapper from "./app/global/collection-wrapper/CollectionR
 import WorkflowPreview from "./app/views/workflow-preview/WorkflowPreview";
 import CreateContent from "./app/views/content/CreateContent";
 import NotFound from "./app/components/not-found";
-import { errCodes } from "./app/utilities/errorCodes";
-import notifications from "./app/utilities/notifications";
 import UsersList from "./app/views/users";
 import CreateUser from "./app/views/users/create";
 import AddGroupsToUser from "./app/views/users/groups";
@@ -104,20 +102,6 @@ const userIsAdmin = connectedReduxRedirect({
     redirectPath: `${rootPath}/collections`,
     allowRedirectBack: false
 });
-
-const hasRedirect = () => {
-    const redirect = new URLSearchParams(window.location.search).get('redirect');
-    if (redirect) {
-        const notification = {
-            type: "neutral",
-            message: errCodes.SESSION_EXPIRED,
-            isDismissable: true,
-            autoDismiss: 20000,
-        };
-        notifications.add(notification);
-    }
-    return SignInController;
-};
 
 const logoutUser = async () => {
     try {
@@ -210,7 +194,7 @@ const Index = () => {
                     <Route path={`${rootPath}/upload-test`} component={config.enableNewUpload ? userIsAuthenticated(UploadTest) : null} />
                     <Route path={`${rootPath}/selectable-list`} component={SelectableTest} />
                     <Route path={`${rootPath}/logs`} component={Logs} />
-                    <Route path={`${rootPath}/login`} component={hasRedirect()} />
+                    <Route path={`${rootPath}/login`} component={SignInController} />
                     <Route path={`${rootPath}/logout`} onEnter={logoutUser}/>
                     <Route path={`${rootPath}/forgotten-password`} component={ForgottenPasswordController} />
                     <Route path={`${rootPath}/password-reset`} component={SetForgottenPasswordController} />


### PR DESCRIPTION
### What

Added support for `next` query string parameter that behaves in the same way as the existing `redirect` parameter - aka ✅ [Support for Django’s Default Redirect Query Parameter](https://jira.ons.gov.uk/browse/DIS-2812)
- Added test coverage
- Improved test coverage semantics 
- Made `redirect` a class with external functions
- Removed unnecessary notification displayed on redirect that lacks context of actual events

### How to review

Sense check
Tests pass
Try it yourself

### Who can review

Frontend dev
