### PR TITLE
Fix/automated collection list

### DIFF
--- a/src/app/views/collections/mapper/collectionMapper.js
+++ b/src/app/views/collections/mapper/collectionMapper.js
@@ -245,9 +245,7 @@ export default class collectionMapper {
 
         if (collection.publishDate) {
             return date.format(collection.publishDate, "ddd, dd/mm/yyyy h:MMTT");
-        }
-
-        if (!collection.publishDate) {
+        } else {
             // This check should be a switch with manual but this
             // approach preserves the existing logic better in this
             // instance.

--- a/src/app/views/collections/mapper/collectionMapper.js
+++ b/src/app/views/collections/mapper/collectionMapper.js
@@ -248,6 +248,13 @@ export default class collectionMapper {
         }
 
         if (!collection.publishDate) {
+            // This check should be a switch with manual but this
+            // approach preserves the existing logic better in this
+            // instance.
+            if (collection.type === "automated") {
+                return "[automated collection]";
+            }
+
             return "[manual collection]";
         }
     }

--- a/src/legacy/js/functions/_createCollection.js
+++ b/src/legacy/js/functions/_createCollection.js
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This function is from the legacy implementation of collection editing
+ * and should likely be removed.
+*/ 
 function createCollection(teams) {
 
     var publishTime, collectionId, collectionDate, releaseUri;

--- a/src/legacy/js/functions/_editCollection.js
+++ b/src/legacy/js/functions/_editCollection.js
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This function is from the legacy implementation of collection editing
+ * and should likely be removed.
+*/ 
 function editCollection(collection) {
 
     switchEditLinkText();

--- a/src/legacy/js/functions/_postApproveCollection.js
+++ b/src/legacy/js/functions/_postApproveCollection.js
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This function is from the legacy implementation of collection editing
+ * and should likely be removed.
+*/ 
 function postApproveCollection(collectionId) {
     $.ajax({
         url: `${API_PROXY.VERSIONED_PATH}/approve/${collectionId}`,

--- a/src/legacy/js/functions/_viewCollectionDetails.js
+++ b/src/legacy/js/functions/_viewCollectionDetails.js
@@ -1,3 +1,7 @@
+/**
+ * @deprecated This function is from the legacy implementation of collection editing
+ * and should likely be removed.
+*/ 
 function viewCollectionDetails(collectionId, $this) {
 
     getCollectionDetails(collectionId,

--- a/src/legacy/js/functions/_viewRestoreDeleted.js
+++ b/src/legacy/js/functions/_viewRestoreDeleted.js
@@ -1,4 +1,7 @@
-
+/**
+ * @deprecated This function is from the legacy implementation of collection editing
+ * and should likely be removed.
+*/ 
 function viewRestoreDeleted(collectionData) {
 
     var onSearchDeletedPagesData;

--- a/src/legacy/templates/collectionDetails.handlebars
+++ b/src/legacy/templates/collectionDetails.handlebars
@@ -1,3 +1,4 @@
+{{!-- DEPRECATED: This template is from the legacy implementation of collection editing and should likely be removed. --}}
 <div class="slider">
     <div class="slider__head js-collection__head">
         <h2>{{name}}<span class="edit btn-collection-edit js-edit-collection">Edit collection</span></h2>

--- a/src/legacy/templates/collectionEdit.handlebars
+++ b/src/legacy/templates/collectionEdit.handlebars
@@ -1,3 +1,4 @@
+{{!-- DEPRECATED: This template is from the legacy implementation of collection editing and should likely be removed. --}}
 <div class="slider__modal js-collection__edit-modal">
     <div class="slider__content slider__content--padded">
         <p>{{createdBy collection.events}}</p>

--- a/src/legacy/templates/collectionList.handlebars
+++ b/src/legacy/templates/collectionList.handlebars
@@ -1,3 +1,4 @@
+{{!-- DEPRECATED: This template is from the legacy implementation of collection editing and should likely be removed. --}}
 <section class="panel panel--padded col col--6" xmlns="http://www.w3.org/1999/html">
     <h1 class="text-align-center">Select a collection</h1>
     <table class="table table--primary table--fixed-height-27 js-selectable-table">


### PR DESCRIPTION
### What

Automated collections aren't showing up in the list in florence with 'automated collection'
I've also marked a series of functions / template in legacy florence as deprecated.

### How to review

You can run florence with zebedee and change a collection to 'automated' via the content store - then see it in the list. This can be most easily done with the legacy-core-publishing stack

### Who can review

Not me. 