### PR TITLE
Remove this when determining admin or editor

### DIFF
--- a/src/legacy/js/classes/florence.js
+++ b/src/legacy/js/classes/florence.js
@@ -69,7 +69,7 @@ Florence.Authentication = {
         return localStorage.getItem("userRole") === "EDITOR";
     },
     isAdminOrEditor: function() {
-        return this.isAdmin() || this.isEditor();
+        return Florence.Authentication.isAdmin() || Florence.Authentication.isEditor();
     }
 };
 


### PR DESCRIPTION
### What

Using `this` was causing issues so I have removed it in favour of the direct path to the function.

### How to review

Check looks ok - optionally you can test it by:

- enable permissions api
- port forward to dp-identity-api in sandbox
- run the dp-api-router
- run florence
- login
- go the publishing queue screen

### Who can review

Not me. 