### PR TITLE
Feature/remove topic proxy

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -123,7 +123,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	importAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/import"), nil)
 	datasetAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/dataset"), nil)
 	recipeAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
-	topicsProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
 	imageAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/image"), nil)
 	uploadServiceAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
 	filesAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
@@ -155,8 +154,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	router.Handle("/image/{uri:.*}", imageAPIProxy)
 	router.Handle("/zebedee{uri:/.*}", zebedeeProxy)
 	router.Handle("/table/{uri:.*}", tableProxy)
-	router.Handle("/topics", topicsProxy)
-	router.Handle("/topics/{uri:.*}", topicsProxy)
 
 	// Florence endpoints
 	router.HandleFunc("/florence/dist/{uri:.*}", staticFiles)

--- a/src/app/reducers/taxonomies.js
+++ b/src/app/reducers/taxonomies.js
@@ -11,12 +11,6 @@ export default function reducer(state = initialState, action = {}) {
             return Object.assign({}, state, {
                 taxonomies: action.taxonomies,
             });
-        case types.INTERACTIVE_ERROR:
-            return Object.assign({}, state, {
-                errors: {
-                    msg: action.error.response,
-                },
-            });
         default:
             return state;
     }

--- a/src/app/utilities/api-clients/constants.js
+++ b/src/app/utilities/api-clients/constants.js
@@ -1,0 +1,7 @@
+export const API_PROXY = {
+    BASE_PATH: "/api",
+    VERSION: window.getEnv().apiRouterVersion,
+    get VERSIONED_PATH() {
+        return `${this.BASE_PATH}/${this.VERSION}`;
+    },
+};

--- a/src/app/utilities/api-clients/teams.js
+++ b/src/app/utilities/api-clients/teams.js
@@ -1,7 +1,5 @@
 import http from "../http";
-
-const API_PROXY_PATH = `/api/${window.getEnv().apiRouterVersion}`;
-
+import { API_PROXY } from "./constants";
 export default class teams {
     static getAll() {
         return http.get(`/zebedee/teams`).then(response => {
@@ -42,61 +40,61 @@ export default class teams {
     // TODO: new auth work
 
     static createTeam(body) {
-        return http.post(`${API_PROXY_PATH}/groups`, body).then(response => {
+        return http.post(`${API_PROXY.VERSIONED_PATH}/groups`, body).then(response => {
             return response;
         });
     }
 
     static addMemberToTeam(id, userID) {
-        return http.post(`${API_PROXY_PATH}/groups/${id}/members`, { user_id: userID }).then(response => {
+        return http.post(`${API_PROXY.VERSIONED_PATH}/groups/${id}/members`, { user_id: userID }).then(response => {
             return response;
         });
     }
 
     static deleteMemberFromTeam(id, body) {
-        return http.post(`${API_PROXY_PATH}/groups/${id}/members`, body).then(response => {
+        return http.post(`${API_PROXY.VERSIONED_PATH}/groups/${id}/members`, body).then(response => {
             return response;
         });
     }
 
     static getGroups() {
-        return http.get(`${API_PROXY_PATH}/groups?sort=name:asc`).then(response => {
+        return http.get(`${API_PROXY.VERSIONED_PATH}/groups?sort=name:asc`).then(response => {
             return response;
         });
     }
 
     static getGroup(id) {
-        return http.get(`${API_PROXY_PATH}/groups/${id}`).then(response => {
+        return http.get(`${API_PROXY.VERSIONED_PATH}/groups/${id}`).then(response => {
             return response;
         });
     }
 
     static updateGroup(id, body) {
-        return http.put(`${API_PROXY_PATH}/groups/${id}`, body).then(response => {
+        return http.put(`${API_PROXY.VERSIONED_PATH}/groups/${id}`, body).then(response => {
             return response;
         });
     }
 
     static updateGroupMembers(id, body) {
-        return http.put(`${API_PROXY_PATH}/groups/${id}/members`, body).then(response => {
+        return http.put(`${API_PROXY.VERSIONED_PATH}/groups/${id}/members`, body).then(response => {
             return response;
         });
     }
 
     static deleteGroup(id) {
-        return http.delete(`${API_PROXY_PATH}/groups/${id}`).then(response => {
+        return http.delete(`${API_PROXY.VERSIONED_PATH}/groups/${id}`).then(response => {
             return response;
         });
     }
 
     static getGroupMembers(id) {
-        return http.get(`${API_PROXY_PATH}/groups/${id}/members?sort=forename:asc`).then(response => {
+        return http.get(`${API_PROXY.VERSIONED_PATH}/groups/${id}/members?sort=forename:asc`).then(response => {
             return response;
         });
     }
 
     static addGroupsToUser(name, body) {
-        return http.post(`${API_PROXY_PATH}/groups/${name}`, body).then(response => {
+        return http.post(`${API_PROXY.VERSIONED_PATH}/groups/${name}`, body).then(response => {
             return response;
         });
     }

--- a/src/app/utilities/api-clients/topics.js
+++ b/src/app/utilities/api-clients/topics.js
@@ -1,11 +1,12 @@
 import http from "../http";
+import { API_PROXY } from "./constants";
 
 export default class topics {
     static getRootTopics() {
-        return http.get(`/topics`, false, false);
+        return http.get(`${API_PROXY.VERSIONED_PATH}/topics`, false, false);
     }
 
     static getSubtopics(rootTopicId) {
-        return http.get(`/topics/${rootTopicId}/subtopics`, false, false);
+        return http.get(`${API_PROXY.VERSIONED_PATH}/topics/${rootTopicId}/subtopics`, false, false);
     }
 }

--- a/src/app/utilities/api-clients/user.js
+++ b/src/app/utilities/api-clients/user.js
@@ -8,8 +8,7 @@ import log from "../logging/log";
 import SessionManagement from "dis-authorisation-client-js";
 import { errCodes as errorCodes, errCodes } from "../errorCodes";
 import { removeAuthState, setAuthState } from "../auth";
-
-const API_PROXY_PATH = `/api/${window.getEnv().apiRouterVersion}`;
+import { API_PROXY } from "./constants";
 
 export default class user {
     static get(email) {
@@ -27,7 +26,7 @@ export default class user {
             queryString = queryString ? `${queryString}&${key}=${params[key]}` : `?${key}=${params[key]}`;
         });
         try {
-            return await http.get(`${API_PROXY_PATH}/users${queryString}`);
+            return await http.get(`${API_PROXY.VERSIONED_PATH}/users${queryString}`);
         } catch (error) {
             if (error.status) {
                 if (error.status >= 400 && error.status < 500) {
@@ -81,34 +80,34 @@ export default class user {
     };
 
     static create(body) {
-        return http.post(`${API_PROXY_PATH}/users`, body);
+        return http.post(`${API_PROXY.VERSIONED_PATH}/users`, body);
     }
 
     // TODO: new auth work
     static getUsers() {
-        return http.get(`${API_PROXY_PATH}/users?sort=forename:asc`);
+        return http.get(`${API_PROXY.VERSIONED_PATH}/users?sort=forename:asc`);
     }
 
     // TODO: new auth work
     static createNewUser(body) {
-        return http.post(`${API_PROXY_PATH}/users`, body);
+        return http.post(`${API_PROXY.VERSIONED_PATH}/users`, body);
     }
 
     static getUser(id) {
-        return http.get(`${API_PROXY_PATH}/users/${id}`);
+        return http.get(`${API_PROXY.VERSIONED_PATH}/users/${id}`);
     }
 
     // TODO: new auth work
     static updateUser(id, body) {
-        return http.put(`${API_PROXY_PATH}/users/${id}`, body);
+        return http.put(`${API_PROXY.VERSIONED_PATH}/users/${id}`, body);
     }
 
     static getUserGroups(id) {
-        return http.get(`${API_PROXY_PATH}/users/${id}/groups`);
+        return http.get(`${API_PROXY.VERSIONED_PATH}/users/${id}/groups`);
     }
 
     static remove(email) {
-        return http.delete(`${API_PROXY_PATH}/users?email=" + ${email}`);
+        return http.delete(`${API_PROXY.VERSIONED_PATH}/users?email=" + ${email}`);
     }
 
     static setPassword(body) {
@@ -142,24 +141,24 @@ export default class user {
     }
 
     static signIn(body) {
-        return http.post(`${API_PROXY_PATH}/tokens`, body, true, true, true);
+        return http.post(`${API_PROXY.VERSIONED_PATH}/tokens`, body, true, true, true);
     }
 
     // TODO: new auth work
     static deleteTokens() {
-        return http.delete(`${API_PROXY_PATH}/tokens`);
+        return http.delete(`${API_PROXY.VERSIONED_PATH}/tokens`);
     }
 
     static setForgottenPassword(body) {
-        return http.put(`${API_PROXY_PATH}/users/self/password`, body, true, true);
+        return http.put(`${API_PROXY.VERSIONED_PATH}/users/self/password`, body, true, true);
     }
 
     static renewSession(body) {
-        return http.put(`${API_PROXY_PATH}/tokens/self`, body, true, false);
+        return http.put(`${API_PROXY.VERSIONED_PATH}/tokens/self`, body, true, false);
     }
 
     static expireSession() {
-        return http.delete(`${API_PROXY_PATH}/tokens/self`, true, true);
+        return http.delete(`${API_PROXY.VERSIONED_PATH}/tokens/self`, true, true);
     }
 
     // This is a temporary fix for 925: Login fails after going from new login to old login

--- a/src/legacy/js/constants/proxy.js
+++ b/src/legacy/js/constants/proxy.js
@@ -1,0 +1,7 @@
+const API_PROXY = {
+    BASE_PATH: "/api",
+    VERSION: window.getEnv().apiRouterVersion,
+    get VERSIONED_PATH() {
+        return `${this.BASE_PATH}/${this.VERSION}`;
+    },
+};

--- a/src/legacy/js/functions/_tags.js
+++ b/src/legacy/js/functions/_tags.js
@@ -3,7 +3,7 @@
  * @param templateData
  */
 
- async function tags(templateData) {
+async function tags(templateData) {
     var html = templates.tags()
     $('#tags').replaceWith(html);
 
@@ -61,7 +61,7 @@ function formatResponse(response){
 
 async function getTopics(){
     const result = await $.ajax({
-        url: "/topics",
+        url: `${API_PROXY.VERSIONED_PATH}/topics`,
         dataType: 'json',
         crossDomain: true,
     });
@@ -71,7 +71,7 @@ async function getTopics(){
 
 async function getSubTopics(topicID){ 
     const result = await $.ajax({
-        url: "/topics/" + topicID + "/subtopics",
+        url: `${API_PROXY.VERSIONED_PATH}/topics/${topicID}/subtopics`,
         dataType: 'json',
         crossDomain: true,
     });

--- a/src/legacy/package.json
+++ b/src/legacy/package.json
@@ -13,8 +13,8 @@
     },
     "scripts": {
         "audit": "npx auditjs ossi --whitelist ../audit-allowlist.json --quiet",
-        "watch-js": "npm run build-js && npx onchange 'js/classes/*.js' 'js/functions/*.js' 'js/components/*.js' 'js/zebedee-api/*.js' -v -- npm run build-js",
-        "build-js": "mkdir -p ../../dist/legacy-assets/js && cat js/classes/*.js js/zebedee-api/*.js js/functions/*.js js/components/*.js > ../../dist/legacy-assets/js/main.js",
+        "watch-js": "npm run build-js && npx onchange 'js/classes/*.js' 'js/constants/*.js' 'js/functions/*.js' 'js/components/*.js' 'js/zebedee-api/*.js' -v -- npm run build-js",
+        "build-js": "mkdir -p ../../dist/legacy-assets/js && cat js/classes/*.js js/constants/*.js js/zebedee-api/*.js js/functions/*.js js/components/*.js > ../../dist/legacy-assets/js/main.js",
         "watch-templates": "npm run build-templates && npx onchange 'templates/*.handlebars' -v -- npm run build-templates",
         "build-templates": "mkdir -p ../../dist/legacy-assets/js && node ./node_modules/handlebars/bin/handlebars templates/*.handlebars --output ../../dist/legacy-assets/js/templates.js",
         "watch-css": "npm run build-css && npx onchange 'scss/*.scss' 'scss/*/*.scss' -v -- npm run build-css",


### PR DESCRIPTION
### What

- Removed Topic API proxy in favour of API router proxy
- Removed redundant Interactives action type (no longer used or exists)
- Refactor Identity API calls to use generic proxy constants to match Topic API

There is duplication here between Legacy and React - this is to follow the existing conventions of no cross-pollution between the two. 

In writing this PR I did consider abstracting the base path to config as well but thought it was not worth the effort right now. I also considered that we could just wrap all the Florence requests in the Versioned Paths but am uncertain if this is possible at the current time. If we deprecated all the proxies and find that we can do this then we can refactor at that point. 
 
### How to review

Check looks ok and seems sensible approach. 

Optionally, to test:

- Run florence (make watch-src & make debug)
- Port forward to sandbox dp-api-router
- Check requests to `/topics` are now 404ing
- To test the topic request changes:
   - make a collection
   - edit a page
   - see that the topic selector in 'tags' populates and no console errors
   - save / check it re-appears etc.
- To test the identity request changes:
  - login
  - view all users
  - edit a user
  - view all groups
  - edit a group 

### Who can review

Not me. 