### PR TITLE
Feature/migration field ux normal pages

### DIFF
--- a/src/legacy/js/classes/florence.js
+++ b/src/legacy/js/classes/florence.js
@@ -28,6 +28,8 @@ var Florence = Florence || {
 
 Florence.Editor = {
     isDirty: false,
+    hasNonMigrationChanges: false,
+    warnOnNonMigrationSave: false,
     data: {}
 };
 

--- a/src/legacy/js/constants/sweetAlerts.js
+++ b/src/legacy/js/constants/sweetAlerts.js
@@ -1,2 +1,3 @@
 const MIGRATION_FIELD_VALIDATION_FAILURE = ["Cannot save this page", "Migration path must be a relative path starting with '/'"];
 const MIGRATED_DATASET_CONTENT = ["This content has been migrated", "You cannot make any changes or publish new editions or versions"];
+const MIGRATED_PAGE_CONTENT = ["This content has been migrated", "You can only make changes to the migration link"];

--- a/src/legacy/js/functions/_editAddFileWithDetails.js
+++ b/src/legacy/js/functions/_editAddFileWithDetails.js
@@ -27,6 +27,10 @@ function addFileWithDetails(collectionId, data, field, idField) {
 
             // Edit
             $('#' + idField + '-edit_' + index).click(function () {
+                // Block edit if content has migration link
+                if (blockNonMigrationChangeWithWarning()) {
+                    return;
+                }
                 var editedSectionValue = {
                     "title": $('#' + idField + '-title_' + index).val(),
                     "markdown": $('#' + idField + '-summary_' + index).val()

--- a/src/legacy/js/functions/_editIntLinks.js
+++ b/src/legacy/js/functions/_editIntLinks.js
@@ -39,6 +39,10 @@ function initialiseLinks(collectionId, data, templateData, field, idField) {
     $(data[field]).each(function (index) {
         // Delete
         $('#' + idField + '-delete_' + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete this link?",
@@ -83,6 +87,10 @@ function initialiseLinks(collectionId, data, templateData, field, idField) {
     //Add
     //$('#add-' + idField).off().one('click', function () {
     $('#add-link').off().click(function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         //add a modal to select an option for internal or external
         var position = $(".workspace-edit").scrollTop();
         Florence.globalVars.pagePos = position;

--- a/src/legacy/js/functions/_editMarkdownOneObject.js
+++ b/src/legacy/js/functions/_editMarkdownOneObject.js
@@ -24,6 +24,10 @@ function editMarkdownOneObject (collectionId, data, field, title) {
   $('#one').replaceWith(html);
   // Load
   $('#one-edit').click(function() {
+    // Block edit if content has migration link
+    if (blockNonMigrationChangeWithWarning()) {
+      return;
+    }
     var markdown = $('#one-markdown').val();
     var editedSectionValue = {title: 'Content', markdown: markdown};
     var saveContent = function(updatedContent) {
@@ -36,6 +40,10 @@ function editMarkdownOneObject (collectionId, data, field, title) {
 
   // Delete
   $('#one-delete').click(function() {
+    // Block delete if content has migration link
+    if (blockNonMigrationChangeWithWarning()) {
+      return;
+    }
     swal ({
       title: "Warning",
       text: "Are you sure you want to delete?",
@@ -61,6 +69,11 @@ function editMarkdownOneObject (collectionId, data, field, title) {
 }
 
 function saveMarkdownOne (collectionId, path, data, field) {
+  // Block save if content has migration link
+  if (blockNonMigrationChangeWithWarning()) {
+    return;
+  }
+  
   putContent(collectionId, path, JSON.stringify(data),
     success = function () {
       Florence.Editor.isDirty = false;

--- a/src/legacy/js/functions/_editMarkdownWithNoTitle.js
+++ b/src/legacy/js/functions/_editMarkdownWithNoTitle.js
@@ -21,6 +21,10 @@ function editMarkdownWithNoTitle(collectionId, data, field, idField) {
   $('#' + idField).replaceWith(html);
   // Load
   $('#content-edit').click(function () {
+    // Block edit if content has migration link
+    if (blockNonMigrationChangeWithWarning()) {
+      return;
+    }
     var markdown = $('#content-markdown').val();
     var editedSectionValue = {title: 'Content', markdown: markdown};
     var saveContent = function (updatedContent) {
@@ -37,6 +41,10 @@ function editMarkdownWithNoTitle(collectionId, data, field, idField) {
 
   // Delete
   $('#content-delete').click(function () {
+    // Block delete if content has migration link
+    if (blockNonMigrationChangeWithWarning()) {
+      return;
+    }
     swal({
       title: "Warning",
       text: "Are you sure you want to delete?",
@@ -63,6 +71,9 @@ function editMarkdownWithNoTitle(collectionId, data, field, idField) {
 }
 
 function saveMarkdownNoTitle(collectionId, path, data, field, idField) {
+  if (blockNonMigrationChangeWithWarning()) {
+    return;
+  }
   putContent(collectionId, path, JSON.stringify(data),
     success = function () {
       Florence.Editor.isDirty = false;

--- a/src/legacy/js/functions/_externalLinkAccordionSection.js
+++ b/src/legacy/js/functions/_externalLinkAccordionSection.js
@@ -28,6 +28,10 @@ function renderExternalLinkAccordionSection(collectionId, data, field, idField) 
     $(data[field]).each(function (index) {
 
         $('#' + idField + '-edit_' + index).click(function () {
+            // Block edit if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             var uri = data[field][index].uri;
             var title = data[field][index].title;
             if (idField === "filterable-dataset") {
@@ -39,6 +43,10 @@ function renderExternalLinkAccordionSection(collectionId, data, field, idField) 
 
         // Delete
         $('#' + idField + '-delete_' + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete?",
@@ -68,6 +76,10 @@ function renderExternalLinkAccordionSection(collectionId, data, field, idField) 
 
     //Add
     $('#add-' + idField).click(function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         var position = $(".workspace-edit").scrollTop();
         Florence.globalVars.pagePos = position + 300;
         if (idField === "filterable-dataset") {
@@ -90,6 +102,10 @@ function renderExternalLinkAccordionSection(collectionId, data, field, idField) 
     sortable();
 
     function saveLink(collectionId, path, data, field, idField) {
+        // Block save if content has migration link - any change to links is a non-migration change
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         putContent(collectionId, path, JSON.stringify(data),
             success = function () {
                 Florence.Editor.isDirty = false;

--- a/src/legacy/js/functions/_fileDelete.js
+++ b/src/legacy/js/functions/_fileDelete.js
@@ -1,4 +1,9 @@
 function fileDelete (collectionId, data, field, index) {
+  // Block delete if content has migration link
+  if (blockNonMigrationChangeWithWarning()) {
+    return;
+  }
+
   swal ({
     title: "Warning",
     text: "Are you sure you want to delete this file?",

--- a/src/legacy/js/functions/_fileUpload.js
+++ b/src/legacy/js/functions/_fileUpload.js
@@ -1,4 +1,9 @@
 function uploadFile(collectionId, data, field, idField, lastIndex, downloadExtensions, onSave) {
+    // Block file upload if content has migration link
+    if (blockNonMigrationChangeWithWarning()) {
+        return;
+    }
+
     var position = $(".workspace-edit").scrollTop();
     Florence.globalVars.pagePos = position + 200;
     var html = templates.uploadFileForm(lastIndex);

--- a/src/legacy/js/functions/_loadChartsList.js
+++ b/src/legacy/js/functions/_loadChartsList.js
@@ -18,6 +18,10 @@ function refreshChartList(collectionId, data) {
 function initialiseChartList(collectionId, data) {
 
     $('#add-chart').click(function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         loadChartBuilder(data, function () {
             refreshPreview();
 
@@ -41,6 +45,10 @@ function initialiseChartList(collectionId, data) {
         var chartJson = chartPath;
 
         $("#chart-edit_" + index).click(function () {
+            // Block edit if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             getPageData(collectionId, chartJson,
                 onSuccess = function (chartData) {
 
@@ -62,6 +70,10 @@ function initialiseChartList(collectionId, data) {
         });
 
         $("#chart-delete_" + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete this chart?",

--- a/src/legacy/js/functions/_loadEquationsList.js
+++ b/src/legacy/js/functions/_loadEquationsList.js
@@ -18,6 +18,10 @@ function refreshEquationsList(collectionId, data) {
 function initialiseEquationList(collectionId, data) {
 
     $('#add-equation').click(function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         loadEquationBuilder(data, function () {
             refreshPreview();
 
@@ -41,6 +45,10 @@ function initialiseEquationList(collectionId, data) {
         var equationJson = equationPath;
 
         $("#equation-edit_" + index).click(function () {
+            // Block edit if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             getPageData(collectionId, equationJson,
                 onSuccess = function (equationData) {
 
@@ -62,6 +70,10 @@ function initialiseEquationList(collectionId, data) {
         });
 
         $("#equation-delete_" + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete this equation?",

--- a/src/legacy/js/functions/_loadImagesList.js
+++ b/src/legacy/js/functions/_loadImagesList.js
@@ -15,6 +15,10 @@ function refreshImagesList(collectionId, data) {
 function initialiseImagesList(collectionId, data) {
 
     $('#add-image').click(function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         loadImageBuilder(data, function () {
             Florence.Editor.isDirty = false;
             refreshImagesList(collectionId, data);
@@ -27,6 +31,10 @@ function initialiseImagesList(collectionId, data) {
         var imageJson = noExtension[1] + '.json';
 
         $("#image-edit_" + index).click(function () {
+            // Block edit if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             getPageResource(collectionId, imageJson,
                 onSuccess = function (imageData) {
                     loadImageBuilder(data, function () {
@@ -39,6 +47,10 @@ function initialiseImagesList(collectionId, data) {
         });
 
         $("#image-delete_" + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete this image?",

--- a/src/legacy/js/functions/_loadTablesList.js
+++ b/src/legacy/js/functions/_loadTablesList.js
@@ -15,6 +15,10 @@ function refreshTablesList(collectionId, data) {
 function initialiseTablesList(collectionId, data) {
 
     $('#add-table-v2').click(function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         loadTableBuilderV2(data, function () {
             Florence.Editor.isDirty = false;
             refreshPreview();
@@ -28,6 +32,10 @@ function initialiseTablesList(collectionId, data) {
         var tableJson = tablePath;
 
         $("#table-edit_" + index).click(function () {
+            // Block edit if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             getPageData(collectionId, tableJson,
                 onSuccess = function (tableData) {
                     let onSave = function () {
@@ -42,6 +50,10 @@ function initialiseTablesList(collectionId, data) {
         });
 
         $("#table-delete_" + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete this table?",

--- a/src/legacy/js/functions/_markdownContentAccordionSection.js
+++ b/src/legacy/js/functions/_markdownContentAccordionSection.js
@@ -51,6 +51,10 @@ function initialiseMarkdownContentAccordionSection(collectionId, data, field, id
 
         // attach edit handler
         $('#' + idField + '-edit_' + index).click(function () {
+            // Block edit if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
 
             // create view model to pass to the markdown editor
             var editedSectionValue = {
@@ -75,6 +79,10 @@ function initialiseMarkdownContentAccordionSection(collectionId, data, field, id
 
         // attach delete handler
         $('#' + idField + '-delete_' + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete?",
@@ -105,6 +113,10 @@ function initialiseMarkdownContentAccordionSection(collectionId, data, field, id
 
     // Attach add new handler.
     $('#add-' + idField).off().one('click', function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         data[field].push({markdown: "", title: ""});
         saveContentThenRefreshSection(collectionId, data.uri, data, field, idField);
     });
@@ -141,6 +153,9 @@ function initialiseMarkdownContentAccordionSection(collectionId, data, field, id
     sortable();
 
     function saveContentThenRefreshSection(collectionId, path, data, field, idField) {
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         putContent(collectionId, path, JSON.stringify(data),
             success = function () {
                 Florence.Editor.isDirty = false;
@@ -158,4 +173,3 @@ function initialiseMarkdownContentAccordionSection(collectionId, data, field, id
         );
     }
 }
-

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -26,9 +26,19 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false, wa
 }
 
 function shouldBlockNonMigrationSave() {
-    Florence.Editor.hasNonMigrationChanges = hasNonMigrationInputChanges();
+    // no warning if no changes have been made
+    if (!Florence.Editor.isDirty) {
+        return false;
+    }
 
-    if (Florence.Editor.warnOnNonMigrationSave && Florence.Editor.hasMigrationLink && Florence.Editor.isDirty && Florence.Editor.hasNonMigrationChanges) {
+    const hasNonMigrationChanges = hasNonMigrationInputChanges();
+
+    let currentMigrationLink = $('#migration_link').val();
+    if (currentMigrationLink) {
+        currentMigrationLink = currentMigrationLink.trim();
+    }
+
+    if (Florence.Editor.warnOnNonMigrationSave && currentMigrationLink && hasNonMigrationChanges) {
         sweetAlert(...MIGRATED_PAGE_CONTENT);
         return true;
     }
@@ -36,9 +46,21 @@ function shouldBlockNonMigrationSave() {
     return false;
 }
 
-/**
- * Disables save buttons for content that has been migrated.
- */
+// Blocks save and shows warning if content has a migration link.
+function blockNonMigrationChangeWithWarning() {
+    let currentMigrationLink = $('#migration_link').val();
+    if (currentMigrationLink) {
+        currentMigrationLink = currentMigrationLink.trim();
+    }
+
+    if (Florence.Editor.warnOnNonMigrationSave && currentMigrationLink) {
+        sweetAlert(...MIGRATED_PAGE_CONTENT);
+        return true;
+    }
+    return false;
+}
+
+// Disables save buttons for content that has been migrated.
 function disableSaveButtonsForMigratedContent() {
     if (!Florence.Editor.hasMigrationLink) {
         return;
@@ -71,10 +93,12 @@ function hasInputChanged(input) {
     }
 
     if (type === 'checkbox') {
-        return input.checked !== input.defaultChecked;
+        const changed = input.checked !== input.defaultChecked;
+        return changed;
     }
 
-    return input.value !== input.defaultValue;
+    const changed = input.value !== input.defaultValue;
+    return changed;
 }
 
 // isRelativePath validates if the given path is a relative path

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -3,14 +3,17 @@
  * @param templateData
  * @param data
  * @param isReadOnlyMigrationPath
+ * @param warnOnNonMigrationSave
  */
 
-async function migration(templateData, data, isReadOnlyMigrationPath = false) {
+async function migration(templateData, data, isReadOnlyMigrationPath = false, warnOnNonMigrationSave = false) {
     const migrationConfig = window.getEnv().enableMigrationField;
     if (migrationConfig) {
         Florence.Editor.hasMigrationLink = data.description?.migrationLink || '';
+        Florence.Editor.warnOnNonMigrationSave = warnOnNonMigrationSave;
+        Florence.Editor.hasNonMigrationChanges = false;
         templateData.readOnlyMigrationPath = isReadOnlyMigrationPath;
-        let html = templates.migration(templateData)
+        let html = templates.migration(templateData);
         $('#migration').replaceWith(html);
 
         if (!isReadOnlyMigrationPath) {
@@ -20,6 +23,17 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false) {
             });
         }
     }
+}
+
+function shouldBlockNonMigrationSave() {
+    Florence.Editor.hasNonMigrationChanges = hasNonMigrationInputChanges();
+
+    if (Florence.Editor.warnOnNonMigrationSave && Florence.Editor.hasMigrationLink && Florence.Editor.isDirty && Florence.Editor.hasNonMigrationChanges) {
+        sweetAlert(...MIGRATED_PAGE_CONTENT);
+        return true;
+    }
+
+    return false;
 }
 
 /**
@@ -34,6 +48,33 @@ function disableSaveButtonsForMigratedContent() {
         .prop('disabled', true);
     
     sweetAlert(...MIGRATED_DATASET_CONTENT);
+}
+
+function hasNonMigrationInputChanges() {
+    let hasChanges = false;
+
+    $('.workspace-edit :input').not('#migration_link').each(function () {
+        if (hasInputChanged(this)) {
+            hasChanges = true;
+            return false;
+        }
+    });
+
+    return hasChanges;
+}
+
+function hasInputChanged(input) {
+    const type = (input.type || '').toLowerCase();
+
+    if (type === 'button' || type === 'submit' || type === 'reset' || type === 'file') {
+        return false;
+    }
+
+    if (type === 'checkbox') {
+        return input.checked !== input.defaultChecked;
+    }
+
+    return input.value !== input.defaultValue;
 }
 
 // isRelativePath validates if the given path is a relative path

--- a/src/legacy/js/functions/_postComplete.js
+++ b/src/legacy/js/functions/_postComplete.js
@@ -1,5 +1,9 @@
 function saveAndCompleteContent(collectionId, path, content, recursive, redirectToPath) {
 
+    if (shouldBlockNonMigrationSave()) {
+        return;
+    }
+
     if (!recursive) {
         recursive = false;
     }
@@ -7,6 +11,7 @@ function saveAndCompleteContent(collectionId, path, content, recursive, redirect
     putContent(collectionId, path, content,
         success = function () {
             Florence.Editor.isDirty = false;
+            Florence.Editor.hasNonMigrationChanges = false;
             if (redirectToPath) {
                 completeContent(collectionId, path, recursive, redirectToPath);
             } else {

--- a/src/legacy/js/functions/_postReview.js
+++ b/src/legacy/js/functions/_postReview.js
@@ -1,5 +1,9 @@
 function saveAndReviewContent(collectionId, path, content, recursive, redirectToPath) {
 
+    if (shouldBlockNonMigrationSave()) {
+        return;
+    }
+
     if (!recursive) {
         recursive = false;
     }
@@ -7,6 +11,7 @@ function saveAndReviewContent(collectionId, path, content, recursive, redirectTo
     putContent(collectionId, path, content,
         success = function () {
             Florence.Editor.isDirty = false;
+            Florence.Editor.hasNonMigrationChanges = false;
             if (redirectToPath) {
                 postReview(collectionId, path, recursive, redirectToPath);
             } else {

--- a/src/legacy/js/functions/_relatedItemAccordionSection.js
+++ b/src/legacy/js/functions/_relatedItemAccordionSection.js
@@ -66,6 +66,10 @@ function initialiseRelatedItemAccordionSection(collectionId, data, templateData,
         $(data[field]).each(function (index) {
             // Attach delete button handler.
             $('#' + idField + '-delete_' + index).click(function () {
+                // Block delete if content has migration link
+                if (blockNonMigrationChangeWithWarning()) {
+                    return;
+                }
                 deleteItem(index);
             });
         });
@@ -73,6 +77,10 @@ function initialiseRelatedItemAccordionSection(collectionId, data, templateData,
 
     // attach add button handler.
     $('#add-' + idField).click(function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         renderRelatedItemModal();
     });
 
@@ -131,6 +139,9 @@ function initialiseRelatedItemAccordionSection(collectionId, data, templateData,
     }
 
     function saveContentAndRefreshSection() {
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         putContent(collectionId, data.uri, JSON.stringify(data),
             success = function () {
                 Florence.Editor.isDirty = false;
@@ -193,6 +204,10 @@ function initialiseRelatedItemAccordionSection(collectionId, data, templateData,
                 }, function(hasConfirmed) {
                     if (hasConfirmed) {
                         var templateTitle = "[Unpublished/broken]\n" + parsedURL.pathname;
+                        if (!data[field]) {
+                            data[field] = [];
+                            templateData[field] = [];
+                        }
                         data[field].push({uri: parsedURL.pathname});
                         templateData[field].push({uri: parsedURL.pathname, description: {title: templateTitle}});
                         saveContentAndRefreshSection();

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -9,11 +9,12 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
 
     var templateData = jQuery.extend(true, {}, pageData); // clone page data to add template related properties.
     templateData.isPageComplete = isPageComplete;
+    Florence.Editor.hasNonMigrationChanges = false;
 
     if (pageData.type === 'taxonomy_landing_page') {
         var html = templates.workEditT2(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'highlightedLinks', 'highlights');
         accordion();
         t2Editor(collectionId, pageData);
@@ -22,7 +23,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'product_page') {
         var html = templates.workEditT3(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData)
+        migration(templateData, pageData, false, true);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'items', 'timeseries');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'statsBulletins', 'bulletins');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedArticles', 'articles');
@@ -49,7 +50,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, false);
         tags(templateData);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
@@ -81,7 +82,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, false);
         tags(templateData);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
@@ -143,7 +144,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'compendium_landing_page') {
         var html = templates.workEditT6(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, false);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedData', 'data');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedMethodology', 'qmi');
@@ -169,7 +170,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');
@@ -186,7 +187,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'compendium_data') {
         var html = templates.workEditT8Compendium(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDatasets', 'dataset');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedMethodology', 'qmi');
@@ -200,7 +201,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_landing_page') {
         var html = templates.workEditT7Landing(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         accordion();
@@ -213,7 +214,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.tables) {
             loadTablesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         tags(templateData)
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -237,7 +238,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         tags(templateData)
         editIntAndExtLinks(collectionId, pageData, templateData, 'links', 'link');
@@ -250,7 +251,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_qmi') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -264,7 +265,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_foi') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -275,7 +276,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_adhoc') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -298,7 +299,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.equations) {
             loadEquationsList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         tags(templateData)
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
@@ -315,7 +316,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_methodology_download') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -331,7 +332,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'dataset_landing_page') {
         var html = templates.workEditT8LandingPage(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData, true);
+        migration(templateData, pageData, true, false);
         tags(templateData)
         editMarkdownOneObject(collectionId, pageData, 'section', 'Notes');
         addDataset(collectionId, pageData, 'datasets', 'edition');
@@ -357,7 +358,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'dataset') {
         var html = templates.workEditT8(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData, true);
+        migration(templateData, pageData, true, false);
         editDatasetVersion(collectionId, pageData, 'versions', 'version');
         editDatasetVersion(collectionId, pageData, 'versions', 'correction');
         addFile(collectionId, pageData, 'supplementaryFiles', 'supplementary-files');
@@ -379,7 +380,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'release') {
         var html = templates.workEditT16(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'prerelease');
         editDate(collectionId, pageData, templateData, 'dateChanges', 'changeDate');
         renderExternalLinkAccordionSection(collectionId, pageData, 'links', 'link');
@@ -433,6 +434,9 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     // Listen on all input within the workspace edit panel for dirty checks.
     $('.workspace-edit :input').on('input', function () {
         Florence.Editor.isDirty = true;
+        if (Florence.Editor.warnOnNonMigrationSave && this.id !== 'migration_link') {
+            Florence.Editor.hasNonMigrationChanges = true;
+        }
         // remove the handler now we know content has changed.
         //$(':input').unbind('input');
         //console.log('Changes detected.');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -431,6 +431,15 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         });
     }
 
+    // Initialise defaultValue/defaultChecked for all inputs to match current values
+    $('.workspace-edit :input').each(function () {
+        if (this.type === 'checkbox' || this.type === 'radio') {
+            this.defaultChecked = this.checked;
+        } else {
+            this.defaultValue = this.value;
+        }
+    });
+
     // Listen on all input within the workspace edit panel for dirty checks.
     $('.workspace-edit :input').on('input', function () {
         Florence.Editor.isDirty = true;

--- a/src/legacy/js/functions/_updateContent.js
+++ b/src/legacy/js/functions/_updateContent.js
@@ -1,7 +1,12 @@
 function updateContent(collectionId, path, content, redirectToPath) {
+    if (shouldBlockNonMigrationSave()) {
+        return;
+    }
+
     putContent(collectionId, path, content,
         success = function () {
             Florence.Editor.isDirty = false;
+            Florence.Editor.hasNonMigrationChanges = false;
             if (redirectToPath) {
                 createWorkspace(redirectToPath, collectionId, 'edit');
                 return;


### PR DESCRIPTION
### What

https://officefornationalstatistics.atlassian.net/browse/DIS-4812

- Add warning message when updating migrated content for pages:
  - taxonomy_landing_page
  - product_page
  - article_download
  - timeseries
  - compendium_chapter
  - compendium_data
  - static_landing_page
  - static_page
  - static_article
  - static_qmi
  - static_foi
  - static_adhoc
  - static_methodology
  - static_methodology_download
  - api_dataset_landing_page
  - timeseries_dataset
  - release
  - visualisation
- Add guard to related item modal; the onError handler was attempting to push
to data[field] without first checking if the array exists.

### How to review

- run florence locally with `make debug ENABLE_PERMISSION_API=true ENABLE_MIGRATION_FIELD=true`
- port forward the api-router
- login with sandbox creds
- Create collection, add migration link to a normal page i.e. a product page, approve and publish the change
- Create a new collection, edit the migrated content. 
  - Try updating other fields (excluding migration link) and save/save and submit for review - you should get the warning message
  - Remove all changes, you should be able to save
  - You should be able to update the migration link
- Adding a related link, uploading files, updating tables buttons should be blocked with a warning
- Test scenarios
  - Add a migration link (no warnings)
  - Add a migration link with other content changed (warnings)
  - Review a migration link (no warnings)
  - Edit a migration link (no warnings)
  - Edit a migration link with other content changes.....(warnings)
  - Delete a migration link (no warnings)
  - Delete a migration link with other content changes....(warnings)
- Check no warning for these content type
  - bulletin
  - article
  - compendium_landing_page
  - dataset
  - dataset_landing_page

### Who can review

!Me