### PR TITLE
Make navbar more consistent

### DIFF
--- a/src/app/components/navbar/NavBar.jsx
+++ b/src/app/components/navbar/NavBar.jsx
@@ -84,17 +84,11 @@ const NavBar = props => {
                                 Publishing queue
                             </a>
                         </li>
-                        {auth.isAdminOrEditor(props.user) && (
-                            <li className="global-nav__item">
-                                <Link to={`${rootPath}/users`} activeClassName="selected" className="global-nav__link">
-                                    Users and access
-                                </Link>
-                            </li>
-                        )}
-                    </>
-                )}
-                {auth.isAdminOrEditor(props.user) && (
-                    <>
+                        <li className="global-nav__item">
+                            <Link to={`${rootPath}/users`} activeClassName="selected" className="global-nav__link">
+                                Users and access
+                            </Link>
+                        </li>
                         <li className="global-nav__item">
                             <Link to={`${rootPath}/groups`} activeClassName="selected" className="global-nav__link">
                                 Preview teams
@@ -103,13 +97,11 @@ const NavBar = props => {
                     </>
                 )}
                 {auth.isAdmin(props.user) && (
-                    <>
-                        <li className="global-nav__item">
-                            <Link to={`${rootPath}/security`} activeClassName="selected" className="global-nav__link">
-                                Security
-                            </Link>
-                        </li>
-                    </>
+                    <li className="global-nav__item">
+                        <Link to={`${rootPath}/security`} activeClassName="selected" className="global-nav__link">
+                            Security
+                        </Link>
+                    </li>
                 )}
                 <li className="global-nav__item">
                     <Link to={url.resolve("/logout")} className="global-nav__link">

--- a/src/legacy/js/classes/florence.js
+++ b/src/legacy/js/classes/florence.js
@@ -64,6 +64,12 @@ Florence.Authentication = {
     },
     isAdmin: function() {
         return localStorage.getItem("userRole") === "ADMIN";
+    },
+    isEditor: function() {
+        return localStorage.getItem("userRole") === "EDITOR";
+    },
+    isAdminOrEditor: function() {
+        return this.isAdmin() || this.isEditor();
     }
 };
 

--- a/src/legacy/templates/mainNav.handlebars
+++ b/src/legacy/templates/mainNav.handlebars
@@ -15,20 +15,17 @@
                 on: {{this.collection.name}}</a></li>
         {{/if}}
 
-        <li class="nav__item">
-            <a class="nav__link js-nav-item js-nav-item--collections" href="javascript:void(0)">Collections</a>
-        </li>
-        <li class="nav__item">
-            <a class="nav__link js-nav-item js-nav-item--datasets" href="javascript:void(0)">Datasets</a>
-        </li>
+        <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--collections" href="javascript:void(0)">Collections</a></li>
+        {{#if this.Authentication.isAdminOrEditor }}
+        <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--datasets" href="javascript:void(0)">Datasets</a></li>
         <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--publish" href="javascript:void(0)">Publishing queue</a></li>
-        {{#if this.Authentication.isAdmin}}
-            <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--users" href="javascript:void(0)">Users and access</a></li>
-        {{/if}}
+        <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--users" href="javascript:void(0)">Users and access</a></li>
         <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--teams" href="javascript:void(0)">Preview teams</a></li>
-         {{#if this.Authentication.isAdmin}}
-            <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--security" href="javascript:void(0)">Security</a></li>
-         {{/if}}
+        {{/if}}
+
+        {{#if this.Authentication.isAdmin}}
+        <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--security" href="javascript:void(0)">Security</a></li>
+        {{/if}}
         <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--logout" href="javascript:void(0)">Sign out</a></li>
     {{else}}
         <li class="nav__item"><a class="nav__link js-nav-item js-nav-item--login selected" href="javascript:void(0)">Sign in</a></li>


### PR DESCRIPTION
### What

Made the nav bar more consistent between the two parts of Florence.

AdminOrEditor should now be able to see:
- Datasets
- Publishing Queue
- Users and Access
- Preview Teams

Admin only should see:
- Security

All should see:
- Collections
- Logout

### How to review

Run it, login (may involve complicated setup with the legacy-core-publishing stack) and see you can see the right things. 

### Who can review

Not me. 