### PR TITLE
Block changes for migrated static and compendium pages

### DIFF
--- a/src/legacy/js/functions/_editAlert.js
+++ b/src/legacy/js/functions/_editAlert.js
@@ -15,6 +15,10 @@ function editAlert(collectionId, data, templateData, field, idField) {
   initialiseAlert(collectionId, data, templateData, field, idField);
   // New alert
   $("#add-" + idField).click(function () {
+    // Block add if content has migration link
+    if (blockNonMigrationChangeWithWarning()) {
+      return;
+    }
     if (!data[field]) {
       data[field] = [];
       templateData[field] = [];
@@ -45,6 +49,10 @@ function initialiseAlert(collectionId, data, templateData, field, idField) {
       templateData[field][index].date = new Date($('#date_' + index).datepicker('getDate')).toISOString();
     });
     $('#' + idField + '-edit_' + index).click(function () {
+      // Block edit if content has migration link
+      if (blockNonMigrationChangeWithWarning()) {
+        return;
+      }
       var editedSectionValue = {title: 'Alert notice', markdown: data[field][index].markdown};
       //var editedSectionValue = data[field][index].markdown;
       var saveContent = function (updatedContent) {
@@ -79,6 +87,10 @@ function initialiseAlert(collectionId, data, templateData, field, idField) {
 
     // Delete
     $('#' + idField + '-delete_' + index).click(function () {
+      // Block delete if content has migration link
+      if (blockNonMigrationChangeWithWarning()) {
+        return;
+      }
       swal ({
         title: "Warning",
         text: "Are you sure you want to delete this alert?",

--- a/src/legacy/js/functions/_editDocumentCorrection.js
+++ b/src/legacy/js/functions/_editDocumentCorrection.js
@@ -15,6 +15,10 @@ function editDocumentCorrection(collectionId, data, templateData, field, idField
   initialiseCorrection(collectionId, data, templateData, field, idField);
   // New correction
   $("#add-" + idField).one('click', function () {
+    // Block add if content has migration link
+    if (blockNonMigrationChangeWithWarning()) {
+      return;
+    }
     if (!data[field]) {
       data[field] = [];
       templateData[field] = [];
@@ -127,6 +131,10 @@ function initialiseCorrection(collectionId, data, templateData, field, idField) 
 
 
     $('#' + idField + '-edit_' + index).click(function () {
+      // Block edit if content has migration link
+      if (blockNonMigrationChangeWithWarning()) {
+        return;
+      }
       var markdown = data[field][index].correctionNotice;
       var editedSectionValue = {title: 'Correction notice', markdown: markdown};
       var saveContent = function (updatedContent) {
@@ -138,6 +146,10 @@ function initialiseCorrection(collectionId, data, templateData, field, idField) 
     });
     // Delete
     $('#' + idField + '-delete_' + index).click(function () {
+      // Block delete if content has migration link
+      if (blockNonMigrationChangeWithWarning()) {
+        return;
+      }
       swal ({
         title: "Warning",
         text: "Are you sure you want to delete this correction?",

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -37,8 +37,9 @@ function shouldBlockNonMigrationSave() {
     if (currentMigrationLink) {
         currentMigrationLink = currentMigrationLink.trim();
     }
+    const hasMigrationLink = Florence.Editor.hasMigrationLink || currentMigrationLink;
 
-    if (Florence.Editor.warnOnNonMigrationSave && currentMigrationLink && hasNonMigrationChanges) {
+    if (Florence.Editor.warnOnNonMigrationSave && hasMigrationLink && hasNonMigrationChanges) {
         sweetAlert(...MIGRATED_PAGE_CONTENT);
         return true;
     }
@@ -52,8 +53,9 @@ function blockNonMigrationChangeWithWarning() {
     if (currentMigrationLink) {
         currentMigrationLink = currentMigrationLink.trim();
     }
+    const hasMigrationLink = Florence.Editor.hasMigrationLink || currentMigrationLink;
 
-    if (Florence.Editor.warnOnNonMigrationSave && currentMigrationLink) {
+    if (Florence.Editor.warnOnNonMigrationSave && hasMigrationLink) {
         sweetAlert(...MIGRATED_PAGE_CONTENT);
         return true;
     }

--- a/src/legacy/js/functions/_t7StaticLandingPageEditor.js
+++ b/src/legacy/js/functions/_t7StaticLandingPageEditor.js
@@ -84,6 +84,10 @@ function staticLandingPageEditor(collectionId, data) {
         }
 
         $("#section-edit_" + index).click(function () {
+            // Block edit if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             var editedSectionValue = {
                 "title": $('#section-title_' + index).val(),
                 "markdown": $("#section-markdown_" + index).val()
@@ -101,6 +105,10 @@ function staticLandingPageEditor(collectionId, data) {
 
         // Delete
         $("#section-delete_" + index).click(function () {
+            // Block delete if content has migration link
+            if (blockNonMigrationChangeWithWarning()) {
+                return;
+            }
             swal({
                 title: "Warning",
                 text: "Are you sure you want to delete?",
@@ -156,6 +164,10 @@ function staticLandingPageEditor(collectionId, data) {
 
     //Add new content
     $("#add-section").one('click', function () {
+        // Block add if content has migration link
+        if (blockNonMigrationChangeWithWarning()) {
+            return;
+        }
         swal({
             title: "Warning",
             text: "If you do not come back to this page, you will lose any unsaved changes",


### PR DESCRIPTION
### What

https://officefornationalstatistics.atlassian.net/browse/DIS-4812

You can test for 
- Add warning message when updating migrated content for pages:
  - compendium_chapter
  - compendium_data
  - static_landing_page
  - static_page
  - static_article
  - static_qmi
  - static_foi
  - static_adhoc
  - static_methodology
  - static_methodology_download

### How to review

- port forward the api-router
- run florence locally with `make debug ENABLE_PERMISSION_API=true ENABLE_MIGRATION_FIELD=true`
- login with sandbox creds
- Create collection, add migration link to a normal page
- Create a new collection, edit the migrated content. 
  - Try updating other fields (excluding migration link) and save/save and submit for review - you should get the warning message
  - Remove all changes, you should be able to save
  - You should be able to update the migration link
- Adding a related link, uploading files, updating tables buttons should be blocked with a warning

- Test scenarios
  - Add a migration link (no warnings)
  - Add a migration link with other content changed (warnings)
  - Review a migration link (no warnings)
  - Edit a migration link (no warnings)
  - Edit a migration link with other content changes.....(warnings)
  - Delete a migration link (no warnings)
  - Delete a migration link with other content changes....(warnings)

### Who can review

!Me