### PR TITLE
Block creating new editions for migrated series

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.3-bookworm-node-20
+    tag: 1.26.4-bookworm-node-20
 
 inputs:
   - name: florence

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.3-bookworm-node-20
+    tag: 1.26.4-bookworm-node-20
 
 inputs:
   - name: florence

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go-node
-    tag: 1.26.3-bookworm-golangci-lint-2-node-20
+    tag: 1.26.4-bookworm-golangci-lint-2-node-20
 
 inputs:
   - name: florence

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-node-go
-    tag: 1.26.3-bookworm-node-20
+    tag: 1.26.4-bookworm-node-20
 
 inputs:
   - name: florence

--- a/src/legacy/js/constants/sweetAlerts.js
+++ b/src/legacy/js/constants/sweetAlerts.js
@@ -1,3 +1,4 @@
 const MIGRATION_FIELD_VALIDATION_FAILURE = ["Cannot save this page", "Migration path must be a relative path starting with '/'"];
 const MIGRATED_DATASET_CONTENT = ["This content has been migrated", "You cannot make any changes or publish new editions or versions"];
 const MIGRATED_PAGE_CONTENT = ["This content has been migrated", "You can only make changes to the migration link"];
+const MIGRATED_SERIES_CONTENT = ["This content has been migrated", "You will not be able to create new editions"];

--- a/src/legacy/js/functions/_createWorkspace.js
+++ b/src/legacy/js/functions/_createWorkspace.js
@@ -139,7 +139,7 @@ function createWorkspace(path, collectionId, menu, collectionData, stopEventList
             var type = typeGroup[1];
 
             if (type === 'bulletin' || type === 'article' || type === 'article_download' || type === 'compendium_landing_page') {
-                var seriesParentUrl = getParentPage(dest);
+                const seriesParentUrl = getParentPage(dest);
                 if (checkLatestEditionMigrated(seriesParentUrl, collectionId)) {
                     return;
                 }

--- a/src/legacy/js/functions/_createWorkspace.js
+++ b/src/legacy/js/functions/_createWorkspace.js
@@ -137,6 +137,14 @@ function createWorkspace(path, collectionId, menu, collectionData, stopEventList
             var typeClass = spanType[0].attributes[0].nodeValue;
             var typeGroup = typeClass.match(/--(\w*)$/);
             var type = typeGroup[1];
+
+            if (type === 'bulletin' || type === 'article' || type === 'article_download' || type === 'compendium_landing_page') {
+                var seriesParentUrl = getParentPage(dest);
+                if (checkLatestEditionMigrated(seriesParentUrl, collectionId)) {
+                    return;
+                }
+            }
+
             Florence.globalVars.pagePath = dest;
             $navItem.removeClass('selected');
             $("#create").addClass('selected');

--- a/src/legacy/js/functions/_loadT4Creator.js
+++ b/src/legacy/js/functions/_loadT4Creator.js
@@ -25,6 +25,12 @@ function loadT4Creator(collectionId, releaseDate, pageType, parentUrl) {
             if ((checkData.type === 'bulletin' && pageType === 'bulletin') || (checkData.type === 'article' && pageType === 'article') || (checkData.type === 'article_download' && pageType === 'article_download')) {
                 var checkedUrl = checkPathSlashes(checkData.uri);
                 var safeParentUrl = getParentPage(checkedUrl);
+
+                if (checkLatestEditionMigrated(safeParentUrl, collectionId)) {
+                    loadBrowseScreen(collectionId, 'click');
+                    return;
+                }
+                
                 natStat = checkData.description.nationalStatistic;
                 contactName = checkData.description.contact.name;
                 contactEmail = checkData.description.contact.email;

--- a/src/legacy/js/functions/_loadT6Creator.js
+++ b/src/legacy/js/functions/_loadT6Creator.js
@@ -29,7 +29,14 @@ function loadT6Creator(collectionId, releaseDate, pageType, parentUrl, pageTitle
                 return true;
             }
             if (checkData.type === 'compendium_landing_page' && pageType === 'compendium_landing_page') {
-                parentUrl = getParentPage(checkData.uri);
+                var seriesParentUrl = getParentPage(checkData.uri);
+
+                if (checkLatestEditionMigrated(seriesParentUrl, collectionId)) {
+                    loadBrowseScreen(collectionId, 'click');
+                    return;
+                }
+                
+                parentUrl = seriesParentUrl;
                 pageTitle = checkData.description.title;
                 isInheriting = true;
                 pageData = pageTypeDataT6(pageType, checkData);

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -74,6 +74,36 @@ function disableSaveButtonsForMigratedContent() {
     sweetAlert(...MIGRATED_DATASET_CONTENT);
 }
 
+// Check if the latest edition of a series has been migrated.
+// Returns true if migrated and shows warning, false if not migrated.
+function checkLatestEditionMigrated(seriesParentUrl, collectionId) {
+    if (!window.getEnv().enableMigrationField) {
+        return false;
+    }
+
+    var latestUrl = seriesParentUrl + '/latest';
+    var apiUrl = `${API_PROXY.ZEBEDEE_DATA_ENDPOINT}/${collectionId}?uri=${latestUrl}`;
+    var isMigrated = false;
+    
+    $.ajax({
+        url: apiUrl,
+        dataType: 'json',
+        crossDomain: true,
+        async: false,
+        success: function (latestData) {
+            if (latestData.description && latestData.description.migrationLink) {
+                isMigrated = true;
+                sweetAlert(...MIGRATED_SERIES_CONTENT);
+            }
+        },
+        error: function () {
+            console.log('Could not fetch latest edition, proceeding with creation');
+        }
+    });
+    
+    return isMigrated;
+}
+
 function hasNonMigrationInputChanges() {
     let hasChanges = false;
 

--- a/src/legacy/js/functions/_migration.js
+++ b/src/legacy/js/functions/_migration.js
@@ -81,9 +81,9 @@ function checkLatestEditionMigrated(seriesParentUrl, collectionId) {
         return false;
     }
 
-    var latestUrl = seriesParentUrl + '/latest';
-    var apiUrl = `${API_PROXY.ZEBEDEE_DATA_ENDPOINT}/${collectionId}?uri=${latestUrl}`;
-    var isMigrated = false;
+    const latestUrl = seriesParentUrl + '/latest';
+    const apiUrl = `${API_PROXY.ZEBEDEE_DATA_ENDPOINT}/${collectionId}?uri=${latestUrl}`;
+    let isMigrated = false;
     
     $.ajax({
         url: apiUrl,
@@ -91,7 +91,7 @@ function checkLatestEditionMigrated(seriesParentUrl, collectionId) {
         crossDomain: true,
         async: false,
         success: function (latestData) {
-            if (latestData.description && latestData.description.migrationLink) {
+            if (latestData.description?.migrationLink) {
                 isMigrated = true;
                 sweetAlert(...MIGRATED_SERIES_CONTENT);
             }


### PR DESCRIPTION
### What

- Block creating new editions for [migrated editorial series](https://officefornationalstatistics.atlassian.net/browse/DIS-4810)
- Upgrade go to 1.26.4

### How to review

port forward the api-router

- run `make watch-src` on branch
- run  with `make debug ENABLE_PERMISSION_API=true ENABLE_MIGRATION_FIELD=true`
- login with sandbox creds
- Create a collection and migration link the latest of a `bulletin`, `article` and `compendium_landing_page`
- Optionally use the ones I have migrated;
  -  [migrated latest article](https://dp.aws.onsdigital.uk/economy/grossvalueaddedgva/articles/disaggregatingannualsubnationalgrossvalueaddedgvatolowerlevelsofgeography/1998to2020)
  - [migrated latest bulletin](https://dp.aws.onsdigital.uk/economy/grossdomesticproductgdp/bulletins/businessinvestment/julytoseptember2023provisionalresults)
  - [migrated latest compendium_landing_page](https://dp.aws.onsdigital.uk/economy/grossdomesticproductgdp/compendium/unitedkingdomnationalaccountsthebluebook/2014-10-31)
  - You can see they are latest and with migration link by checking [zebedee latest endpoint](https://api.dp.aws.onsdigital.uk/v1/data?uri=/economy/grossvalueaddedgva/articles/disaggregatingannualsubnationalgrossvalueaddedgvatolowerlevelsofgeography/latest)
- Click "Create" on any edition of the migrated series and you should see the warning and no redirect to the create page.
- There should be no warning if the series has not been migrated 

### Who can review

!Me