### PR TITLE
Fix typo in legacy JS causing runtime failure

### DIFF
--- a/src/legacy/js/zebedee-api/_deleteAPIDatasetFromCollection.js
+++ b/src/legacy/js/zebedee-api/_deleteAPIDatasetFromCollection.js
@@ -1,7 +1,7 @@
 function deleteAPIDataset(collectionId, instanceId, success, error) {
 
     $.ajax({
-        url: `${API_PROXY.VERSIONED_PATH}/collections/${collectionId}/datasets/${instanceId},
+        url: `${API_PROXY.VERSIONED_PATH}/collections/${collectionId}/datasets/${instanceId}`,
         type: 'DELETE',
         success: function (response) {
             if (success)


### PR DESCRIPTION
### What

A recent change introduced a typo in the legacy JS causing publishing-queue to fail

### How to review

Ensure tests pass and fix looks sensible

### Who can review

Anyone