### PR TITLE
Fix/brace expansion 2

### DIFF
--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -3139,12 +3139,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -3763,6 +3757,16 @@
       "license": "Unlicense",
       "dependencies": {
         "stackframe": "^0.3.1"
+      }
+    },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
@@ -13048,16 +13052,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
       "version": "7.18.6",
       "dev": true,
@@ -13148,6 +13142,12 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
+      "license": "MIT"
+    },
+    "node_modules/minimatch/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -19539,11 +19539,6 @@
         }
       }
     },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
     "batch": {
       "version": "0.6.1",
       "dev": true
@@ -19628,15 +19623,6 @@
     },
     "bowser": {
       "version": "0.7.3"
-    },
-    "brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
     },
     "braces": {
       "version": "3.0.3",
@@ -23497,7 +23483,23 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "requires": {
-        "brace-expansion": "1.1.14"
+        "brace-expansion": "1.1.16"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+          "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+        },
+        "brace-expansion": {
+          "version": "1.1.16",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+          "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        }
       }
     },
     "minimist": {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -28,7 +28,7 @@
         "ssri": "^6.0.2",
         "redux-devtools-extension": "^2.13.7",
         "dateformat": "^2.0.0",
-        "redux-auth-wrapper": "^2.0.3",
+        "redux-auth-wrapper": "^2.1.0",
         "json5": "^2.2.2",
         "react-transition-group": "^2.9.0",
         "react-table": "^7.7.0",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -2903,10 +2903,12 @@
       "license": "MIT"
     },
     "node_modules/decode-uri-component": {
-      "version": "0.2.2",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=0.10"
+        "node": ">=14.16"
       }
     },
     "node_modules/is-symbol": {
@@ -20174,7 +20176,9 @@
       "dev": true
     },
     "decode-uri-component": {
-      "version": "0.2.2"
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.5.0.tgz",
+      "integrity": "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg=="
     },
     "dedent": {
       "version": "1.7.2",
@@ -24569,7 +24573,7 @@
         "query-string": {
           "version": "5.1.1",
           "requires": {
-            "decode-uri-component": "^0.2.0",
+            "decode-uri-component": "^0.5.0",
             "object-assign": "^4.1.0",
             "strict-uri-encode": "^1.0.0"
           }

--- a/src/package.json
+++ b/src/package.json
@@ -154,6 +154,7 @@
     "flatted": "^3.4.2",
     "picomatch": "^2.3.2",
     "yaml": "^1.10.3",
-    "uuid": "$uuid"
+    "uuid": "$uuid",
+    "decode-uri-component": "^0.5.0"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -131,7 +131,7 @@
     "react-table": "^7.7.0",
     "react-transition-group": "^2.9.0",
     "redux": "^3.7.2",
-    "redux-auth-wrapper": "^2.0.3",
+    "redux-auth-wrapper": "^2.1.0",
     "redux-devtools-extension": "^2.13.7",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.1.4",

--- a/src/package.json
+++ b/src/package.json
@@ -145,7 +145,7 @@
     "cross-spawn": ">=7.0.5",
     "@babel/runtime": ">=7.26.10",
     "@xmldom/xmldom": "0.9.10",
-    "brace-expansion": "1.1.14",
+    "brace-expansion": "1.1.16",
     "js-yaml": "$js-yaml",
     "lodash": "^4.18.0",
     "lodash-es": "^4.18.0",


### PR DESCRIPTION
### What

Upgrades:
- brace-expansion to 1.1.16 (CVE backport)
- redux-auth-wrapper to 2.1.0 (latest v2 branch)
- overrides decode-uri-component to 0.5.0

### How to review

Check looks ok, tests pass. 

The area of risk is login / auth related to views so you can run florence portforwarded to sandbox api router and login and browse etc. 

### Who can review

Not me. 