### PR TITLE
Remove Image API Proxy

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -123,7 +123,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 	importAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/import"), nil)
 	datasetAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/dataset"), nil)
 	recipeAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
-	imageAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, "/image"), nil)
 	uploadServiceAPIProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
 	downloadServiceProxy := reverseproxy.Create(apiRouterURL, directors.FixedVersionDirector(cfg.SharedConfig.APIRouterVersion, ""), nil)
 	// End of deprecated proxies
@@ -149,7 +148,6 @@ func (svc *Service) createRouter(ctx context.Context, cfg *config.Config) (route
 		router.Handle("/cantabular-metadata/{uri:.*}", cantabularMetadataExtractorAPIProxy)
 	}
 
-	router.Handle("/image/{uri:.*}", imageAPIProxy)
 	router.Handle("/zebedee{uri:/.*}", zebedeeProxy)
 	router.Handle("/table/{uri:.*}", tableProxy)
 

--- a/src/app/utilities/api-clients/images.js
+++ b/src/app/utilities/api-clients/images.js
@@ -1,6 +1,7 @@
 import http from "../http";
+import { API_PROXY } from "./constants";
 
-const imageAPIURL = "/image";
+const imageAPIURL = `${API_PROXY.VERSIONED_PATH}`;
 
 export default class image {
     static create = body => {


### PR DESCRIPTION
### What

Remove Image API proxy

### How to review

Check looks ok, tests pass. 

To test:

- Run florence
- Port forward sandbox publishing api router
- Edit homepage in a collection
- Add an image (you won't see the thumbnail due to cross-domain auth issues)

### Who can review

Not me. 