### PR TITLE
Accept minimatch vulnerability

### DIFF
--- a/src/audit-allowlist.json
+++ b/src/audit-allowlist.json
@@ -19,6 +19,10 @@
         {
             "id": "CVE-2025-57352",
             "reason": "Requires upgrades to dp-table-builder-ui"
+        },
+        {
+            "id": "CVE-2026-26996",
+            "reason": "Temporary allow to progress release - audit flags as all version prior to 10.2.0 are vulnerable. v3 is still being maintained but no patch release yet."
         }
     ]
 }


### PR DESCRIPTION
### What

I have allow the minimatch vuln to pass - this is because the v3 branch does not have a patch yet and is still being maintained. This will allow a prod release with no code changes. A maintenance ticket will be created to revisit this.

### How to review

Check now passes.

### Who can review

Not me. 