### PR TITLE
Whitelist the go directory to fix error in Auth stack

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,7 @@
 FROM golang:1.23.4-bullseye AS base
 
+RUN git config --global --add safe.directory /go
+
 ENV GOCACHE=/go/.go/cache GOPATH=/go/.go/path TZ=Europe/London
 
 RUN GOBIN=/bin go install github.com/cespare/reflex@latest


### PR DESCRIPTION
### What

When I tried running the Auth stack the 'dubious ownership' error appeared in the docker logs for the Florence container. This is described here: 

https://github.com/ONSdigital/dp-operations/blob/main/troubleshooting/fixing-colima-related-errors.md#dubious-ownership-error

So I added a line to the whitelist the /go directory, as described in the link above.

### How to review

Sense check and/or run the Auth stack to check that the Florence logs look correct.
 
### Who can review

Anyone but me.
