### PR TITLE
Disable save buttons for migrated datasets

### DIFF
--- a/src/legacy/js/constants/sweetAlerts.js
+++ b/src/legacy/js/constants/sweetAlerts.js
@@ -1,1 +1,2 @@
 const MIGRATION_FIELD_VALIDATION_FAILURE = ["Cannot save this page", "Migration path must be a relative path starting with '/'"];
+const MIGRATED_DATASET_CONTENT = ["This content has been migrated", "You cannot make any changes or publish new editions or versions"];

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -8,6 +8,7 @@
 async function migration(templateData, data, isReadOnlyMigrationPath = false) {
     const migrationConfig = window.getEnv().enableMigrationField;
     if (migrationConfig) {
+        Florence.Editor.hasMigrationLink = data.description?.migrationLink || '';
         templateData.readOnlyMigrationPath = isReadOnlyMigrationPath;
         let html = templates.migration(templateData)
         $('#migration').replaceWith(html);
@@ -19,6 +20,20 @@ async function migration(templateData, data, isReadOnlyMigrationPath = false) {
             });
         }
     }
+}
+
+/**
+ * Disables save buttons for content that has been migrated.
+ */
+function disableSaveButtonsForMigratedContent() {
+    if (!Florence.Editor.hasMigrationLink) {
+        return;
+    }
+    $('.btn-edit-save, .btn-edit-save-and-submit-for-review, .btn-edit-save-and-submit-for-approval')
+        .addClass('btn--disabled')
+        .prop('disabled', true);
+    
+    sweetAlert(...MIGRATED_DATASET_CONTENT);
 }
 
 // isRelativePath validates if the given path is a relative path

--- a/src/legacy/js/functions/_renderAccordionSections.js
+++ b/src/legacy/js/functions/_renderAccordionSections.js
@@ -345,6 +345,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         editAlert(collectionId, pageData, templateData, 'alerts', 'alert');
         accordion();
         datasetLandingEditor(collectionId, pageData);
+        disableSaveButtonsForMigratedContent();
     }
 
     else if (pageData.type === 'api_dataset_landing_page') {
@@ -362,6 +363,7 @@ function renderAccordionSections(collectionId, pageData, isPageComplete) {
         addFile(collectionId, pageData, 'supplementaryFiles', 'supplementary-files');
         accordion();
         datasetEditor(collectionId, pageData);
+        disableSaveButtonsForMigratedContent();
     }
 
     else if (pageData.type === 'timeseries_dataset') {


### PR DESCRIPTION
### What

[Migration field UX](https://officefornationalstatistics.atlassian.net/browse/DIS-4811)

Add warning message and disabled save buttons for migrated datasets

### How to review

- run florence locally with make debug ENABLE_MIGRATION_FIELD=true
- port forward the api-route, identity api and permissions api or use legacy-core-publishing
- login with sandbox creds
- Create collection, add migration link to a dataset content - Since datasets migration field are now read-only, you will have to add one in the data json of a dataset in `dp-zebedee-content/generated/publishing/zebedee/master/`. Add migration link to: 
  - dataset
  - dataset_landing_page
- With migration link, save buttons should be disabled and greyed out
- Without migration link, save buttons should work as usual

<img width="617" height="782" alt="image" src="https://github.com/user-attachments/assets/3971b837-12b2-4f51-8d3a-c13957b2aa56" />

<img width="1023" height="662" alt="image" src="https://github.com/user-attachments/assets/722b5fab-b3fc-4581-86dd-db04f1d05c5d" />


### Who can review

!Me
