### PR TITLE
Feature/add migration field to non series types

### DIFF
--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -30,6 +30,10 @@ function isRelativePath(path) {
     if (path.includes(' ')) {
         return false;
     }
+    // Exclude end slash
+    if (path.endsWith('/')) {
+        return false;
+    }
     // Check if the path starts with '/'
     if (path.startsWith('/')) {
         return true;

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -322,6 +322,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_adhoc') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
+        migration(templateData, pageData);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -311,6 +311,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_foi') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
+        migration(templateData, pageData);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -216,6 +216,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
+        migration(templateData, pageData);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -260,6 +260,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.tables) {
             loadTablesList(collectionId, pageData);
         }
+        migration(templateData, pageData);
         tags(templateData)
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         addFile(collectionId, pageData, 'downloads', 'file');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -341,6 +341,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.equations) {
             loadEquationsList(collectionId, pageData);
         }
+        migration(templateData, pageData);
         tags(templateData)
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -69,6 +69,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'product_page') {
         var html = templates.workEditT3(templateData);
         $('.workspace-menu').html(html);
+        migration(templateData, pageData)
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'items', 'timeseries');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'statsBulletins', 'bulletins');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedArticles', 'articles');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -297,6 +297,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_qmi') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
+        migration(templateData, pageData);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -283,6 +283,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
+        migration(templateData, pageData);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         tags(templateData)
         editIntAndExtLinks(collectionId, pageData, templateData, 'links', 'link');
@@ -348,7 +349,6 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         addFile(collectionId, pageData, 'downloads', 'file');
         editIntAndExtLinks(collectionId, pageData, templateData, 'links', 'link');
         addFile(collectionId, pageData, 'pdfTable', 'pdf');
-        //editTopics (collectionId, pageData, templateData, 'topics', 'topics');  //ready 2b used
         editAlert(collectionId, pageData, templateData, 'alerts', 'alert');
         accordion();
         methodologyEditor(collectionId, pageData);

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -247,6 +247,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_landing_page') {
         var html = templates.workEditT7Landing(templateData);
         $('.workspace-menu').html(html);
+        migration(templateData, pageData);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         accordion();

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -233,6 +233,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'compendium_data') {
         var html = templates.workEditT8Compendium(templateData);
         $('.workspace-menu').html(html);
+        migration(templateData, pageData);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDatasets', 'dataset');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedMethodology', 'qmi');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -358,6 +358,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_methodology_download') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
+        migration(templateData, pageData);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');

--- a/src/legacy/js/functions/_t3Editor.js
+++ b/src/legacy/js/functions/_t3Editor.js
@@ -1,61 +1,70 @@
 function t3Editor(collectionId, data) {
+    var setActiveTab, getActiveTab;
 
-  var setActiveTab, getActiveTab;
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
+    });
 
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
-    }
-  });
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+    getLastPosition();
 
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-  getLastPosition();
+    // Metadata load, edition and saving
+    $("#title").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    $("#summary").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.summary = $(this).val();
+    });
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
+    });
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
+    });
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
+    });
 
-  // Metadata load, edition and saving
-  $("#title").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  $("#summary").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.summary = $(this).val();
-  });
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
 
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
+    editNav.on('click', '.btn-edit-save', function () {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
+        updateContent(collectionId, data.uri, JSON.stringify(data));
+    });
 
-  editNav.on('click', '.btn-edit-save', function () {
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-    updateContent(collectionId, data.uri, JSON.stringify(data));
-  });
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
+        saveAndCompleteContent(collectionId, data.uri, JSON.stringify(data));
+    });
 
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-    saveAndCompleteContent(collectionId, data.uri, JSON.stringify(data));
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-    saveAndReviewContent(collectionId, data.uri, JSON.stringify(data));
-  });
-
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
+        saveAndReviewContent(collectionId, data.uri, JSON.stringify(data));
+    });
 }
-

--- a/src/legacy/js/functions/_t6CompendiumChapterEditor.js
+++ b/src/legacy/js/functions/_t6CompendiumChapterEditor.js
@@ -1,5 +1,4 @@
 function compendiumChapterEditor(collectionId, data) {
-
     var newChart = [], newTable = [], newEquation = [], newImage = [], newLinks = [];
     var parentUrl = getParentPage(data.uri);
     var setActiveTab, getActiveTab;
@@ -28,13 +27,13 @@ function compendiumChapterEditor(collectionId, data) {
         data.description.headline = $(this).val();
     });
     if (!data.description.releaseDate) {
-        $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-            data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
         });
     } else {
         dateTmp = data.description.releaseDate;
         var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-        $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
             data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
         });
     }
@@ -111,6 +110,10 @@ function compendiumChapterEditor(collectionId, data) {
 
 
     function save() {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
 
         Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
 
@@ -121,7 +124,7 @@ function compendiumChapterEditor(collectionId, data) {
             var title = data.charts[parseInt(nameCh)].title;
             var filename = data.charts[parseInt(nameCh)].filename;
             var safeUri = checkPathSlashes(uri);
-            newChart[indexCh] = {uri: safeUri, title: title, filename: filename};
+            newChart[indexCh] = { uri: safeUri, title: title, filename: filename };
         });
         data.charts = newChart;
 
@@ -133,7 +136,7 @@ function compendiumChapterEditor(collectionId, data) {
             var filename = data.tables[parseInt(nameTable)].filename;
             var version = data.tables[parseInt(nameTable)].version;
             var safeUri = checkPathSlashes(uri);
-            newTable[indexTable] = {uri: safeUri, title: title, filename: filename, version: version};
+            newTable[indexTable] = { uri: safeUri, title: title, filename: filename, version: version };
         });
         data.tables = newTable;
         var orderEquation = $("#sortable-equation").sortable('toArray');
@@ -142,7 +145,7 @@ function compendiumChapterEditor(collectionId, data) {
             var title = data.equations[parseInt(nameEquation)].title;
             var filename = data.equations[parseInt(nameEquation)].filename;
             var safeUri = checkPathSlashes(uri);
-            newEquation[indexEquation] = {uri: safeUri, title: title, filename: filename};
+            newEquation[indexEquation] = { uri: safeUri, title: title, filename: filename };
         });
         data.equations = newEquation;
         // images
@@ -152,7 +155,7 @@ function compendiumChapterEditor(collectionId, data) {
             var title = data.images[parseInt(nameImage)].title;
             var filename = data.images[parseInt(nameImage)].filename;
             var safeUri = checkPathSlashes(uri);
-            newImage[indexImage] = {uri: safeUri, title: title, filename: filename};
+            newImage[indexImage] = { uri: safeUri, title: title, filename: filename };
         });
         data.images = newImage;
 
@@ -161,7 +164,7 @@ function compendiumChapterEditor(collectionId, data) {
         $(orderLink).each(function (indexL, nameL) {
             var displayText = data.links[parseInt(nameL)].title;
             var link = $('#link-uri_' + nameL).val();
-            newLinks[indexL] = {uri: link, title: displayText};
+            newLinks[indexL] = { uri: link, title: displayText };
         });
         data.links = newLinks;
     }

--- a/src/legacy/js/functions/_t6CompendiumChapterEditor.js
+++ b/src/legacy/js/functions/_t6CompendiumChapterEditor.js
@@ -92,24 +92,21 @@ function compendiumChapterEditor(collectionId, data) {
     editNav.off(); // remove any existing event handlers.
 
     editNav.on('click', '.btn-edit-save', function () {
-        save();
-        updateContent(collectionId, data.uri, JSON.stringify(data));
+        save("update");
     });
 
     // completed to review
     editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-        save();
-        saveAndCompleteContent(collectionId, data.uri, JSON.stringify(data), false, parentUrl);
+        save("complete");
     });
 
     // reviewed to approve
     editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-        save();
-        saveAndReviewContent(collectionId, data.uri, JSON.stringify(data), false, parentUrl);
+        save("review");
     });
 
 
-    function save() {
+    function save(action) {
         if (!validateMigrationPath(data.description.migrationLink)) {
             sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
             return
@@ -167,6 +164,16 @@ function compendiumChapterEditor(collectionId, data) {
             newLinks[indexL] = { uri: link, title: displayText };
         });
         data.links = newLinks;
+
+        switch (action) {
+            case "complete":
+                saveAndCompleteContent(collectionId, data.uri, JSON.stringify(data), false, parentUrl);
+                break;
+            case "review":
+                saveAndReviewContent(collectionId, data.uri, JSON.stringify(data), false, parentUrl);
+                break;
+            default:
+                updateContent(collectionId, data.uri, JSON.stringify(data));
+        }
     }
 }
-

--- a/src/legacy/js/functions/_t6CompendiumDataEditor.js
+++ b/src/legacy/js/functions/_t6CompendiumDataEditor.js
@@ -1,5 +1,4 @@
 function compendiumDataEditor(collectionId, data) {
-
     var newFiles = [];
     var parentUrl = getParentPage(data.uri);
     var setActiveTab, getActiveTab;
@@ -27,21 +26,17 @@ function compendiumDataEditor(collectionId, data) {
         $(this).textareaAutoSize();
         data.description.summary = $(this).val();
     });
-    //if (!Florence.collection.date) {                    //overwrite scheduled collection date
     if (!data.description.releaseDate) {
-        $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-            data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
         });
     } else {
         dateTmp = data.description.releaseDate;
         var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-        $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
             data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
         });
     }
-    //} else {
-    //    $('.release-date').hide();
-    //}
     $("#nextRelease").on('input', function () {
         $(this).textareaAutoSize();
         data.description.nextRelease = $(this).val();
@@ -87,7 +82,7 @@ function compendiumDataEditor(collectionId, data) {
         }
         return true;
     };
-    
+
     $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
         data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
     });
@@ -97,24 +92,24 @@ function compendiumDataEditor(collectionId, data) {
     editNav.off(); // remove any existing event handlers.
 
     editNav.on('click', '.btn-edit-save', function () {
-        save();
-        updateContent(collectionId, data.uri, JSON.stringify(data));
+        save("update");
     });
 
     // completed to review
     editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-        //pageData = $('.fl-editor__headline').val();
-        save();
-        saveAndCompleteContent(collectionId, data.uri, JSON.stringify(data), parentUrl);
+        save("complete");
     });
 
     // reviewed to approve
     editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-        save();
-        saveAndReviewContent(collectionId, data.uri, JSON.stringify(data), parentUrl);
+        save("review");
     });
 
-    function save() {
+    function save(action) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
 
         Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
 
@@ -124,9 +119,20 @@ function compendiumDataEditor(collectionId, data) {
             var title = $('#file-title_' + nameF).val();
             var fileDescription = $("#file-summary_" + nameF).val();
             var file = data.downloads[parseInt(nameF)].file;
-            newFiles[indexF] = {title: title, fileDescription: fileDescription, file: file};
+            newFiles[indexF] = { title: title, fileDescription: fileDescription, file: file };
         });
         data.downloads = newFiles;
+
+        switch (action) {
+            case "complete":
+                saveAndCompleteContent(collectionId, data.uri, JSON.stringify(data), false, parentUrl);
+                break;
+            case "review":
+                saveAndReviewContent(collectionId, data.uri, JSON.stringify(data), false, parentUrl);
+                break;
+            default:
+                updateContent(collectionId, data.uri, JSON.stringify(data));
+        }
     }
 }
 

--- a/src/legacy/js/functions/_t7AdHocEditor.js
+++ b/src/legacy/js/functions/_t7AdHocEditor.js
@@ -1,114 +1,113 @@
 function adHocEditor(collectionId, data) {
+    var newFiles = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newFiles = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
-
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
-    }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-  getLastPosition();
-
-  $("#metadata-f").remove();
-  $("#metadata-md").remove();
-  $("#metadata-q").remove();
-  $("#metadata-s").remove();
-  $("#summary-p").remove();
-  $("#contact-p").remove();
-  $("#natStat").remove();
-  $("#survey-p").remove();
-  $("#frequency-p").remove();
-  $("#compilation-p").remove();
-  $("#geoCoverage-p").remove();
-  $("#sampleSize-p").remove();
-  $(".lastRevised-p").remove();
-
-  // Metadata edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  //if (!Florence.collection.date) {                    //overwrite scheduled collection date
-  if (!data.description.releaseDate) {
-    $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
     });
-  } else {
-    dateTmp = data.description.releaseDate;
-    var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-    $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+    getLastPosition();
+
+    $("#metadata-f").remove();
+    $("#metadata-md").remove();
+    $("#metadata-q").remove();
+    $("#metadata-s").remove();
+    $("#summary-p").remove();
+    $("#contact-p").remove();
+    $("#natStat").remove();
+    $("#survey-p").remove();
+    $("#frequency-p").remove();
+    $("#compilation-p").remove();
+    $("#geoCoverage-p").remove();
+    $("#sampleSize-p").remove();
+    $(".lastRevised-p").remove();
+
+    // Metadata edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
     });
-  }
-  //} else {
-  //    $('.release-date').hide();
-  //}
-  $("#reference").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    var isNumber = $(this).val();
-    if (isNumber.match(/^\d+$/)) {
-      data.description.reference = isNumber;
+    if (!data.description.releaseDate) {
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
+        });
     } else {
-      sweetAlert('This needs to be a number');
+        dateTmp = data.description.releaseDate;
+        var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+        });
     }
-  });
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-    validateAndSaveTags(data);
-
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-
-    // Sections
-    data.markdown = [$('#content-markdown').val()];
-    // Files are uploaded. Save metadata
-    var orderFile = $("#sortable-file").sortable('toArray');
-    $(orderFile).each(function (indexF, nameF) {
-      var title = $('#file-title_' + nameF).val();
-      var file = data.downloads[parseInt(nameF)].file;
-      newFiles[indexF] = {title: title, file: file};
+    $("#reference").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        var isNumber = $(this).val();
+        if (isNumber.match(/^\d+$/)) {
+            data.description.reference = isNumber;
+        } else {
+            sweetAlert('This needs to be a number');
+        }
     });
-    data.downloads = newFiles;
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
+    });
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
+    });
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
+    });
 
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
+    });
+
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+
+        validateAndSaveTags(data);
+
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
+
+        // Sections
+        data.markdown = [$('#content-markdown').val()];
+        // Files are uploaded. Save metadata
+        var orderFile = $("#sortable-file").sortable('toArray');
+        $(orderFile).each(function (indexF, nameF) {
+            var title = $('#file-title_' + nameF).val();
+            var file = data.downloads[parseInt(nameF)].file;
+            newFiles[indexF] = { title: title, file: file };
+        });
+        data.downloads = newFiles;
+
+        checkRenameUri(collectionId, data, renameUri, onSave);
+    }
 }
-

--- a/src/legacy/js/functions/_t7FoiEditor.js
+++ b/src/legacy/js/functions/_t7FoiEditor.js
@@ -1,103 +1,102 @@
 function foiEditor(collectionId, data) {
+    var newFiles = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newFiles = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
+    });
 
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+    getLastPosition();
+
+    $("#metadata-ad").remove();
+    $("#metadata-md").remove();
+    $("#metadata-q").remove();
+    $("#metadata-s").remove();
+    $("#summary-p").remove();
+    $("#contact-p").remove();
+    $("#natStat").remove();
+    $("#survey-p").remove();
+    $("#frequency-p").remove();
+    $("#compilation-p").remove();
+    $("#geoCoverage-p").remove();
+    $("#sampleSize-p").remove();
+    $(".lastRevised-p").remove();
+    $("#reference-p").remove();
+
+    // Metadata edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    if (!data.description.releaseDate) {
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
+        });
+    } else {
+        dateTmp = data.description.releaseDate;
+        var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+        });
     }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-  getLastPosition();
-
-  $("#metadata-ad").remove();
-  $("#metadata-md").remove();
-  $("#metadata-q").remove();
-  $("#metadata-s").remove();
-  $("#summary-p").remove();
-  $("#contact-p").remove();
-  $("#natStat").remove();
-  $("#survey-p").remove();
-  $("#frequency-p").remove();
-  $("#compilation-p").remove();
-  $("#geoCoverage-p").remove();
-  $("#sampleSize-p").remove();
-  $(".lastRevised-p").remove();
-  $("#reference-p").remove();
-
-  // Metadata edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  //if (!Florence.collection.date) {                    //overwrite scheduled collection date
-  if (!data.description.releaseDate) {
-    $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
     });
-  } else {
-    dateTmp = data.description.releaseDate;
-    var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-    $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
     });
-  }
-  //} else {
-  //    $('.release-date').hide();
-  //}
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-    validateAndSaveTags(data);
-
-    // Sections
-    data.markdown = [$('#content-markdown').val()];
-    // Files are uploaded. Save metadata
-    var orderFile = $("#sortable-file").sortable('toArray');
-    $(orderFile).each(function (indexF, nameF) {
-      var title = $('#file-title_' + nameF).val();
-      var file = data.downloads[parseInt(nameF)].file;
-      newFiles[indexF] = {title: title, file: file};
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
     });
-    data.downloads = newFiles;
 
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
+    });
+
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+
+        validateAndSaveTags(data);
+
+        // Sections
+        data.markdown = [$('#content-markdown').val()];
+        // Files are uploaded. Save metadata
+        var orderFile = $("#sortable-file").sortable('toArray');
+        $(orderFile).each(function (indexF, nameF) {
+            var title = $('#file-title_' + nameF).val();
+            var file = data.downloads[parseInt(nameF)].file;
+            newFiles[indexF] = { title: title, file: file };
+        });
+        data.downloads = newFiles;
+
+        checkRenameUri(collectionId, data, renameUri, onSave);
+    }
 }
-

--- a/src/legacy/js/functions/_t7MethodologyDownloadEditor.js
+++ b/src/legacy/js/functions/_t7MethodologyDownloadEditor.js
@@ -1,122 +1,126 @@
 function methodologyDownloadEditor(collectionId, data) {
+    var newFiles = [], newPdfFiles = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newFiles = [], newPdfFiles = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
+    });
 
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+    getLastPosition();
+
+    $("#metadata-ad").remove();
+    $("#metadata-f").remove();
+    $("#metadata-q").remove();
+    $("#metadata-s").remove();
+    $("#summary-p").remove();
+    $("#natStat").remove();
+    $("#survey-p").remove();
+    $("#frequency-p").remove();
+    $("#compilation-p").remove();
+    $("#geoCoverage-p").remove();
+    $("#sampleSize-p").remove();
+    $(".lastRevised-p").remove();
+    $("#reference-p").remove();
+
+    // Metadata edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    if (!data.description.contact) {
+        data.description.contact = {};
     }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-  getLastPosition();
-
-  $("#metadata-ad").remove();
-  $("#metadata-f").remove();
-  $("#metadata-q").remove();
-  $("#metadata-s").remove();
-  $("#summary-p").remove();
-  $("#natStat").remove();
-  $("#survey-p").remove();
-  $("#frequency-p").remove();
-  $("#compilation-p").remove();
-  $("#geoCoverage-p").remove();
-  $("#sampleSize-p").remove();
-  $(".lastRevised-p").remove();
-  $("#reference-p").remove();
-
-  // Metadata edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  if (!data.description.contact) {
-    data.description.contact = {};
-  }
-  $("#contactName").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.name = $(this).val();
-  });
-  $("#contactEmail").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.email = $(this).val();
-  });
-  $("#contactTelephone").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.telephone = $(this).val();
-  });
-  if (!data.description.releaseDate) {
-    $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+    $("#contactName").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.name = $(this).val();
     });
-  } else {
-    dateTmp = data.description.releaseDate;
-    var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-    $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+    $("#contactEmail").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.email = $(this).val();
     });
-  }
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-    validateAndSaveTags(data);
-
-    // Sections
-    data.markdown = [$('#content-markdown').val()];
-    // Files are uploaded. Save metadata
-    var orderFile = $("#sortable-file").sortable('toArray');
-    $(orderFile).each(function (indexF, nameF) {
-      var title = $('#file-title_' + nameF).val();
-      var file = data.downloads[parseInt(nameF)].file;
-      newFiles[indexF] = {title: title, file: file};
+    $("#contactTelephone").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.telephone = $(this).val();
     });
-    data.downloads = newFiles;
-    // PDF files are uploaded. Save metadata
-    var orderPdfFile = $("#sortable-pdfFile").sortable('toArray');
-    $(orderPdfFile).each(function (indexP, nameP) {
-      var pdfTitle = $('#pdfFile-title_' + nameP).val();
-      var pdfFile = data.pdfDownloads[parseInt(nameP)].file;
-      newPdfFiles[indexP] = {title: pdfTitle, file: pdfFile};
+    if (!data.description.releaseDate) {
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
+        });
+    } else {
+        dateTmp = data.description.releaseDate;
+        var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+        });
+    }
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
     });
-    data.pdfDownloads = newPdfFiles;
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
+    });
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
+    });
 
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
+    });
+
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+        
+        validateAndSaveTags(data);
+
+        // Sections
+        data.markdown = [$('#content-markdown').val()];
+        // Files are uploaded. Save metadata
+        var orderFile = $("#sortable-file").sortable('toArray');
+        $(orderFile).each(function (indexF, nameF) {
+            var title = $('#file-title_' + nameF).val();
+            var file = data.downloads[parseInt(nameF)].file;
+            newFiles[indexF] = { title: title, file: file };
+        });
+        data.downloads = newFiles;
+        // PDF files are uploaded. Save metadata
+        var orderPdfFile = $("#sortable-pdfFile").sortable('toArray');
+        $(orderPdfFile).each(function (indexP, nameP) {
+            var pdfTitle = $('#pdfFile-title_' + nameP).val();
+            var pdfFile = data.pdfDownloads[parseInt(nameP)].file;
+            newPdfFiles[indexP] = { title: pdfTitle, file: pdfFile };
+        });
+        data.pdfDownloads = newPdfFiles;
+
+        checkRenameUri(collectionId, data, renameUri, onSave);
+    }
 }
 
 

--- a/src/legacy/js/functions/_t7MethodologyEditor.js
+++ b/src/legacy/js/functions/_t7MethodologyEditor.js
@@ -1,160 +1,158 @@
 function methodologyEditor(collectionId, data) {
+    var newChart = [], newTable = [], newEquation = [], newImage = [], newFiles = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newChart = [], newTable = [], newEquation = [], newImage = [], newFiles = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
+    });
 
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+    getLastPosition();
+
+    // Metadata load, edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    if (!data.description.releaseDate) {
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
+        });
+    } else {
+        dateTmp = data.description.releaseDate;
+        var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+        });
     }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-  getLastPosition();
-
-  // Metadata load, edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  //if (!Florence.collection.date) {                        //overwrite scheduled collection date
-  if (!data.description.releaseDate) {
-    $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
-    });
-  } else {
-    //dateTmp = $('#releaseDate').val();
-    dateTmp = data.description.releaseDate;
-    var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-    $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
-    });
-  }
-  //} else {
-  //    $('.release-date').hide();
-  //}
-  if (!data.description.contact) {
-    data.description.contact = {};
-  }
-  $("#contactName").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.name = $(this).val();
-  });
-  $("#contactEmail").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.email = $(this).val();
-  });
-  $("#contactTelephone").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.telephone = $(this).val();
-  });
-  $("#summary").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.summary = $(this).val();
-  });
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-    validateAndSaveTags(data);
-
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-
-    // charts
-    var orderChart = $("#sortable-chart").sortable('toArray');
-    $(orderChart).each(function (indexCh, nameCh) {
-      var uri = data.charts[parseInt(nameCh)].uri;
-      var title = data.charts[parseInt(nameCh)].title;
-      var filename = data.charts[parseInt(nameCh)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newChart[indexCh] = {uri: safeUri, title: title, filename: filename};
-    });
-    data.charts = newChart;
-    // tables
-    var orderTable = $("#sortable-table").sortable('toArray');
-    $(orderTable).each(function (indexTable, nameTable) {
-      var uri = data.tables[parseInt(nameTable)].uri;
-      var title = data.tables[parseInt(nameTable)].title;
-      var filename = data.tables[parseInt(nameTable)].filename;
-      var version = data.tables[parseInt(nameTable)].version;
-      var safeUri = checkPathSlashes(uri);
-      newTable[indexTable] = {uri: safeUri, title: title, filename: filename, version: version};
-    });
-    data.tables = newTable;
-    // equations
-    var orderEquation = $("#sortable-equation").sortable('toArray');
-    $(orderEquation).each(function (indexEquation, nameEquation) {
-      var uri = data.equations[parseInt(nameEquation)].uri;
-      var title = data.equations[parseInt(nameEquation)].title;
-      var filename = data.equations[parseInt(nameEquation)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newEquation[indexEquation] = {uri: safeUri, title: title, filename: filename};
-    });
-    data.equations = newEquation;
-    // images
-    var orderImage = $("#sortable-image").sortable('toArray');
-    $(orderImage).each(function (indexImage, nameImage) {
-      var uri = data.images[parseInt(nameImage)].uri;
-      var title = data.images[parseInt(nameImage)].title;
-      var filename = data.images[parseInt(nameImage)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newImage[indexImage] = {uri: safeUri, title: title, filename: filename};
-    });
-    data.images = newImage;
-
-    // Files are uploaded. Save metadata
-    var orderFile = $("#sortable-file").sortable('toArray');
-    $(orderFile).each(function (indexF, nameF) {
-      var title = $('#file-title_' + nameF).val();
-      var file = data.downloads[parseInt(nameF)].file;
-      newFiles[indexF] = {title: title, file: file};
-    });
-    data.downloads = newFiles;
-
-    // tags
-    if ($("#selectTopic").val() && $("#selectSubTopic").val()) {
-      data.description.canonicalTopic = $("#selectTopic").val()[0]
-      data.description.secondaryTopics = $("#selectSubTopic").val()
+    if (!data.description.contact) {
+        data.description.contact = {};
     }
-    else if ($("#selectTopic").val() && !$("#selectSubTopic").val()) {
-      sweetAlert("Cannot save this page", "A value is required for 'Subtopic' if a 'Topic' has been selected");
-      return
-    } 
+    $("#contactName").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.name = $(this).val();
+    });
+    $("#contactEmail").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.email = $(this).val();
+    });
+    $("#contactTelephone").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.telephone = $(this).val();
+    });
+    $("#summary").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.summary = $(this).val();
+    });
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
+    });
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
+    });
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
+    });
 
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
+    });
+
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+
+        validateAndSaveTags(data);
+
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
+
+        // charts
+        var orderChart = $("#sortable-chart").sortable('toArray');
+        $(orderChart).each(function (indexCh, nameCh) {
+            var uri = data.charts[parseInt(nameCh)].uri;
+            var title = data.charts[parseInt(nameCh)].title;
+            var filename = data.charts[parseInt(nameCh)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newChart[indexCh] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.charts = newChart;
+        // tables
+        var orderTable = $("#sortable-table").sortable('toArray');
+        $(orderTable).each(function (indexTable, nameTable) {
+            var uri = data.tables[parseInt(nameTable)].uri;
+            var title = data.tables[parseInt(nameTable)].title;
+            var filename = data.tables[parseInt(nameTable)].filename;
+            var version = data.tables[parseInt(nameTable)].version;
+            var safeUri = checkPathSlashes(uri);
+            newTable[indexTable] = { uri: safeUri, title: title, filename: filename, version: version };
+        });
+        data.tables = newTable;
+        // equations
+        var orderEquation = $("#sortable-equation").sortable('toArray');
+        $(orderEquation).each(function (indexEquation, nameEquation) {
+            var uri = data.equations[parseInt(nameEquation)].uri;
+            var title = data.equations[parseInt(nameEquation)].title;
+            var filename = data.equations[parseInt(nameEquation)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newEquation[indexEquation] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.equations = newEquation;
+        // images
+        var orderImage = $("#sortable-image").sortable('toArray');
+        $(orderImage).each(function (indexImage, nameImage) {
+            var uri = data.images[parseInt(nameImage)].uri;
+            var title = data.images[parseInt(nameImage)].title;
+            var filename = data.images[parseInt(nameImage)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newImage[indexImage] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.images = newImage;
+
+        // Files are uploaded. Save metadata
+        var orderFile = $("#sortable-file").sortable('toArray');
+        $(orderFile).each(function (indexF, nameF) {
+            var title = $('#file-title_' + nameF).val();
+            var file = data.downloads[parseInt(nameF)].file;
+            newFiles[indexF] = { title: title, file: file };
+        });
+        data.downloads = newFiles;
+
+        // tags
+        if ($("#selectTopic").val() && $("#selectSubTopic").val()) {
+            data.description.canonicalTopic = $("#selectTopic").val()[0]
+            data.description.secondaryTopics = $("#selectSubTopic").val()
+        }
+        else if ($("#selectTopic").val() && !$("#selectSubTopic").val()) {
+            sweetAlert("Cannot save this page", "A value is required for 'Subtopic' if a 'Topic' has been selected");
+            return
+        }
+
+        checkRenameUri(collectionId, data, renameUri, onSave);
+    }
 }
-

--- a/src/legacy/js/functions/_t7QmiEditor.js
+++ b/src/legacy/js/functions/_t7QmiEditor.js
@@ -1,143 +1,145 @@
 function qmiEditor(collectionId, data) {
+    var newFiles = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newFiles = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
+    });
 
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+    getLastPosition();
+
+    $("#metadata-ad").remove();
+    $("#metadata-f").remove();
+    $("#metadata-md").remove();
+    $("#metadata-s").remove();
+    $("#summary-p").remove();
+    $(".release-date").remove();
+    $("#reference-p").remove();
+
+    // Metadata edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    if (!data.description.contact) {
+        data.description.contact = {};
     }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-  getLastPosition();
-
-  $("#metadata-ad").remove();
-  $("#metadata-f").remove();
-  $("#metadata-md").remove();
-  $("#metadata-s").remove();
-  $("#summary-p").remove();
-  $(".release-date").remove();
-  $("#reference-p").remove();
-
-  // Metadata edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  if (!data.description.contact) {
-    data.description.contact = {};
-  }
-  $("#contactName").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.name = $(this).val();
-  });
-  $("#contactEmail").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.email = $(this).val();
-  });
-  $("#contactTelephone").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.contact.telephone = $(this).val();
-  });
-  $("#survey").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.surveyName = $(this).val();
-  });
-  $("#frequency").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.frequency = $(this).val();
-  });
-  $("#compilation").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.compilation = $(this).val();
-  });
-  $("#geoCoverage").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.geographicCoverage = $(this).val();
-  });
-  $("#sampleSize").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.sampleSize = $(this).val();
-  });
-  if (!data.description.lastRevised) {
-    $('#lastRevised').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.lastRevised = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+    $("#contactName").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.name = $(this).val();
     });
-  } else {
-    dateTmp = data.description.lastRevised;
-    var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-    $('#lastRevised').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.lastRevised = new Date($('#lastRevised').datepicker('getDate')).toISOString();
+    $("#contactEmail").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.email = $(this).val();
     });
-  }
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  /* The checked attribute is a boolean attribute and the corresponding property 
-  will be true if the attribute is present and has a value other than false */
-  var checkBoxStatus = function (value) {
-    if (value === "" || value === "false" || value === false) {
-        return false;
+    $("#contactTelephone").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.contact.telephone = $(this).val();
+    });
+    $("#survey").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.surveyName = $(this).val();
+    });
+    $("#frequency").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.frequency = $(this).val();
+    });
+    $("#compilation").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.compilation = $(this).val();
+    });
+    $("#geoCoverage").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.geographicCoverage = $(this).val();
+    });
+    $("#sampleSize").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.sampleSize = $(this).val();
+    });
+    if (!data.description.lastRevised) {
+        $('#lastRevised').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.lastRevised = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
+        });
+    } else {
+        dateTmp = data.description.lastRevised;
+        var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
+        $('#lastRevised').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.lastRevised = new Date($('#lastRevised').datepicker('getDate')).toISOString();
+        });
     }
-    return true;
-  };
-
-  $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
-    data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
-  });
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-
-    validateAndSaveTags(data);
-
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-
-    // Sections
-    data.markdown = [$('#content-markdown').val()];
-    // Files are uploaded. Save metadata
-    var orderFile = $("#sortable-file").sortable('toArray');
-    $(orderFile).each(function (indexF, nameF) {
-      var title = $('#file-title_' + nameF).val();
-      var file = data.downloads[parseInt(nameF)].file;
-      newFiles[indexF] = {title: title, file: file};
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
     });
-    data.downloads = newFiles;
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
+    });
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
+    });
 
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
+    /* The checked attribute is a boolean attribute and the corresponding property 
+    will be true if the attribute is present and has a value other than false */
+    var checkBoxStatus = function (value) {
+        if (value === "" || value === "false" || value === false) {
+            return false;
+        }
+        return true;
+    };
+
+    $("#natStat-checkbox").prop('checked', checkBoxStatus(data.description.nationalStatistic)).click(function () {
+        data.description.nationalStatistic = $("#natStat-checkbox").prop('checked');
+    });
+
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
+    });
+
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+
+        validateAndSaveTags(data);
+
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
+
+        // Sections
+        data.markdown = [$('#content-markdown').val()];
+        // Files are uploaded. Save metadata
+        var orderFile = $("#sortable-file").sortable('toArray');
+        $(orderFile).each(function (indexF, nameF) {
+            var title = $('#file-title_' + nameF).val();
+            var file = data.downloads[parseInt(nameF)].file;
+            newFiles[indexF] = { title: title, file: file };
+        });
+        data.downloads = newFiles;
+
+        checkRenameUri(collectionId, data, renameUri, onSave);
+    }
 }
-

--- a/src/legacy/js/functions/_t7StaticArticleEditor.js
+++ b/src/legacy/js/functions/_t7StaticArticleEditor.js
@@ -1,147 +1,145 @@
 function staticArticleEditor(collectionId, data) {
+    var newChart = [], newTable = [], newEquation = [], newImage = [], newLinks = [], newFiles = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newChart = [], newTable = [], newEquation = [], newImage = [], newLinks = [], newFiles = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
+    });
 
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+    getLastPosition();
+
+    // Metadata load, edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    if (!data.description.releaseDate) {
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
+        });
+    } else {
+        dateTmp = data.description.releaseDate;
+        var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+        });
     }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-  getLastPosition();
-
-  // Metadata load, edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  //if (!Florence.collection.date) {                        //overwrite scheduled collection date
-  if (!data.description.releaseDate) {
-    $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+    $("#summary").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.summary = $(this).val();
     });
-  } else {
-    //dateTmp = $('#releaseDate').val();
-    dateTmp = data.description.releaseDate;
-    var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-    $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
     });
-  }
-  //} else {
-  //    $('.release-date').hide();
-  //}
-  $("#summary").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.summary = $(this).val();
-  });
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-    validateAndSaveTags(data);
-
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-
-    // charts
-    var orderChart = $("#sortable-chart").sortable('toArray');
-    $(orderChart).each(function (indexCh, nameCh) {
-      var uri = data.charts[parseInt(nameCh)].uri;
-      var title = data.charts[parseInt(nameCh)].title;
-      var filename = data.charts[parseInt(nameCh)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newChart[indexCh] = {uri: safeUri, title: title, filename: filename};
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
     });
-    data.charts = newChart;
-    // tables
-    var orderTable = $("#sortable-table").sortable('toArray');
-    $(orderTable).each(function (indexTable, nameTable) {
-      var uri = data.tables[parseInt(nameTable)].uri;
-      var title = data.tables[parseInt(nameTable)].title;
-      var filename = data.tables[parseInt(nameTable)].filename;
-      var version = data.tables[parseInt(nameTable)].version;
-      var safeUri = checkPathSlashes(uri);
-      newTable[indexTable] = {uri: safeUri, title: title, filename: filename, version: version};
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
     });
-    data.tables = newTable;
-    // equations
-    var orderEquation = $("#sortable-equation").sortable('toArray');
-    $(orderEquation).each(function (indexEquation, nameEquation) {
-      var uri = data.equations[parseInt(nameEquation)].uri;
-      var title = data.equations[parseInt(nameEquation)].title;
-      var filename = data.equations[parseInt(nameEquation)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newEquation[indexEquation] = {uri: safeUri, title: title, filename: filename};
-    });
-    data.equations = newEquation;
-    // images
-    var orderImage = $("#sortable-image").sortable('toArray');
-    $(orderImage).each(function (indexImage, nameImage) {
-      var uri = data.images[parseInt(nameImage)].uri;
-      var title = data.images[parseInt(nameImage)].title;
-      var filename = data.images[parseInt(nameImage)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newImage[indexImage] = {uri: safeUri, title: title, filename: filename};
-    });
-    data.images = newImage;
-    // Files are uploaded. Save metadata
-    var orderFile = $("#sortable-file").sortable('toArray');
-    $(orderFile).each(function (indexF, nameF) {
-      var title = $('#file-title_' + nameF).val();
-      var file = data.downloads[parseInt(nameF)].file;
-      newFiles[indexF] = {title: title, file: file};
-    });
-    data.downloads = newFiles;
-    // links
-    var orderLink = $("#sortable-link").sortable('toArray');
-    $(orderLink).each(function (indexL, nameL) {
-      if (data.links[parseInt(nameL)].title) {
-        var name = data.links[parseInt(nameL)].title;
-        var link = data.links[parseInt(nameL)].uri;
-        newLinks[indexL] = {uri: link, title: name};
-      } else {
-        var link = data.links[parseInt(nameL)].uri;
-        newLinks[indexL] = {uri: link};
-      }
-    });
-    data.links = newLinks;
 
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
+    });
+
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+        
+        validateAndSaveTags(data);
+
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
+
+        // charts
+        var orderChart = $("#sortable-chart").sortable('toArray');
+        $(orderChart).each(function (indexCh, nameCh) {
+            var uri = data.charts[parseInt(nameCh)].uri;
+            var title = data.charts[parseInt(nameCh)].title;
+            var filename = data.charts[parseInt(nameCh)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newChart[indexCh] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.charts = newChart;
+        // tables
+        var orderTable = $("#sortable-table").sortable('toArray');
+        $(orderTable).each(function (indexTable, nameTable) {
+            var uri = data.tables[parseInt(nameTable)].uri;
+            var title = data.tables[parseInt(nameTable)].title;
+            var filename = data.tables[parseInt(nameTable)].filename;
+            var version = data.tables[parseInt(nameTable)].version;
+            var safeUri = checkPathSlashes(uri);
+            newTable[indexTable] = { uri: safeUri, title: title, filename: filename, version: version };
+        });
+        data.tables = newTable;
+        // equations
+        var orderEquation = $("#sortable-equation").sortable('toArray');
+        $(orderEquation).each(function (indexEquation, nameEquation) {
+            var uri = data.equations[parseInt(nameEquation)].uri;
+            var title = data.equations[parseInt(nameEquation)].title;
+            var filename = data.equations[parseInt(nameEquation)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newEquation[indexEquation] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.equations = newEquation;
+        // images
+        var orderImage = $("#sortable-image").sortable('toArray');
+        $(orderImage).each(function (indexImage, nameImage) {
+            var uri = data.images[parseInt(nameImage)].uri;
+            var title = data.images[parseInt(nameImage)].title;
+            var filename = data.images[parseInt(nameImage)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newImage[indexImage] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.images = newImage;
+        // Files are uploaded. Save metadata
+        var orderFile = $("#sortable-file").sortable('toArray');
+        $(orderFile).each(function (indexF, nameF) {
+            var title = $('#file-title_' + nameF).val();
+            var file = data.downloads[parseInt(nameF)].file;
+            newFiles[indexF] = { title: title, file: file };
+        });
+        data.downloads = newFiles;
+        // links
+        var orderLink = $("#sortable-link").sortable('toArray');
+        $(orderLink).each(function (indexL, nameL) {
+            if (data.links[parseInt(nameL)].title) {
+                var name = data.links[parseInt(nameL)].title;
+                var link = data.links[parseInt(nameL)].uri;
+                newLinks[indexL] = { uri: link, title: name };
+            } else {
+                var link = data.links[parseInt(nameL)].uri;
+                newLinks[indexL] = { uri: link };
+            }
+        });
+        data.links = newLinks;
+
+        checkRenameUri(collectionId, data, renameUri, onSave);
+    }
 }
-

--- a/src/legacy/js/functions/_t7StaticLandingPageEditor.js
+++ b/src/legacy/js/functions/_t7StaticLandingPageEditor.js
@@ -1,232 +1,236 @@
 function staticLandingPageEditor(collectionId, data) {
+    var newSections = [], newLinks = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newSections = [], newLinks = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
-
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
-    }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-
-
-  // Metadata edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  $("#summary").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.summary = $(this).val();
-  });
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  // Edit content
-  // Load and edition
-  $(data.sections).each(function (index) {
-
-    $('#section-uri_' + index).on('paste', function () {
-      setTimeout(function () {
-        var pastedUrl = $('#section-uri_' + index).val();
-        var safeUrl = checkPathParsed(pastedUrl);
-        $('#section-uri_' + index).val(safeUrl);
-      }, 50);
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
     });
 
-    if (!$('#section-uri_' + index).val()) {
-      $('<button class="btn-edit-save-and-submit-for-review" id="section-get_' + index + '">Go to</button>').insertAfter('#section-uri_' + index);
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
 
-      $('#section-get_' + index).click(function () {
-        var iframeEvent = document.getElementById('iframe').contentWindow;
-        iframeEvent.removeEventListener('click', Florence.Handler, true);
-        createWorkspace(data.uri, collectionId, '', null, true);
-        $('#section-get_' + index).html('Copy link').off().one('click', function () {
-          var uriCheck = getPathNameTrimLast();
-          var uriChecked = checkPathSlashes(uriCheck);
-          data.sections[index].uri = uriChecked;
-          putContent(collectionId, data.uri, JSON.stringify(data),
-            success = function (response) {
-              console.log("Updating completed " + response);
-              Florence.Editor.isDirty = false;
-              viewWorkspace(data.uri, collectionId, 'edit');
-              refreshPreview(data.uri);
-              var iframeEvent = document.getElementById('iframe').contentWindow;
-              iframeEvent.addEventListener('click', Florence.Handler, true);
-            },
-            error = function (response) {
-              if (response.status === 400) {
-                  sweetAlert("Cannot edit this page", "It is already part of another collection.");
-              }
-              else {
-                handleApiError(response);
-              }
-            }
-          );
+
+    // Metadata edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    $("#summary").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.summary = $(this).val();
+    });
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
+    });
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
+    });
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
+    });
+
+    // Edit content
+    // Load and edition
+    $(data.sections).each(function (index) {
+
+        $('#section-uri_' + index).on('paste', function () {
+            setTimeout(function () {
+                var pastedUrl = $('#section-uri_' + index).val();
+                var safeUrl = checkPathParsed(pastedUrl);
+                $('#section-uri_' + index).val(safeUrl);
+            }, 50);
         });
-      });
+
+        if (!$('#section-uri_' + index).val()) {
+            $('<button class="btn-edit-save-and-submit-for-review" id="section-get_' + index + '">Go to</button>').insertAfter('#section-uri_' + index);
+
+            $('#section-get_' + index).click(function () {
+                var iframeEvent = document.getElementById('iframe').contentWindow;
+                iframeEvent.removeEventListener('click', Florence.Handler, true);
+                createWorkspace(data.uri, collectionId, '', null, true);
+                $('#section-get_' + index).html('Copy link').off().one('click', function () {
+                    var uriCheck = getPathNameTrimLast();
+                    var uriChecked = checkPathSlashes(uriCheck);
+                    data.sections[index].uri = uriChecked;
+                    putContent(collectionId, data.uri, JSON.stringify(data),
+                        success = function (response) {
+                            console.log("Updating completed " + response);
+                            Florence.Editor.isDirty = false;
+                            viewWorkspace(data.uri, collectionId, 'edit');
+                            refreshPreview(data.uri);
+                            var iframeEvent = document.getElementById('iframe').contentWindow;
+                            iframeEvent.addEventListener('click', Florence.Handler, true);
+                        },
+                        error = function (response) {
+                            if (response.status === 400) {
+                                sweetAlert("Cannot edit this page", "It is already part of another collection.");
+                            }
+                            else {
+                                handleApiError(response);
+                            }
+                        }
+                    );
+                });
+            });
+        }
+
+        $("#section-edit_" + index).click(function () {
+            var editedSectionValue = {
+                "title": $('#section-title_' + index).val(),
+                "markdown": $("#section-markdown_" + index).val()
+            };
+
+            var saveContent = function (updatedContent) {
+                data.sections[index].summary = updatedContent;
+                data.sections[index].title = $('#section-title_' + index).val();
+                data.sections[index].uri = $('#section-uri_' + index).val();
+                updateContent(collectionId, data.uri, JSON.stringify(data));
+            };
+
+            loadMarkdownEditor(editedSectionValue, saveContent, data);
+        });
+
+        // Delete
+        $("#section-delete_" + index).click(function () {
+            swal({
+                title: "Warning",
+                text: "Are you sure you want to delete?",
+                type: "warning",
+                showCancelButton: true,
+                confirmButtonText: "Delete",
+                cancelButtonText: "Cancel",
+                closeOnConfirm: false
+            }, function (result) {
+                if (result === true) {
+                    $("#" + index).remove();
+                    data.sections.splice(index, 1);
+                    updateContent(collectionId, data.uri, JSON.stringify(data));
+                    swal({
+                        title: "Deleted",
+                        text: "This section has been deleted",
+                        type: "success",
+                        timer: 2000
+                    });
+                }
+            });
+        });
+
+        // Tooltips
+        $(function () {
+            $('#section-uri_' + index).tooltip({
+                items: '#section-uri_' + index,
+                content: 'Copy link or click Go to, navigate to page and click Copy link. Then add a title and click Edit',
+                show: "slideDown", // show immediately
+                open: function (event, ui) {
+                    ui.tooltip.hover(
+                        function () {
+                            $(this).fadeTo("slow", 0.5);
+                        });
+                }
+            });
+        });
+
+        $(function () {
+            $('#section-title_' + index).tooltip({
+                items: '#section-title_' + index,
+                content: 'Type a title and click Edit',
+                show: "slideDown", // show immediately
+                open: function (event, ui) {
+                    ui.tooltip.hover(
+                        function () {
+                            $(this).fadeTo("slow", 0.5);
+                        });
+                }
+            });
+        });
+    });
+
+    //Add new content
+    $("#add-section").one('click', function () {
+        swal({
+            title: "Warning",
+            text: "If you do not come back to this page, you will lose any unsaved changes",
+            type: "warning",
+            showCancelButton: true,
+            confirmButtonText: "Continue",
+            cancelButtonText: "Cancel"
+        }, function (result) {
+            if (result === true) {
+                data.sections.push({ uri: "", title: "", summary: "" });
+                updateContent(collectionId, data.uri, JSON.stringify(data));
+            } else {
+                loadPageDataIntoEditor(data.uri, collectionId);
+            }
+        });
+    });
+
+    function sortableContent() {
+        $("#sortable-section").sortable();
     }
 
-    $("#section-edit_" + index).click(function () {
-      var editedSectionValue = {
-        "title": $('#section-title_' + index).val(),
-        "markdown": $("#section-markdown_" + index).val()
-      };
+    sortableContent();
 
-      var saveContent = function (updatedContent) {
-        data.sections[index].summary = updatedContent;
-        data.sections[index].title = $('#section-title_' + index).val();
-        data.sections[index].uri = $('#section-uri_' + index).val();
-        updateContent(collectionId, data.uri, JSON.stringify(data));
-      };
+    renderExternalLinkAccordionSection(collectionId, data, 'links', 'link');
 
-      loadMarkdownEditor(editedSectionValue, saveContent, data);
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
     });
 
-    // Delete
-    $("#section-delete_" + index).click(function () {
-      swal ({
-        title: "Warning",
-        text: "Are you sure you want to delete?",
-        type: "warning",
-        showCancelButton: true,
-        confirmButtonText: "Delete",
-        cancelButtonText: "Cancel",
-        closeOnConfirm: false
-      }, function(result) {
-        if (result === true) {
-          $("#" + index).remove();
-          data.sections.splice(index, 1);
-          updateContent(collectionId, data.uri, JSON.stringify(data));
-          swal({
-            title: "Deleted",
-            text: "This section has been deleted",
-            type: "success",
-            timer: 2000
-          });
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
         }
-      });
-    });
 
-      // Tooltips
-    $(function () {
-      $('#section-uri_' + index).tooltip({
-        items: '#section-uri_' + index,
-        content: 'Copy link or click Go to, navigate to page and click Copy link. Then add a title and click Edit',
-        show: "slideDown", // show immediately
-        open: function (event, ui) {
-          ui.tooltip.hover(
-            function () {
-              $(this).fadeTo("slow", 0.5);
-            });
-        }
-      });
-    });
+        validateAndSaveTags(data);
 
-    $(function () {
-      $('#section-title_' + index).tooltip({
-        items: '#section-title_' + index,
-        content: 'Type a title and click Edit',
-        show: "slideDown", // show immediately
-        open: function (event, ui) {
-          ui.tooltip.hover(
-            function () {
-              $(this).fadeTo("slow", 0.5);
-            });
-        }
-      });
-    });
-  });
+        Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
 
-  //Add new content
-  $("#add-section").one('click', function () {
-    swal ({
-      title: "Warning",
-      text: "If you do not come back to this page, you will lose any unsaved changes",
-      type: "warning",
-      showCancelButton: true,
-      confirmButtonText: "Continue",
-      cancelButtonText: "Cancel"
-    }, function(result) {
-      if (result === true) {
-        data.sections.push({uri: "", title: "", summary: ""});
-        updateContent(collectionId, data.uri, JSON.stringify(data));
-      } else {
-        loadPageDataIntoEditor(data.uri, collectionId);
-      }
-    });
-  });
+        // Sections
+        var orderSection = $("#sortable-section").sortable('toArray');
+        $(orderSection).each(function (indexS, nameS) {
+            var summary = data.sections[parseInt(nameS)].summary;
+            // Fixes title or uri not saving unless markdown edited
+            var title = $('#section-title_' + nameS).val();
+            var uri = $('#section-uri_' + nameS).val();
+            //var title = data.sections[parseInt(nameS)].title;
+            //var uri = data.sections[parseInt(nameS)].uri;
+            var uriChecked = checkPathSlashes(uri);
+            newSections[indexS] = { uri: uriChecked, title: title, summary: summary };
+        });
+        data.sections = newSections;
+        // External links
+        var orderLink = $("#sortable-link").sortable('toArray');
+        $(orderLink).each(function (indexL, nameL) {
+            var displayText = data.links[parseInt(nameL)].title;
+            var link = $('#link-uri_' + nameL).val();
+            newLinks[indexL] = { uri: link, title: displayText };
+        });
+        data.links = newLinks;
 
-  function sortableContent() {
-    $("#sortable-section").sortable();
-  }
-
-  sortableContent();
-
-  renderExternalLinkAccordionSection(collectionId, data, 'links', 'link');
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-    validateAndSaveTags(data);
-
-    Florence.globalVars.pagePos = $(".workspace-edit").scrollTop();
-
-    // Sections
-    var orderSection = $("#sortable-section").sortable('toArray');
-    $(orderSection).each(function (indexS, nameS) {
-      var summary = data.sections[parseInt(nameS)].summary;
-        // Fixes title or uri not saving unless markdown edited
-        var title = $('#section-title_' + nameS).val();
-        var uri = $('#section-uri_' + nameS).val();
-      //var title = data.sections[parseInt(nameS)].title;
-      //var uri = data.sections[parseInt(nameS)].uri;
-      var uriChecked = checkPathSlashes(uri);
-      newSections[indexS] = {uri: uriChecked, title: title, summary: summary};
-    });
-    data.sections = newSections;
-    // External links
-    var orderLink = $("#sortable-link").sortable('toArray');
-    $(orderLink).each(function (indexL, nameL) {
-      var displayText = data.links[parseInt(nameL)].title;
-      var link = $('#link-uri_' + nameL).val();
-      newLinks[indexL] = {uri: link, title: displayText};
-    });
-    data.links = newLinks;
-
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
+        checkRenameUri(collectionId, data, renameUri, onSave);
+    }
 }

--- a/src/legacy/js/functions/_t7StaticPageEditor.js
+++ b/src/legacy/js/functions/_t7StaticPageEditor.js
@@ -1,155 +1,158 @@
 function staticPageEditor(collectionId, data) {
+    var newLinks = [], newFiles = [], newChart = [], newTable = [], newImage = [];
+    var setActiveTab, getActiveTab;
+    var renameUri = false;
 
-  var newLinks = [], newFiles = [], newChart = [], newTable = [], newImage = [];
-  var setActiveTab, getActiveTab;
-  var renameUri = false;
+    $(".edit-accordion").on('accordionactivate', function (event, ui) {
+        setActiveTab = $(".edit-accordion").accordion("option", "active");
+        if (setActiveTab !== false) {
+            Florence.globalVars.activeTab = setActiveTab;
+        }
+    });
 
-  $(".edit-accordion").on('accordionactivate', function (event, ui) {
-    setActiveTab = $(".edit-accordion").accordion("option", "active");
-    if (setActiveTab !== false) {
-      Florence.globalVars.activeTab = setActiveTab;
+    getActiveTab = Florence.globalVars.activeTab;
+    accordion(getActiveTab);
+
+    $("#metadata-ad").remove();
+    $("#metadata-f").remove();
+    $("#metadata-md").remove();
+    $("#metadata-q").remove();
+    $("#contact-p").remove();
+    $("#natStat").remove();
+    $("#survey-p").remove();
+    $("#frequency-p").remove();
+    $("#compilation-p").remove();
+    $("#geoCoverage-p").remove();
+    $("#sampleSize-p").remove();
+    $(".lastRevised-p").remove();
+    $("#reference-p").remove();
+
+    // Metadata edition and saving
+    $("#title").on('input', function () {
+        renameUri = true;
+        $(this).textareaAutoSize();
+        data.description.title = $(this).val();
+    });
+    $("#summary").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.summary = $(this).val();
+    });
+    if (!data.description.releaseDate) {
+        $('#releaseDate').datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($(this).datepicker({ dateFormat: 'dd MM yy' })[0].value).toISOString();
+        });
+    } else {
+        dateTmp = data.description.releaseDate;
+        var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
+        $('#releaseDate').val(dateTmpFormatted).datepicker({ dateFormat: 'dd MM yy' }).on('change', function () {
+            data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+        });
     }
-  });
-
-  getActiveTab = Florence.globalVars.activeTab;
-  accordion(getActiveTab);
-
-  $("#metadata-ad").remove();
-  $("#metadata-f").remove();
-  $("#metadata-md").remove();
-  $("#metadata-q").remove();
-  $("#contact-p").remove();
-  $("#natStat").remove();
-  $("#survey-p").remove();
-  $("#frequency-p").remove();
-  $("#compilation-p").remove();
-  $("#geoCoverage-p").remove();
-  $("#sampleSize-p").remove();
-  $(".lastRevised-p").remove();
-  $("#reference-p").remove();
-
-  // Metadata edition and saving
-  $("#title").on('input', function () {
-    renameUri = true;
-    $(this).textareaAutoSize();
-    data.description.title = $(this).val();
-  });
-  $("#summary").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.summary = $(this).val();
-  });
-  if (!data.description.releaseDate) {
-    $('#releaseDate').datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($(this).datepicker({dateFormat: 'dd MM yy'})[0].value).toISOString();
+    $("#keywordsTag").tagit({
+        availableTags: data.description.keywords,
+        singleField: true,
+        allowSpaces: true,
+        singleFieldNode: $('#keywords')
     });
-  } else {
-    dateTmp = data.description.releaseDate;
-    var dateTmpFormatted = $.datepicker.formatDate('dd MM yy', new Date(dateTmp));
-    $('#releaseDate').val(dateTmpFormatted).datepicker({dateFormat: 'dd MM yy'}).on('change', function () {
-      data.description.releaseDate = new Date($('#releaseDate').datepicker('getDate')).toISOString();
+    $('#keywords').on('change', function () {
+        data.description.keywords = $('#keywords').val().split(',');
     });
-  }
-  $("#keywordsTag").tagit({
-    availableTags: data.description.keywords,
-    singleField: true,
-    allowSpaces: true,
-    singleFieldNode: $('#keywords')
-  });
-  $('#keywords').on('change', function () {
-    data.description.keywords = $('#keywords').val().split(',');
-  });
-  $("#metaDescription").on('input', function () {
-    $(this).textareaAutoSize();
-    data.description.metaDescription = $(this).val();
-  });
-
-  // Save
-  var editNav = $('.edit-nav');
-  editNav.off(); // remove any existing event handlers.
-
-  editNav.on('click', '.btn-edit-save', function () {
-    save(updateContent);
-  });
-
-  // completed to review
-  editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
-    save(saveAndCompleteContent);
-  });
-
-  // reviewed to approve
-  editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
-    save(saveAndReviewContent);
-  });
-
-  function save(onSave) {
-    validateAndSaveTags(data);
-
-    // Sections
-    data.markdown = [$('#content-markdown').val()];
-    // Files are uploaded. Save metadata
-    var orderFile = $("#sortable-file").sortable('toArray');
-    $(orderFile).each(function (indexF, nameF) {
-      var title = $('#file-title_' + nameF).val();
-      var file = data.downloads[parseInt(nameF)].file;
-      newFiles[indexF] = {title: title, file: file};
+    $("#metaDescription").on('input', function () {
+        $(this).textareaAutoSize();
+        data.description.metaDescription = $(this).val();
     });
-    data.downloads = newFiles;
-    // charts
-    var orderChart = $("#sortable-chart").sortable('toArray');
-    $(orderChart).each(function (indexCh, nameCh) {
-      var uri = data.charts[parseInt(nameCh)].uri;
-      var title = data.charts[parseInt(nameCh)].title;
-      var filename = data.charts[parseInt(nameCh)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newChart[indexCh] = {uri: safeUri, title: title, filename: filename};
-    });
-    data.charts = newChart;
-    // tables
-    var orderTable = $("#sortable-table").sortable('toArray');
-    $(orderTable).each(function (indexTable, nameTable) {
-      var uri = data.tables[parseInt(nameTable)].uri;
-      var title = data.tables[parseInt(nameTable)].title;
-      var filename = data.tables[parseInt(nameTable)].filename;
-      var version = data.tables[parseInt(nameTable)].version;
-      var safeUri = checkPathSlashes(uri);
-      newTable[indexTable] = {uri: safeUri, title: title, filename: filename, version: version};
-    });
-    data.tables = newTable;
-    // images
-    var orderImage = $("#sortable-image").sortable('toArray');
-    $(orderImage).each(function (indexImage, nameImage) {
-      var uri = data.images[parseInt(nameImage)].uri;
-      var title = data.images[parseInt(nameImage)].title;
-      var filename = data.images[parseInt(nameImage)].filename;
-      var safeUri = checkPathSlashes(uri);
-      newImage[indexImage] = {uri: safeUri, title: title, filename: filename};
-    });
-    data.images = newImage;
-    // links
-    var orderLink = $("#sortable-link").sortable('toArray');
-    $(orderLink).each(function (indexL, nameL) {
-      if (data.links[parseInt(nameL)].title) {
-        var name = data.links[parseInt(nameL)].title;
-        var link = data.links[parseInt(nameL)].uri;
-        newLinks[indexL] = {uri: link, title: name};
-      } else {
-        var link = data.links[parseInt(nameL)].uri;
-        newLinks[indexL] = {uri: link};
-      }
-    });
-    data.links = newLinks;
 
-    // tags
-    if ($("#selectTopic").val() && $("#selectSubTopic").val()) {
-      data.description.canonicalTopic = $("#selectTopic").val()[0]
-      data.description.secondaryTopics = $("#selectSubTopic").val()
+    // Save
+    var editNav = $('.edit-nav');
+    editNav.off(); // remove any existing event handlers.
+
+    editNav.on('click', '.btn-edit-save', function () {
+        save(updateContent);
+    });
+
+    // completed to review
+    editNav.on('click', '.btn-edit-save-and-submit-for-review', function () {
+        save(saveAndCompleteContent);
+    });
+
+    // reviewed to approve
+    editNav.on('click', '.btn-edit-save-and-submit-for-approval', function () {
+        save(saveAndReviewContent);
+    });
+
+    function save(onSave) {
+        if (!validateMigrationPath(data.description.migrationLink)) {
+            sweetAlert(...MIGRATION_FIELD_VALIDATION_FAILURE);
+            return
+        }
+
+        validateAndSaveTags(data);
+
+        // Sections
+        data.markdown = [$('#content-markdown').val()];
+        // Files are uploaded. Save metadata
+        var orderFile = $("#sortable-file").sortable('toArray');
+        $(orderFile).each(function (indexF, nameF) {
+            var title = $('#file-title_' + nameF).val();
+            var file = data.downloads[parseInt(nameF)].file;
+            newFiles[indexF] = { title: title, file: file };
+        });
+        data.downloads = newFiles;
+        // charts
+        var orderChart = $("#sortable-chart").sortable('toArray');
+        $(orderChart).each(function (indexCh, nameCh) {
+            var uri = data.charts[parseInt(nameCh)].uri;
+            var title = data.charts[parseInt(nameCh)].title;
+            var filename = data.charts[parseInt(nameCh)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newChart[indexCh] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.charts = newChart;
+        // tables
+        var orderTable = $("#sortable-table").sortable('toArray');
+        $(orderTable).each(function (indexTable, nameTable) {
+            var uri = data.tables[parseInt(nameTable)].uri;
+            var title = data.tables[parseInt(nameTable)].title;
+            var filename = data.tables[parseInt(nameTable)].filename;
+            var version = data.tables[parseInt(nameTable)].version;
+            var safeUri = checkPathSlashes(uri);
+            newTable[indexTable] = { uri: safeUri, title: title, filename: filename, version: version };
+        });
+        data.tables = newTable;
+        // images
+        var orderImage = $("#sortable-image").sortable('toArray');
+        $(orderImage).each(function (indexImage, nameImage) {
+            var uri = data.images[parseInt(nameImage)].uri;
+            var title = data.images[parseInt(nameImage)].title;
+            var filename = data.images[parseInt(nameImage)].filename;
+            var safeUri = checkPathSlashes(uri);
+            newImage[indexImage] = { uri: safeUri, title: title, filename: filename };
+        });
+        data.images = newImage;
+        // links
+        var orderLink = $("#sortable-link").sortable('toArray');
+        $(orderLink).each(function (indexL, nameL) {
+            if (data.links[parseInt(nameL)].title) {
+                var name = data.links[parseInt(nameL)].title;
+                var link = data.links[parseInt(nameL)].uri;
+                newLinks[indexL] = { uri: link, title: name };
+            } else {
+                var link = data.links[parseInt(nameL)].uri;
+                newLinks[indexL] = { uri: link };
+            }
+        });
+        data.links = newLinks;
+
+        // tags
+        if ($("#selectTopic").val() && $("#selectSubTopic").val()) {
+            data.description.canonicalTopic = $("#selectTopic").val()[0]
+            data.description.secondaryTopics = $("#selectSubTopic").val()
+        }
+        else if ($("#selectTopic").val() && !$("#selectSubTopic").val()) {
+            sweetAlert("Cannot save this page", "A value is required for 'Subtopic' if a 'Topic' has been selected");
+            return
+        }
+
+        checkRenameUri(collectionId, data, renameUri, onSave);
     }
-    else if ($("#selectTopic").val() && !$("#selectSubTopic").val()) {
-      sweetAlert("Cannot save this page", "A value is required for 'Subtopic' if a 'Topic' has been selected");
-      return
-    } 
-
-    checkRenameUri(collectionId, data, renameUri, onSave);
-  }
 }
-

--- a/src/legacy/templates/workEditT3.handlebars
+++ b/src/legacy/templates/workEditT3.handlebars
@@ -35,6 +35,8 @@
             </div>
         </div>
 
+        <div id="migration"></div>
+
         <div id="highlighted-content"></div>
 
         <div id="timeseries"></div>

--- a/src/legacy/templates/workEditT4Compendium.handlebars
+++ b/src/legacy/templates/workEditT4Compendium.handlebars
@@ -81,6 +81,8 @@
             </div>
         </div>
 
+        <div id="migration"></div>
+
         <div id="section"></div>
 
         <div id="tab"></div>

--- a/src/legacy/templates/workEditT4Methodology.handlebars
+++ b/src/legacy/templates/workEditT4Methodology.handlebars
@@ -1,6 +1,5 @@
 <section class="panel workspace-edit">
     <div class="edit-accordion">
-
         <div class="edit-section">
             <div class="edit-section__head">
                 <h1>Metadata</h1>
@@ -10,55 +9,85 @@
                 <div id="metadata-list">
                     <div>
                         <label for="title">Title
-                            <textarea class="auto-size" type="text" id="title">{{this.description.title}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="title"
+                            >{{this.description.title}}</textarea>
                         </label>
                     </div>
                     <div class="release-date">
                         <label for="releaseDate">Release date
-                            <input id="releaseDate" type="text" placeholder="Day month year"
-                                   value="{{this.description.releaseDate}}"/>
+                            <input
+                                id="releaseDate"
+                                type="text"
+                                placeholder="Day month year"
+                                value="{{this.description.releaseDate}}"
+                            />
                         </label>
                     </div>
                     <div>
                         <label for="contactName">Contact name
-                            <textarea class="auto-size" type="text"
-                                      id="contactName">{{this.description.contact.name}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="contactName"
+                            >{{this.description.contact.name}}</textarea>
                         </label>
                     </div>
                     <div>
                         <label for="contactEmail">Contact email
-                            <textarea class="auto-size" type="text"
-                                      id="contactEmail">{{this.description.contact.email}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="contactEmail"
+                            >{{this.description.contact.email}}</textarea>
                         </label>
                     </div>
                     <div>
                         <label for="contactTelephone">Contact telephone
-                            <textarea class="auto-size" type="text"
-                                      id="contactTelephone">{{this.description.contact.telephone}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="contactTelephone"
+                            >{{this.description.contact.telephone}}</textarea>
                         </label>
                     </div>
                     <div id="summary-p">
                         <label for="summary">Summary
-                            <textarea class="auto-size" type="text" id="summary">{{this.description.summary}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="summary"
+                            >{{this.description.summary}}</textarea>
                         </label>
                     </div>
                     <div>
                         <label for="keywords">Keywords
-                            <input name="tags" id="keywords" value="{{this.description.keywords}}"
-                                   style="display: none;">
+                            <input
+                                name="tags"
+                                id="keywords"
+                                value="{{this.description.keywords}}"
+                                style="display: none;"
+                            >
                         </label>
                         <ul id="keywordsTag"></ul>
                     </div>
                     <div>
                         <label for="metaDescription">Meta description
-                            <textarea class="auto-size" type="text"
-                                      id="metaDescription">{{this.description.metaDescription}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="metaDescription"
+                            >{{this.description.metaDescription}}</textarea>
                         </label>
                     </div>
                 </div>
             </div>
         </div>
 
+        <div id="migration"></div>
+        
         <div id="tags"></div>
 
         <div id="section"></div>

--- a/src/legacy/templates/workEditT7.handlebars
+++ b/src/legacy/templates/workEditT7.handlebars
@@ -15,97 +15,153 @@
                     <div id="metadata-list">
                         <div>
                             <label for="title">Title
-                                <textarea class="auto-size" type="text" id="title">{{this.description.title}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="title"
+                                >{{this.description.title}}</textarea>
                             </label>
                         </div>
                         <div id="summary-p">
                             <label for="summary">Summary
-                                <textarea class="auto-size" type="text"
-                                          id="summary">{{this.description.summary}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="summary"
+                                >{{this.description.summary}}</textarea>
                             </label>
                         </div>
                         <div id="natStat">
                             <label for="natStat-checkbox">Accredited official statistics </label>
-                            <input id="natStat-checkbox" type="checkbox" name="natStat" value="false"/>
+                            <input
+                                id="natStat-checkbox"
+                                type="checkbox"
+                                name="natStat"
+                                value="false"
+                            />
                         </div>
                         <div id="contact-p">
                             <label for="contactName">Contact name
-                                <textarea class="auto-size" type="text"
-                                          id="contactName">{{this.description.contact.name}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="contactName"
+                                >{{this.description.contact.name}}</textarea>
                             </label>
                             <label for="contactEmail">Contact email
-                                <textarea class="auto-size" type="text"
-                                          id="contactEmail">{{this.description.contact.email}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="contactEmail"
+                                >{{this.description.contact.email}}</textarea>
                             </label>
                             <label for="contactPhone">Contact phone
-                                <textarea class="auto-size" type="text"
-                                          id="contactTelephone">{{this.description.contact.telephone}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="contactTelephone"
+                                >{{this.description.contact.telephone}}</textarea>
                             </label>
                         </div>
                         <div id="survey-p">
                             <label for="survey">Survey name
-                                <textarea class="auto-size" type="text"
-                                          id="survey">{{this.description.surveyName}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="survey"
+                                >{{this.description.surveyName}}</textarea>
                             </label>
                         </div>
                         <div id="frequency-p">
                             <label for="frequency">Frequency
-                                <textarea class="auto-size" type="text"
-                                          id="frequency">{{this.description.frequency}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="frequency"
+                                >{{this.description.frequency}}</textarea>
                             </label>
                         </div>
                         <div id="compilation-p">
                             <label for="compilation">How compiled
-                                <textarea class="auto-size" type="text"
-                                          id="compilation">{{this.description.compilation}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="compilation"
+                                >{{this.description.compilation}}</textarea>
                             </label>
                         </div>
                         <div id="geoCoverage-p">
                             <label for="geoCoverage">Geographic coverage
-                                <textarea class="auto-size" type="text"
-                                          id="geoCoverage">{{this.description.geographicCoverage}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="geoCoverage"
+                                >{{this.description.geographicCoverage}}</textarea>
                             </label>
                         </div>
                         <div id="sampleSize-p">
                             <label for="sampleSize">Sample size
-                                <textarea class="auto-size" type="text"
-                                          id="sampleSize">{{this.description.sampleSize}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="sampleSize"
+                                >{{this.description.sampleSize}}</textarea>
                             </label>
                         </div>
                         <div class="lastRevised-p">
                             <label for="lastRevised">Last revised
-                                <input type="text" id="lastRevised" placeholder="Day month year"
-                                       value="{{this.description.lastRevised}}"/>
+                                <input
+                                    type="text"
+                                    id="lastRevised"
+                                    placeholder="Day month year"
+                                    value="{{this.description.lastRevised}}"
+                                />
                             </label>
                         </div>
                         <div class="release-date">
                             <label for="releaseDate">Last updated
-                                <input id="releaseDate" type="text" placeholder="Day month year"
-                                       value="{{this.description.releaseDate}}"/>
+                                <input
+                                    id="releaseDate"
+                                    type="text"
+                                    placeholder="Day month year"
+                                    value="{{this.description.releaseDate}}"
+                                />
                             </label>
                         </div>
                         <div id="reference-p">
                             <label for="reference">Reference
-                                <textarea class="auto-size" type="text"
-                                          id="reference">{{this.description.reference}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="reference"
+                                >{{this.description.reference}}</textarea>
                             </label>
                         </div>
                         <div>
                             <label for="keywords">Keywords
-                                <input name="tags" id="keywords" value="{{this.description.keywords}}"
-                                       style="display: none;">
+                                <input
+                                    name="tags"
+                                    id="keywords"
+                                    value="{{this.description.keywords}}"
+                                    style="display: none;"
+                                >
                             </label>
                             <ul id="keywordsTag"></ul>
                         </div>
                         <div>
                             <label for="metaDescription">Meta description
-                                <textarea class="auto-size" type="text"
-                                          id="metaDescription">{{this.description.metaDescription}}</textarea>
+                                <textarea
+                                    class="auto-size"
+                                    type="text"
+                                    id="metaDescription"
+                                >{{this.description.metaDescription}}</textarea>
                             </label>
                         </div>
                     </div>
                 </div>
             </div>
+
+            <div id="migration"></div>
 
             <div id="tags"></div>
 

--- a/src/legacy/templates/workEditT7Landing.handlebars
+++ b/src/legacy/templates/workEditT7Landing.handlebars
@@ -1,71 +1,116 @@
 <section class="panel workspace-edit">
-  <div class="edit-accordion">
+    <div class="edit-accordion">
 
-    <div class="edit-section">
-      <div class="edit-section__head">
-        <h1>Metadata</h1>
-        <p>Title | Summary | Keywords</p>
-      </div>
-      <div class="edit-section__content">
-        <div id="metadata-list">
-          <div>
-            <label for="title">Title
-              <textarea class="auto-size" type="text" id="title">{{this.description.title}}</textarea>
-            </label>
-          </div>
-          <div id="summary-p">
-            <label for="summary">Summary
-              <textarea class="auto-size" type="text" id="summary">{{this.description.summary}}</textarea>
-            </label>
-          </div>
-          <div>
-            <label for="keywords">Keywords
-              <input name="tags" id="keywords" value="{{this.description.keywords}}" style="display: none;">
-            </label>
-            <ul id="keywordsTag"></ul>
-          </div>
-          <div>
-            <label for="metaDescription">Meta description
-              <textarea class="auto-size" type="text" id="metaDescription">{{this.description.metaDescription}}</textarea>
-            </label>
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <div class="edit-section">
-      <div class="edit-section__head">
-        <h1>Sections</h1>
-        <p> Link | Summary</p>
-      </div>
-      <div class="edit-section__content">
-        <div id="sortable-section" class="edit-section__sortable">
-          {{#each this.sections}}
-            <div id="{{@index}}" class="edit-section__sortable-item">
-              <textarea class="auto-size" id="section-uri_{{@index}}" placeholder="Copy link or click Go to, navigate to page and click Copy link. Then add a title and click Edit">{{uri}}</textarea>
-              <textarea class="auto-size" id="section-title_{{@index}}" placeholder="Type a title and click Edit">{{title}}</textarea>
-              <textarea style="display: none;" id="section-markdown_{{@index}}">{{summary}}</textarea>
-              <button class="btn btn--primary btn-markdown-edit" id="section-edit_{{@index}}">Edit</button>
-              <button class="btn btn--primary btn-page-delete" id="section-delete_{{@index}}">Delete</button>
+        <div class="edit-section">
+            <div class="edit-section__head">
+                <h1>Metadata</h1>
+                <p>Title | Summary | Keywords</p>
             </div>
-          {{/each}}
+            <div class="edit-section__content">
+                <div id="metadata-list">
+                    <div>
+                        <label for="title">Title
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="title"
+                            >{{this.description.title}}</textarea>
+                        </label>
+                    </div>
+                    <div id="summary-p">
+                        <label for="summary">Summary
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="summary"
+                            >{{this.description.summary}}</textarea>
+                        </label>
+                    </div>
+                    <div>
+                        <label for="keywords">Keywords
+                            <input
+                                name="tags"
+                                id="keywords"
+                                value="{{this.description.keywords}}"
+                                style="display: none;"
+                            >
+                        </label>
+                        <ul id="keywordsTag"></ul>
+                    </div>
+                    <div>
+                        <label for="metaDescription">Meta description
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="metaDescription"
+                            >{{this.description.metaDescription}}</textarea>
+                        </label>
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="text-center">
-          <button class="btn btn--subtle btn-add-section" id="add-section">Add section</button>
+
+        <div id="migration"></div>
+
+        <div class="edit-section">
+            <div class="edit-section__head">
+                <h1>Sections</h1>
+                <p> Link | Summary</p>
+            </div>
+            <div class="edit-section__content">
+                <div
+                    id="sortable-section"
+                    class="edit-section__sortable"
+                >
+                    {{#each this.sections}}
+                        <div
+                            id="{{@index}}"
+                            class="edit-section__sortable-item"
+                        >
+                            <textarea
+                                class="auto-size"
+                                id="section-uri_{{@index}}"
+                                placeholder="Copy link or click Go to, navigate to page and click Copy link. Then add a title and click Edit"
+                            >{{uri}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                id="section-title_{{@index}}"
+                                placeholder="Type a title and click Edit"
+                            >{{title}}</textarea>
+                            <textarea
+                                style="display: none;"
+                                id="section-markdown_{{@index}}"
+                            >{{summary}}</textarea>
+                            <button
+                                class="btn btn--primary btn-markdown-edit"
+                                id="section-edit_{{@index}}"
+                            >Edit</button>
+                            <button
+                                class="btn btn--primary btn-page-delete"
+                                id="section-delete_{{@index}}"
+                            >Delete</button>
+                        </div>
+                    {{/each}}
+                </div>
+                <div class="text-center">
+                    <button
+                        class="btn btn--subtle btn-add-section"
+                        id="add-section"
+                    >Add section</button>
+                </div>
+            </div>
         </div>
-      </div>
+
+        <div id="edition"></div>
+
+        <div id="content"></div>
+
+        <div id="link"></div>
+
     </div>
 
-    <div id="edition"></div>
-
-    <div id="content"></div>
-
-    <div id="link"></div>
-
-  </div>
-
-  <nav class="edit-nav">
-    {{> editNav}}
-  </nav>
+    <nav class="edit-nav">
+        {{> editNav}}
+    </nav>
 
 </section>

--- a/src/legacy/templates/workEditT7StaticArticle.handlebars
+++ b/src/legacy/templates/workEditT7StaticArticle.handlebars
@@ -1,6 +1,5 @@
 <section class="panel workspace-edit">
     <div class="edit-accordion">
-
         <div class="edit-section">
             <div class="edit-section__head">
                 <h1>Metadata</h1>
@@ -10,36 +9,57 @@
                 <div id="metadata-list">
                     <div>
                         <label for="title">Title
-                            <textarea class="auto-size" type="text" id="title">{{this.description.title}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="title"
+                            >{{this.description.title}}</textarea>
                         </label>
                     </div>
                     <div class="release-date">
                         <label for="releaseDate">Release date
-                            <input id="releaseDate" type="text" placeholder="Day month year"
-                                   value="{{this.description.releaseDate}}"/>
+                            <input
+                                id="releaseDate"
+                                type="text"
+                                placeholder="Day month year"
+                                value="{{this.description.releaseDate}}"
+                            />
                         </label>
                     </div>
                     <div id="summary-p">
                         <label for="summary">Summary
-                            <textarea class="auto-size" type="text" id="summary">{{this.description.summary}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="summary"
+                            >{{this.description.summary}}</textarea>
                         </label>
                     </div>
                     <div>
                         <label for="keywords">Keywords
-                            <input name="tags" id="keywords" value="{{this.description.keywords}}"
-                                   style="display: none;">
+                            <input
+                                name="tags"
+                                id="keywords"
+                                value="{{this.description.keywords}}"
+                                style="display: none;"
+                            >
                         </label>
                         <ul id="keywordsTag"></ul>
                     </div>
                     <div>
                         <label for="metaDescription">Meta description
-                            <textarea class="auto-size" type="text"
-                                      id="metaDescription">{{this.description.metaDescription}}</textarea>
+                            <textarea
+                                class="auto-size"
+                                type="text"
+                                id="metaDescription"
+                            >{{this.description.metaDescription}}</textarea>
                         </label>
                     </div>
                 </div>
             </div>
         </div>
+
+        <div id="migration"></div>
 
         <div id="section"></div>
 

--- a/src/legacy/templates/workEditT8Compendium.handlebars
+++ b/src/legacy/templates/workEditT8Compendium.handlebars
@@ -82,6 +82,8 @@
                 </div>
             </div>
 
+            <div id="migration"></div>
+
             <div id="file"></div>
 
             <div id="document"></div>


### PR DESCRIPTION
### What
✅ Added migration field to the following [non-editorial content types](https://jira.ons.gov.uk/browse/DIS-3284):
- product_page
- compendium_chapter
- compendium_data
- static_landing_page
- static_article
- static_methodology
- static_methodology_download
- static_page
- static_qmi
- static_foi
- static_adhoc
Also added further validation to the migration input field (cannot end with a `/`) 

### How to review

Sense check
_Optionally_ test locally:
- Pull this branch `make debug ENABLE_MIGRATION_FIELD=true` (you may need to rebuild `node_modules`)
- Port forward publishing api router
- Use the [content types spreadsheet](https://docs.google.com/spreadsheets/d/184zo7ZPaw84T53Vfb2T5vbGMMgwQ95yg/edit?gid=1272843549#gid=1272843549) to find the content in sandbox and test 

### Who can review

Frontend dev
