### PR TITLE
Feature/migration field ux datasets

### DIFF
--- a/src/legacy/js/classes/florence.js
+++ b/src/legacy/js/classes/florence.js
@@ -28,6 +28,8 @@ var Florence = Florence || {
 
 Florence.Editor = {
     isDirty: false,
+    hasNonMigrationChanges: false,
+    warnOnNonMigrationSave: false,
     data: {}
 };
 

--- a/src/legacy/js/constants/sweetAlerts.js
+++ b/src/legacy/js/constants/sweetAlerts.js
@@ -1,2 +1,3 @@
 const MIGRATION_FIELD_VALIDATION_FAILURE = ["Cannot save this page", "Migration path must be a relative path starting with '/'"];
 const PAGE_CONTENT_MIGRATED = ["This content has been migrated", "You can only make changes to the migration link"];
+const DATASET_CONTENT_MIGRATED = ["This content has been migrated", "You cannot make any changes or publish new editions or versions"];

--- a/src/legacy/js/constants/sweetAlerts.js
+++ b/src/legacy/js/constants/sweetAlerts.js
@@ -1,1 +1,2 @@
 const MIGRATION_FIELD_VALIDATION_FAILURE = ["Cannot save this page", "Migration path must be a relative path starting with '/'"];
+const PAGE_CONTENT_MIGRATED = ["This content has been migrated", "You can only make changes to the migration link"];

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -3,13 +3,16 @@
  * @param templateData
  * @param data
  * @param isReadOnlyMigrationPath
+ * @param warnOnNonMigrationSave
  */
 
-async function migration(templateData, data, isReadOnlyMigrationPath = false) {
+async function migration(templateData, data, isReadOnlyMigrationPath = false, warnOnNonMigrationSave = false) {
     const migrationConfig = window.getEnv().enableMigrationField;
     if (migrationConfig) {
+        Florence.Editor.warnOnNonMigrationSave = warnOnNonMigrationSave;
+        Florence.Editor.hasNonMigrationChanges = false;
         templateData.readOnlyMigrationPath = isReadOnlyMigrationPath;
-        let html = templates.migration(templateData)
+        let html = templates.migration(templateData);
         $('#migration').replaceWith(html);
 
         if (!isReadOnlyMigrationPath) {
@@ -19,6 +22,15 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false) {
             });
         }
     }
+}
+
+function shouldBlockNonMigrationSave() {
+    if (Florence.Editor.warnOnNonMigrationSave && Florence.Editor.isDirty && Florence.Editor.hasNonMigrationChanges) {
+        sweetAlert(...PAGE_CONTENT_MIGRATED);
+        return true;
+    }
+
+    return false;
 }
 
 // isRelativePath validates if the given path is a relative path

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -25,12 +25,41 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false, wa
 }
 
 function shouldBlockNonMigrationSave() {
+    Florence.Editor.hasNonMigrationChanges = hasNonMigrationInputChanges();
+
     if (Florence.Editor.warnOnNonMigrationSave && Florence.Editor.isDirty && Florence.Editor.hasNonMigrationChanges) {
         sweetAlert(...PAGE_CONTENT_MIGRATED);
         return true;
     }
 
     return false;
+}
+
+function hasNonMigrationInputChanges() {
+    let hasChanges = false;
+
+    $('.workspace-edit :input').not('#migration_link').each(function () {
+        if (hasInputChanged(this)) {
+            hasChanges = true;
+            return false;
+        }
+    });
+
+    return hasChanges;
+}
+
+function hasInputChanged(input) {
+    const type = (input.type || '').toLowerCase();
+
+    if (type === 'button' || type === 'submit' || type === 'reset' || type === 'file') {
+        return false;
+    }
+
+    if (type === 'checkbox') {
+        return input.checked !== input.defaultChecked;
+    }
+
+    return input.value !== input.defaultValue;
 }
 
 // isRelativePath validates if the given path is a relative path

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -25,6 +25,15 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false, wa
     }
 }
 
+function disableSaveButtonsForMigratedContent() {
+    if (!Florence.Editor.hasMigrationLink) {
+        return;
+    }
+    $('.btn-edit-save, .btn-edit-save-and-submit-for-review, .btn-edit-save-and-submit-for-approval')
+        .addClass('btn--disabled')
+        .prop('disabled', true);
+}
+
 function shouldBlockNonMigrationSave() {
     Florence.Editor.hasNonMigrationChanges = hasNonMigrationInputChanges();
 

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -10,6 +10,7 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false, wa
     const migrationConfig = window.getEnv().enableMigrationField;
     if (migrationConfig) {
         Florence.Editor.warnOnNonMigrationSave = warnOnNonMigrationSave;
+        Florence.Editor.hasMigrationLink = data.description?.migrationLink || '';
         Florence.Editor.hasNonMigrationChanges = false;
         templateData.readOnlyMigrationPath = isReadOnlyMigrationPath;
         let html = templates.migration(templateData);
@@ -27,7 +28,7 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false, wa
 function shouldBlockNonMigrationSave() {
     Florence.Editor.hasNonMigrationChanges = hasNonMigrationInputChanges();
 
-    if (Florence.Editor.warnOnNonMigrationSave && Florence.Editor.isDirty && Florence.Editor.hasNonMigrationChanges) {
+    if (Florence.Editor.warnOnNonMigrationSave && Florence.Editor.hasMigrationLink && Florence.Editor.isDirty && Florence.Editor.hasNonMigrationChanges) {
         sweetAlert(...PAGE_CONTENT_MIGRATED);
         return true;
     }

--- a/src/legacy/js/functions/_postComplete.js
+++ b/src/legacy/js/functions/_postComplete.js
@@ -1,5 +1,9 @@
 function saveAndCompleteContent(collectionId, path, content, recursive, redirectToPath) {
 
+    if (shouldBlockNonMigrationSave()) {
+        return;
+    }
+
     if (!recursive) {
         recursive = false;
     }
@@ -7,6 +11,7 @@ function saveAndCompleteContent(collectionId, path, content, recursive, redirect
     putContent(collectionId, path, content,
         success = function () {
             Florence.Editor.isDirty = false;
+            Florence.Editor.hasNonMigrationChanges = false;
             if (redirectToPath) {
                 completeContent(collectionId, path, recursive, redirectToPath);
             } else {

--- a/src/legacy/js/functions/_postReview.js
+++ b/src/legacy/js/functions/_postReview.js
@@ -1,5 +1,9 @@
 function saveAndReviewContent(collectionId, path, content, recursive, redirectToPath) {
 
+    if (shouldBlockNonMigrationSave()) {
+        return;
+    }
+
     if (!recursive) {
         recursive = false;
     }
@@ -7,6 +11,7 @@ function saveAndReviewContent(collectionId, path, content, recursive, redirectTo
     putContent(collectionId, path, content,
         success = function () {
             Florence.Editor.isDirty = false;
+            Florence.Editor.hasNonMigrationChanges = false;
             if (redirectToPath) {
                 postReview(collectionId, path, recursive, redirectToPath);
             } else {

--- a/src/legacy/js/functions/_relatedItemAccordionSection.js
+++ b/src/legacy/js/functions/_relatedItemAccordionSection.js
@@ -193,6 +193,10 @@ function initialiseRelatedItemAccordionSection(collectionId, data, templateData,
                 }, function(hasConfirmed) {
                     if (hasConfirmed) {
                         var templateTitle = "[Unpublished/broken]\n" + parsedURL.pathname;
+                        if (!data[field]) {
+                            data[field] = [];
+                            templateData[field] = [];
+                        }
                         data[field].push({uri: parsedURL.pathname});
                         templateData[field].push({uri: parsedURL.pathname, description: {title: templateTitle}});
                         saveContentAndRefreshSection();

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -9,11 +9,12 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
 
     var templateData = jQuery.extend(true, {}, pageData); // clone page data to add template related properties.
     templateData.isPageComplete = isPageComplete;
+    Florence.Editor.hasNonMigrationChanges = false;
 
     if (pageData.type === 'taxonomy_landing_page') {
         var html = templates.workEditT2(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'highlightedLinks', 'highlights');
         accordion();
         t2Editor(collectionId, pageData);
@@ -22,7 +23,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'product_page') {
         var html = templates.workEditT3(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData)
+        migration(templateData, pageData, false, true);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'items', 'timeseries');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'statsBulletins', 'bulletins');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedArticles', 'articles');
@@ -49,7 +50,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, false);
         tags(templateData);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
@@ -81,7 +82,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, false);
         tags(templateData);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
@@ -143,7 +144,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'compendium_landing_page') {
         var html = templates.workEditT6(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, false);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedData', 'data');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedMethodology', 'qmi');
@@ -169,7 +170,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');
@@ -186,7 +187,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'compendium_data') {
         var html = templates.workEditT8Compendium(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDocuments', 'document');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedDatasets', 'dataset');
         renderRelatedItemAccordionSection(collectionId, pageData, templateData, 'relatedMethodology', 'qmi');
@@ -200,7 +201,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_landing_page') {
         var html = templates.workEditT7Landing(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         accordion();
@@ -213,7 +214,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.tables) {
             loadTablesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         tags(templateData)
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -237,7 +238,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.images) {
             loadImagesList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         tags(templateData)
         editIntAndExtLinks(collectionId, pageData, templateData, 'links', 'link');
@@ -250,7 +251,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_qmi') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -264,7 +265,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_foi') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -275,7 +276,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_adhoc') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -298,7 +299,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         if (pageData.equations) {
             loadEquationsList(collectionId, pageData);
         }
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         tags(templateData)
         renderMarkdownContentAccordionSection(collectionId, pageData, 'sections', 'section');
         renderMarkdownContentAccordionSection(collectionId, pageData, 'accordion', 'tab');
@@ -315,7 +316,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'static_methodology_download') {
         var html = templates.workEditT7(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'content');
         tags(templateData)
         addFile(collectionId, pageData, 'downloads', 'file');
@@ -331,7 +332,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'dataset_landing_page') {
         var html = templates.workEditT8LandingPage(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData, true);
+        migration(templateData, pageData, true, false);
         tags(templateData)
         editMarkdownOneObject(collectionId, pageData, 'section', 'Notes');
         addDataset(collectionId, pageData, 'datasets', 'edition');
@@ -356,7 +357,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'dataset') {
         var html = templates.workEditT8(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData, true);
+        migration(templateData, pageData, true, false);
         editDatasetVersion(collectionId, pageData, 'versions', 'version');
         editDatasetVersion(collectionId, pageData, 'versions', 'correction');
         addFile(collectionId, pageData, 'supplementaryFiles', 'supplementary-files');
@@ -377,7 +378,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'release') {
         var html = templates.workEditT16(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData);
+        migration(templateData, pageData, false, true);
         editMarkdownWithNoTitle(collectionId, pageData, 'markdown', 'prerelease');
         editDate(collectionId, pageData, templateData, 'dateChanges', 'changeDate');
         renderExternalLinkAccordionSection(collectionId, pageData, 'links', 'link');
@@ -431,6 +432,9 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     // Listen on all input within the workspace edit panel for dirty checks.
     $('.workspace-edit :input').on('input', function () {
         Florence.Editor.isDirty = true;
+        if (Florence.Editor.warnOnNonMigrationSave && this.id !== 'migration_link') {
+            Florence.Editor.hasNonMigrationChanges = true;
+        }
         // remove the handler now we know content has changed.
         //$(':input').unbind('input');
         //console.log('Changes detected.');

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -332,7 +332,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'dataset_landing_page') {
         var html = templates.workEditT8LandingPage(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData, true, false);
+        migration(templateData, pageData, true);
         tags(templateData)
         editMarkdownOneObject(collectionId, pageData, 'section', 'Notes');
         addDataset(collectionId, pageData, 'datasets', 'edition');
@@ -346,6 +346,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         editAlert(collectionId, pageData, templateData, 'alerts', 'alert');
         accordion();
         datasetLandingEditor(collectionId, pageData);
+        disableSaveButtonsForMigratedContent();
     }
 
     else if (pageData.type === 'api_dataset_landing_page') {
@@ -357,12 +358,13 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
     else if (pageData.type === 'dataset') {
         var html = templates.workEditT8(templateData);
         $('.workspace-menu').html(html);
-        migration(templateData, pageData, true, false);
+        migration(templateData, pageData, true);
         editDatasetVersion(collectionId, pageData, 'versions', 'version');
         editDatasetVersion(collectionId, pageData, 'versions', 'correction');
         addFile(collectionId, pageData, 'supplementaryFiles', 'supplementary-files');
         accordion();
         datasetEditor(collectionId, pageData);
+        disableSaveButtonsForMigratedContent();
     }
 
     else if (pageData.type === 'timeseries_dataset') {

--- a/src/legacy/js/functions/_updateContent.js
+++ b/src/legacy/js/functions/_updateContent.js
@@ -1,7 +1,12 @@
 function updateContent(collectionId, path, content, redirectToPath) {
+    if (shouldBlockNonMigrationSave()) {
+        return;
+    }
+
     putContent(collectionId, path, content,
         success = function () {
             Florence.Editor.isDirty = false;
+            Florence.Editor.hasNonMigrationChanges = false;
             if (redirectToPath) {
                 createWorkspace(redirectToPath, collectionId, 'edit');
                 return;


### PR DESCRIPTION
### What

[Migration field UX](https://officefornationalstatistics.atlassian.net/browse/DIS-4811)

Add warning message and disabled save buttons for migrated datasets

This is branched off https://github.com/ONSdigital/florence/pull/1224 will be rebased/updated if any changes are made to the parent

### How to review

- run florence locally with make debug ENABLE_MIGRATION_FIELD=true
- port forward the api-route, identity api and permissions api or use legacy-core-publishing
- login with sandbox creds
- Create collection, add migration link to a dataset content - Since datasets migration field are now read-only, you will have to add one in the data json of a dataset in `dp-zebedee-content/generated/publishing/zebedee/master/`. Add migration link to: 
  - dataset
  - dataset_landing_page
- With migration link, save buttons should be disabled and greyed out
- Without migration link, save buttons should work as usual

<img width="617" height="782" alt="image" src="https://github.com/user-attachments/assets/3971b837-12b2-4f51-8d3a-c13957b2aa56" />

### Who can review

!Me
